### PR TITLE
[DOP-3140] Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release
+
+on:
+  push:
+    tags:
+    - '[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  release:
+    name: Release package
+    runs-on: ubuntu-latest
+    if: github.repository == 'MobileTeleSystems/onetl'  # prevent running on forks
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+
+    - name: Cache pip
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-python-3.11-release-${{ hashFiles('requirements*.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-python-3.11-release-${{ hashFiles('requirements*.txt') }}
+          ${{ runner.os }}-python-3.11-release-
+          ${{ runner.os }}-python
+          ${{ runner.os }}-
+
+    - name: Upgrade pip
+      run: python -m pip install --upgrade pip setuptools wheel
+
+    - name: Build package
+      run: python setup.py sdist bdist_wheel
+
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
This workflow pushes release versions of onETL to [pypi.org](https://pypi.org/).

Unlike .dev versions workflow (#4), releases are build and pushed only while pushing tags (not commits), and no wait for code analysis is performed (to speed up the release process).