### PR TITLE
[DOP-3137] Add tests workflow for Teradata

### DIFF
--- a/.github/workflows/test-teradata.yml
+++ b/.github/workflows/test-teradata.yml
@@ -1,0 +1,68 @@
+name: Tests for Teradata
+on:
+  workflow_call:
+    inputs:
+      spark-version:
+        required: true
+        type: string
+      java-version:
+        required: true
+        type: string
+      python-version:
+        required: true
+        type: string
+      os:
+        required: true
+        type: string
+
+jobs:
+  test-teradata:
+    name: Run Teradata tests (spark=${{ inputs.spark-version }}, java=${{ inputs.java-version }}, python=${{ inputs.python-version }}, os=${{ inputs.os }})
+    runs-on: ${{ inputs.os }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Set up Java ${{ inputs.java-version }}
+      uses: actions/setup-java@v3
+      with:
+        distribution: temurin
+        java-version: ${{ inputs.java-version }}
+
+    - name: Cache pip
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-python-${{ inputs.python-version }}-spark-${{ inputs.spark-version }}-tests-teradata-${{ hashFiles('requirements/core.txt', 'requirements/tests/base.txt', 'requirements/tests-spark*.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-python-${{ inputs.python-version }}-spark-${{ inputs.spark-version }}-tests-teradata-${{ hashFiles('requirements/core.txt', 'requirements/tests/base.txt', 'requirements/tests-spark*.txt') }}
+          ${{ runner.os }}-python-${{ inputs.python-version }}-spark-${{ inputs.spark-version }}-tests-teradata-
+
+    - name: Upgrade pip
+      run: python -m pip install --upgrade pip setuptools wheel
+
+    - name: Install dependencies
+      run: |
+        pip install -I \
+          -r requirements/core.txt \
+          -r requirements/tests/base.txt \
+          -r requirements/tests/spark-${{ inputs.spark-version }}.txt
+
+    - name: Run tests
+      run: |
+        mkdir reports/ || echo "Directory exists"
+        sed '/^$/d' ./.env.local | sed '/^#/d' | sed 's/^/export /' > ./env
+        source ./env
+        ./pytest_runner.sh -m teradata
+
+    - name: Upload coverage results
+      uses: actions/upload-artifact@v3
+      with:
+        name: teradata-spark-${{ inputs.spark-version }}-python-${{ inputs.python-version }}-os-${{ inputs.os }}
+        path: reports/*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,10 +41,32 @@ jobs:
       python-version: ${{ matrix.python-version }}
       os: ${{ matrix.os }}
 
+  tests-teradata:
+    name: Run Teradata tests (spark=${{ matrix.spark-version }}, java=${{ matrix.java-version }}, python=${{ matrix.python-version }}, os=${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - spark-version: 2.4.8
+          java-version: 8
+          python-version: '3.7'
+          os: ubuntu-latest
+        - spark-version: 3.3.2
+          java-version: 17
+          python-version: '3.10'
+          os: ubuntu-latest
+
+    uses: ./.github/workflows/test-teradata.yml
+    with:
+      spark-version: ${{ matrix.spark-version }}
+      java-version: ${{ matrix.java-version }}
+      python-version: ${{ matrix.python-version }}
+      os: ${{ matrix.os }}
+
   all_done:
     name: Tests done
     runs-on: ubuntu-latest
-    needs: [tests-clickhouse]
+    needs: [tests-clickhouse, tests-teradata]
 
     steps:
     - name: Checkout code

--- a/conftest.py
+++ b/conftest.py
@@ -200,7 +200,15 @@ def spark_metastore_dir(tmp_path_factory):
 def get_spark_session(warehouse_dir, spark_metastore_dir):
     import pyspark
 
-    from onetl.connection import MSSQL, Clickhouse, MongoDB, MySQL, Oracle, Postgres
+    from onetl.connection import (
+        MSSQL,
+        Clickhouse,
+        MongoDB,
+        MySQL,
+        Oracle,
+        Postgres,
+        Teradata,
+    )
 
     packages = [
         Clickhouse.package,
@@ -208,6 +216,7 @@ def get_spark_session(warehouse_dir, spark_metastore_dir):
         MySQL.package,
         Oracle.package,
         Postgres.package,
+        Teradata.package,
     ]
 
     pyspark_version = ".".join(pyspark.__version__.split(".")[:2])

--- a/onetl/connection/db_connection/teradata.py
+++ b/onetl/connection/db_connection/teradata.py
@@ -25,7 +25,7 @@ from onetl.connection.db_connection.jdbc_connection import JDBCConnection
 class Teradata(JDBCConnection):
     """Teradata JDBC connection.
 
-    Based on package ``com.teradata.jdbc:terajdbc4:17.20.00.08``
+    Based on package ``com.teradata.jdbc:terajdbc:17.20.00.15``
     (`official Teradata JDBC driver <https://downloads.teradata.com/download/connectivity/jdbc-driver>`_).
 
     .. dropdown:: Version compatibility
@@ -142,7 +142,7 @@ class Teradata(JDBCConnection):
     extra: Extra = Extra()
 
     driver: ClassVar[str] = "com.teradata.jdbc.TeraDriver"
-    package: ClassVar[str] = "com.teradata.jdbc:terajdbc4:17.20.00.08"
+    package: ClassVar[str] = "com.teradata.jdbc:terajdbc:17.20.00.15"
 
     _check_query: ClassVar[str] = "SELECT 1 AS check_result"
 

--- a/tests/tests_integration/tests_db_connection_integration/test_teradata_integration.py
+++ b/tests/tests_integration/tests_db_connection_integration/test_teradata_integration.py
@@ -1,0 +1,53 @@
+import logging
+import secrets
+from unittest.mock import patch
+
+import pandas
+import pytest
+
+from onetl.connection import Teradata
+
+pytestmark = pytest.mark.teradata
+
+
+@patch.object(Teradata, "_query_optional_on_driver")
+def test_teradata_connection_check(query_or_none_on_driver, spark, caplog):
+    query_or_none_on_driver.result = None
+
+    host = "some.domain.com"
+    port = 1234
+    database = secrets.token_hex()
+    user = secrets.token_hex()
+    password = secrets.token_hex()
+
+    teradata = Teradata(
+        host=host,
+        port=port,
+        database=database,
+        user=user,
+        password=password,
+        spark=spark,
+    )
+
+    with caplog.at_level(logging.INFO):
+        assert teradata.check() == teradata
+
+    assert "type = Teradata" in caplog.text
+    assert f"host = '{host}'" in caplog.text
+    assert f"port = {port}" in caplog.text
+    assert f"database = '{database}" in caplog.text
+    assert f"user = '{user}'" in caplog.text
+    assert "password = SecretStr('**********')" in caplog.text
+    assert password not in caplog.text
+
+    assert "package = " not in caplog.text
+    assert "spark = " not in caplog.text
+
+    assert "Connection is available" in caplog.text
+
+
+def test_teradata_connection_check_fail(spark):
+    teradata = Teradata(host="host", user="some_user", password="pwd", database="somedb", spark=spark)
+
+    with pytest.raises(RuntimeError, match="Connection is unavailable"):
+        teradata.check()

--- a/tests/tests_unit/tests_db_connection_unit/test_teradata_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_teradata_unit.py
@@ -7,7 +7,7 @@ pytestmark = pytest.mark.teradata
 
 def test_teradata_class_attributes():
     assert Teradata.driver == "com.teradata.jdbc.TeraDriver"
-    assert Teradata.package == "com.teradata.jdbc:terajdbc4:17.20.00.08"
+    assert Teradata.package == "com.teradata.jdbc:terajdbc:17.20.00.15"
 
 
 def test_teradata(spark_mock):


### PR DESCRIPTION
Added workflow for Teradata tests, using Clickhouse workflow as a template.

Because there is no public Teradata docker image, integration tests are mocked, and test check only that JDBC driver can be downloaded and imported to Spark session.

Also Teradata [published JDBC driver to Maven](https://mvnrepository.com/artifact/com.teradata.jdbc/terajdbc), so I've changed `Teradata.package` value.