### PR TITLE
[DOP-3137] Add tests workflow for Hive

### DIFF
--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -1,0 +1,68 @@
+name: Tests for Hive
+on:
+  workflow_call:
+    inputs:
+      spark-version:
+        required: true
+        type: string
+      java-version:
+        required: true
+        type: string
+      python-version:
+        required: true
+        type: string
+      os:
+        required: true
+        type: string
+
+jobs:
+  test-hive:
+    name: Run Hive tests (spark=${{ inputs.spark-version }}, java=${{ inputs.java-version }}, python=${{ inputs.python-version }}, os=${{ inputs.os }})
+    runs-on: ${{ inputs.os }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Set up Java ${{ inputs.java-version }}
+      uses: actions/setup-java@v3
+      with:
+        distribution: temurin
+        java-version: ${{ inputs.java-version }}
+
+    - name: Cache pip
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-python-${{ inputs.python-version }}-tests-hive-${{ hashFiles('requirements/core.txt', 'requirements/tests/base.txt', 'requirements/tests/spark-*.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-python-${{ inputs.python-version }}-tests-hive-${{ hashFiles('requirements/core.txt', 'requirements/tests/base.txt', 'requirements/tests/spark-*.txt') }}
+          ${{ runner.os }}-python-${{ inputs.python-version }}-tests-hive-
+
+    - name: Upgrade pip
+      run: python -m pip install --upgrade pip setuptools wheel
+
+    - name: Install dependencies
+      run: |
+        pip install -I \
+          -r requirements/core.txt \
+          -r requirements/tests/base.txt \
+          -r requirements/tests/spark-${{ inputs.spark-version }}.txt
+
+    - name: Run tests
+      run: |
+        mkdir reports/ || echo "Directory exists"
+        sed '/^$/d' ./.env.local | sed '/^#/d' | sed 's/^/export /' > ./env
+        source ./env
+        ./pytest_runner.sh -m hive
+
+    - name: Upload coverage results
+      uses: actions/upload-artifact@v3
+      with:
+        name: hive-spark-${{ inputs.spark-version }}-python-${{ inputs.python-version }}-os-${{ inputs.os }}
+        path: reports/*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,6 +63,28 @@ jobs:
       python-version: ${{ matrix.python-version }}
       os: ${{ matrix.os }}
 
+  tests-hive:
+    name: Run Hive tests (spark=${{ matrix.spark-version }}, java=${{ matrix.java-version }}, python=${{ matrix.python-version }}, os=${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - spark-version: 2.4.8
+          java-version: 8
+          python-version: '3.7'
+          os: ubuntu-latest
+        - spark-version: 3.3.2
+          java-version: 17
+          python-version: '3.10'
+          os: ubuntu-latest
+
+    uses: ./.github/workflows/test-hive.yml
+    with:
+      spark-version: ${{ matrix.spark-version }}
+      java-version: ${{ matrix.java-version }}
+      python-version: ${{ matrix.python-version }}
+      os: ${{ matrix.os }}
+
   tests-mongodb:
     name: Run MongoDB tests (server=${{ matrix.mongodb-version }}, spark=${{ matrix.spark-version }}, java=${{ matrix.java-version }}, python=${{ matrix.python-version }}, os=${{ matrix.os }})
     strategy:
@@ -254,6 +276,7 @@ jobs:
     needs:
     - tests-core
     - tests-clickhouse
+    - tests-hive
     - tests-mongodb
     - tests-mysql
     - tests-mssql

--- a/requirements/tests/spark-3.2.0.txt
+++ b/requirements/tests/spark-3.2.0.txt
@@ -1,4 +1,4 @@
-numpy>=1.16
+numpy>=1.16,<1.24
 pandas>=1.0,<2
 pyarrow>=1.0
 pyspark==3.2.0

--- a/requirements/tests/spark-3.3.2.txt
+++ b/requirements/tests/spark-3.3.2.txt
@@ -1,4 +1,4 @@
-numpy>=1.16
+numpy>=1.16,<1.24
 pandas>=1.0,<2
 pyarrow>=1.0
 pyspark==3.3.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -383,7 +383,9 @@ per-file-ignores =
 # F811 redefinition of unused 'onetl' from line 72
         F811,
 # F821: undefined name
-        F821
+        F821,
+# WPS429: Found multiple assign targets a = b = 'c'
+        WPS429
 
 [darglint]
 docstring_style = sphinx

--- a/tests/tests_integration/tests_core_integration/tests_db_writer_integration/test_hive_writer_integration.py
+++ b/tests/tests_integration/tests_core_integration/tests_db_writer_integration/test_hive_writer_integration.py
@@ -45,7 +45,10 @@ def test_hive_writer_with_dict_options(spark, processing, get_schema_table):
     response = hive.sql(f"SHOW CREATE TABLE {get_schema_table.full_name}")
     response = response.collect()[0][0]
 
-    assert "`compression` 'snappy'" in response
+    if spark.version[0] == "2":
+        assert "`compression` 'snappy'" in response
+    else:
+        assert "'compression' = 'snappy'" in response
 
 
 def test_hive_writer_with_pydantic_options(spark, processing, get_schema_table):
@@ -62,7 +65,10 @@ def test_hive_writer_with_pydantic_options(spark, processing, get_schema_table):
     response = hive.sql(f"SHOW CREATE TABLE {get_schema_table.full_name}")
     response = response.collect()[0][0]
 
-    assert "`compression` 'snappy'" in response
+    if spark.version[0] == "2":
+        assert "`compression` 'snappy'" in response
+    else:
+        assert "'compression' = 'snappy'" in response
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Added CI workflow for Hive tests.

Previously tests were run only with Spark 2.4.8. In Spark 3 some system columns in `SHOW DATABASES` and `SHOW TABLES` responses were renamed, so I've added a condition to tests.

I've also discovered that PySpark 3.3.2 was not fully compatible with NumPy 1.24+ (type `np.bool` was removed, but PySpark used it in one internal check), so I've restricted NumPy version in requirements. PySpark 3.4.0 has full support of NumPy 1.24, but a few fixes should be made to onETL to support it.