### PR TITLE
[DOP-3137] Add tests workflow for Greenplum

### DIFF
--- a/.github/workflows/test-clickhouse.yml
+++ b/.github/workflows/test-clickhouse.yml
@@ -18,8 +18,9 @@ on:
         required: true
         type: string
       os:
-        required: true
+        required: false
         type: string
+        default: ubuntu-latest
 
 jobs:
   test-clickhouse:
@@ -38,16 +39,25 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
 
-    - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ inputs.python-version }}
-
     - name: Set up Java ${{ inputs.java-version }}
       uses: actions/setup-java@v3
       with:
         distribution: temurin
         java-version: ${{ inputs.java-version }}
+
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Cache Ivy
+      uses: actions/cache@v3
+      with:
+        path: ~/.ivy2
+        key: ${{ runner.os }}-ivy-${{ inputs.spark-version }}-tests-clickhouse-${{ hashFiles('onetl/connection/db_connection/*.py') }}
+        restore-keys: |
+          ${{ runner.os }}-ivy-${{ inputs.spark-version }}-tests-clickhouse-${{ hashFiles('onetl/connection/db_connection/*.py') }}
+          ${{ runner.os }}-ivy-${{ inputs.spark-version }}-tests-clickhouse-
 
     - name: Cache pip
       uses: actions/cache@v3

--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -12,8 +12,9 @@ on:
         required: true
         type: string
       os:
-        required: true
+        required: false
         type: string
+        default: ubuntu-latest
 
 jobs:
   test-core:

--- a/.github/workflows/test-ftp.yml
+++ b/.github/workflows/test-ftp.yml
@@ -9,8 +9,9 @@ on:
         required: true
         type: string
       os:
-        required: true
+        required: false
         type: string
+        default: ubuntu-latest
 
 jobs:
   test-ftp:

--- a/.github/workflows/test-ftps.yml
+++ b/.github/workflows/test-ftps.yml
@@ -9,8 +9,9 @@ on:
         required: true
         type: string
       os:
-        required: true
+        required: false
         type: string
+        default: ubuntu-latest
 
 jobs:
   test-ftps:

--- a/.github/workflows/test-greenplum.yml
+++ b/.github/workflows/test-greenplum.yml
@@ -1,0 +1,115 @@
+name: Tests for Greenplum
+on:
+  workflow_call:
+    inputs:
+      greenplum-version:
+        required: true
+        type: string
+      spark-version:
+        required: true
+        type: string
+      java-version:
+        required: true
+        type: string
+      python-version:
+        required: true
+        type: string
+      os:
+        required: false
+        type: string
+        default: ubuntu-latest
+    secrets:
+      GREENPLUM_PACKAGES_USER:
+        required: true
+      GREENPLUM_PACKAGES_PASSWORD:
+        required: true
+
+jobs:
+  test-greenplum:
+    if: github.repository == 'MobileTeleSystems/onetl'  # prevent running on forks
+    name: Run Greenplum tests (server=${{ inputs.greenplum-version }}, spark=${{ inputs.spark-version }}, java=${{ inputs.java-version }}, python=${{ inputs.python-version }}, os=${{ inputs.os }})
+    runs-on: ${{ inputs.os }}
+    services:
+      greenplum:
+        image: datagrip/greenplum:${{ inputs.greenplum-version }}
+        env:
+          TZ: UTC
+        ports:
+        - 5433:5432
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up Java ${{ inputs.java-version }}
+      uses: actions/setup-java@v3
+      with:
+        distribution: temurin
+        java-version: ${{ inputs.java-version }}
+
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Cache pip
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-python-${{ inputs.python-version }}-spark-${{ inputs.spark-version }}-tests-greenplum-${{ hashFiles('requirements/core.txt', 'requirements/tests/base.txt', 'requirements/tests/postgres.txt', 'requirements/tests/spark-*.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-python-${{ inputs.python-version }}-spark-${{ inputs.spark-version }}-tests-greenplum-${{ hashFiles('requirements/core.txt', 'requirements/tests/base.txt', 'requirements/tests/postgres.txt', 'requirements/tests/spark-*.txt') }}
+          ${{ runner.os }}-python-${{ inputs.python-version }}-spark-${{ inputs.spark-version }}-tests-greenplum-
+
+    - name: Cache Ivy
+      uses: actions/cache@v3
+      with:
+        path: ~/.ivy2
+        key: ${{ runner.os }}-ivy-${{ inputs.spark-version }}-tests-greenplum-${{ hashFiles('onetl/connection/db_connection/*.py') }}
+        restore-keys: |
+          ${{ runner.os }}-ivy-${{ inputs.spark-version }}-tests-greenplum-${{ hashFiles('onetl/connection/db_connection/*.py') }}
+          ${{ runner.os }}-ivy-${{ inputs.spark-version }}-tests-greenplum-
+
+    - name: Set up Postgres client
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update && sudo apt-get install --no-install-recommends postgresql-client
+
+    - name: Upgrade pip
+      run: python -m pip install --upgrade pip setuptools wheel
+
+    - name: Install dependencies
+      run: |
+        pip install -I \
+          -r requirements/core.txt \
+          -r requirements/tests/base.txt \
+          -r requirements/tests/postgres.txt \
+          -r requirements/tests/spark-${{ inputs.spark-version }}.txt
+
+    - name: Wait for Greenplum to be ready
+      run: |
+        sed '/^$/d' ./.env.local | sed '/^#/d' | sed 's/^/export /' > ./env
+        source ./env
+
+        # Greenplum init script is running very late
+        sleep 30
+
+        export PGPASSWORD=$ONETL_GP_CONN_PASSWORD
+        pg_isready -h localhost -p 5433 -U $ONETL_GP_CONN_USER -d $ONETL_GP_CONN_DATABASE -t 60
+
+    - name: Run tests
+      run: |
+        mkdir reports/ || echo "Directory exists"
+        sed '/^$/d' ./.env.local | sed '/^#/d' | sed 's/^/export /' > ./env
+        source ./env
+        ./pytest_runner.sh -m greenplum
+      env:
+        ONETL_DB_WITH_GREENPLUM: 'true'
+        GREENPLUM_PACKAGES_USER: ${{ secrets.GREENPLUM_PACKAGES_USER }}
+        GREENPLUM_PACKAGES_PASSWORD: ${{ secrets.GREENPLUM_PACKAGES_PASSWORD }}
+
+    - name: Upload coverage results
+      uses: actions/upload-artifact@v3
+      with:
+        name: greenplum-${{ inputs.greenplum-version }}-spark-${{ inputs.spark-version }}-python-${{ inputs.python-version }}-os-${{ inputs.os }}
+        path: reports/*

--- a/.github/workflows/test-hdfs.yml
+++ b/.github/workflows/test-hdfs.yml
@@ -9,8 +9,9 @@ on:
         required: true
         type: string
       os:
-        required: true
+        required: false
         type: string
+        default: ubuntu-latest
 
 jobs:
   test-hdfs:

--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -12,8 +12,9 @@ on:
         required: true
         type: string
       os:
-        required: true
+        required: false
         type: string
+        default: ubuntu-latest
 
 jobs:
   test-hive:
@@ -24,16 +25,25 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
 
-    - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ inputs.python-version }}
-
     - name: Set up Java ${{ inputs.java-version }}
       uses: actions/setup-java@v3
       with:
         distribution: temurin
         java-version: ${{ inputs.java-version }}
+
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Cache Ivy
+      uses: actions/cache@v3
+      with:
+        path: ~/.ivy2
+        key: ${{ runner.os }}-ivy-${{ inputs.spark-version }}-tests-hive-${{ hashFiles('onetl/connection/db_connection/*.py') }}
+        restore-keys: |
+          ${{ runner.os }}-ivy-${{ inputs.spark-version }}-tests-hive-${{ hashFiles('onetl/connection/db_connection/*.py') }}
+          ${{ runner.os }}-ivy-${{ inputs.spark-version }}-tests-hive-
 
     - name: Cache pip
       uses: actions/cache@v3

--- a/.github/workflows/test-mongodb.yml
+++ b/.github/workflows/test-mongodb.yml
@@ -15,8 +15,9 @@ on:
         required: true
         type: string
       os:
-        required: true
+        required: false
         type: string
+        default: ubuntu-latest
 
 jobs:
   test-mongodb:
@@ -36,16 +37,25 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
 
-    - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ inputs.python-version }}
-
     - name: Set up Java ${{ inputs.java-version }}
       uses: actions/setup-java@v3
       with:
         distribution: temurin
         java-version: ${{ inputs.java-version }}
+
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Cache Ivy
+      uses: actions/cache@v3
+      with:
+        path: ~/.ivy2
+        key: ${{ runner.os }}-ivy-${{ inputs.spark-version }}-tests-mongodb-${{ hashFiles('onetl/connection/db_connection/*.py') }}
+        restore-keys: |
+          ${{ runner.os }}-ivy-${{ inputs.spark-version }}-tests-mongodb-${{ hashFiles('onetl/connection/db_connection/*.py') }}
+          ${{ runner.os }}-ivy-${{ inputs.spark-version }}-tests-mongodb-
 
     - name: Cache pip
       uses: actions/cache@v3

--- a/.github/workflows/test-mssql.yml
+++ b/.github/workflows/test-mssql.yml
@@ -15,8 +15,9 @@ on:
         required: true
         type: string
       os:
-        required: true
+        required: false
         type: string
+        default: ubuntu-latest
 
 jobs:
   test-mssql:
@@ -39,16 +40,25 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
 
-    - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ inputs.python-version }}
-
     - name: Set up Java ${{ inputs.java-version }}
       uses: actions/setup-java@v3
       with:
         distribution: temurin
         java-version: ${{ inputs.java-version }}
+
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Cache Ivy
+      uses: actions/cache@v3
+      with:
+        path: ~/.ivy2
+        key: ${{ runner.os }}-ivy-${{ inputs.spark-version }}-tests-mssql-${{ hashFiles('onetl/connection/db_connection/*.py') }}
+        restore-keys: |
+          ${{ runner.os }}-ivy-${{ inputs.spark-version }}-tests-mssql-${{ hashFiles('onetl/connection/db_connection/*.py') }}
+          ${{ runner.os }}-ivy-${{ inputs.spark-version }}-tests-mssql-
 
     - name: Cache pip
       uses: actions/cache@v3

--- a/.github/workflows/test-mysql.yml
+++ b/.github/workflows/test-mysql.yml
@@ -15,8 +15,9 @@ on:
         required: true
         type: string
       os:
-        required: true
+        required: false
         type: string
+        default: ubuntu-latest
 
 jobs:
   test-mysql:
@@ -38,16 +39,25 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
 
-    - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ inputs.python-version }}
-
     - name: Set up Java ${{ inputs.java-version }}
       uses: actions/setup-java@v3
       with:
         distribution: temurin
         java-version: ${{ inputs.java-version }}
+
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Cache Ivy
+      uses: actions/cache@v3
+      with:
+        path: ~/.ivy2
+        key: ${{ runner.os }}-ivy-${{ inputs.spark-version }}-tests-mysql-${{ hashFiles('onetl/connection/db_connection/*.py') }}
+        restore-keys: |
+          ${{ runner.os }}-ivy-${{ inputs.spark-version }}-tests-mysql-${{ hashFiles('onetl/connection/db_connection/*.py') }}
+          ${{ runner.os }}-ivy-${{ inputs.spark-version }}-tests-mysql-
 
     - name: Cache pip
       uses: actions/cache@v3

--- a/.github/workflows/test-oracle.yml
+++ b/.github/workflows/test-oracle.yml
@@ -15,8 +15,9 @@ on:
         required: true
         type: string
       os:
-        required: true
+        required: false
         type: string
+        default: ubuntu-latest
 
 jobs:
   test-oracle:
@@ -37,25 +38,25 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
 
-    - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ inputs.python-version }}
-
     - name: Set up Java ${{ inputs.java-version }}
       uses: actions/setup-java@v3
       with:
         distribution: temurin
         java-version: ${{ inputs.java-version }}
 
-    - name: Set up Oracle instantclient
-      if: runner.os == 'Linux'
-      run: |
-        mkdir ./tmp
-        wget -P ./tmp https://download.oracle.com/otn_software/linux/instantclient/2110000/instantclient-basic-linux.x64-21.10.0.0.0dbru.zip
-        mkdir -p ./oracle
-        unzip ./tmp/instantclient-basic-linux.x64-21.10.0.0.0dbru.zip -d ./oracle
-        rm -rf ./tmp/instantclient-basic-linux.x64-21.10.0.0.0dbru.zip
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Cache Ivy
+      uses: actions/cache@v3
+      with:
+        path: ~/.ivy2
+        key: ${{ runner.os }}-ivy-${{ inputs.spark-version }}-tests-oracle-${{ hashFiles('onetl/connection/db_connection/*.py') }}
+        restore-keys: |
+          ${{ runner.os }}-ivy-${{ inputs.spark-version }}-tests-oracle-${{ hashFiles('onetl/connection/db_connection/*.py') }}
+          ${{ runner.os }}-ivy-${{ inputs.spark-version }}-tests-oracle-
 
     - name: Cache pip
       uses: actions/cache@v3
@@ -65,6 +66,15 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-python-${{ inputs.python-version }}-tests-oracle-${{ hashFiles('requirements/core.txt', 'requirements/tests/base.txt', 'requirements/tests/oracle.txt', 'requirements/tests/spark-*.txt') }}
           ${{ runner.os }}-python-${{ inputs.python-version }}-tests-oracle-
+
+    - name: Set up Oracle instantclient
+      if: runner.os == 'Linux'
+      run: |
+        mkdir ./tmp
+        wget -P ./tmp https://download.oracle.com/otn_software/linux/instantclient/2110000/instantclient-basic-linux.x64-21.10.0.0.0dbru.zip
+        mkdir -p ./oracle
+        unzip ./tmp/instantclient-basic-linux.x64-21.10.0.0.0dbru.zip -d ./oracle
+        rm -rf ./tmp/instantclient-basic-linux.x64-21.10.0.0.0dbru.zip
 
     - name: Upgrade pip
       run: python -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/test-postgres.yml
+++ b/.github/workflows/test-postgres.yml
@@ -15,8 +15,9 @@ on:
         required: true
         type: string
       os:
-        required: true
+        required: false
         type: string
+        default: ubuntu-latest
 
 jobs:
   test-postgres:
@@ -37,25 +38,34 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
 
-    - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ inputs.python-version }}
-
     - name: Set up Java ${{ inputs.java-version }}
       uses: actions/setup-java@v3
       with:
         distribution: temurin
         java-version: ${{ inputs.java-version }}
 
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Cache Ivy
+      uses: actions/cache@v3
+      with:
+        path: ~/.ivy2
+        key: ${{ runner.os }}-ivy-${{ inputs.spark-version }}-tests-postgres-${{ hashFiles('onetl/connection/db_connection/*.py') }}
+        restore-keys: |
+          ${{ runner.os }}-ivy-${{ inputs.spark-version }}-tests-postgres-${{ hashFiles('onetl/connection/db_connection/*.py') }}
+          ${{ runner.os }}-ivy-${{ inputs.spark-version }}-tests-postgres-
+
     - name: Cache pip
       uses: actions/cache@v3
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-python-${{ inputs.python-version }}-spark-${{ inputs.spark-version }}-tests-postgres-${{ hashFiles('requirements/core.txt', 'requirements/tests/base.txt', 'requirements/tests/postres.txt', 'requirements/tests/spark*.txt') }}
+        key: ${{ runner.os }}-python-${{ inputs.python-version }}-tests-postgres-${{ hashFiles('requirements/core.txt', 'requirements/tests/base.txt', 'requirements/tests/postgres.txt', 'requirements/tests/spark-*.txt') }}
         restore-keys: |
-          ${{ runner.os }}-python-${{ inputs.python-version }}-spark-${{ inputs.spark-version }}-tests-postgres-${{ hashFiles('requirements/core.txt', 'requirements/tests/base.txt', 'requirements/tests/postres.txt', 'requirements/tests/spark*.txt') }}
-          ${{ runner.os }}-python-${{ inputs.python-version }}-spark-${{ inputs.spark-version }}-tests-postgres-
+          ${{ runner.os }}-python-${{ inputs.python-version }}-tests-postgres-${{ hashFiles('requirements/core.txt', 'requirements/tests/base.txt', 'requirements/tests/postgres.txt', 'requirements/tests/spark-*.txt') }}
+          ${{ runner.os }}-python-${{ inputs.python-version }}-tests-postgres-
 
     - name: Upgrade pip
       run: python -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/test-s3.yml
+++ b/.github/workflows/test-s3.yml
@@ -9,8 +9,9 @@ on:
         required: true
         type: string
       os:
-        required: true
+        required: false
         type: string
+        default: ubuntu-latest
 
 jobs:
   test-s3:

--- a/.github/workflows/test-sftp.yml
+++ b/.github/workflows/test-sftp.yml
@@ -9,8 +9,9 @@ on:
         required: true
         type: string
       os:
-        required: true
+        required: false
         type: string
+        default: ubuntu-latest
 
 jobs:
   test-sftp:

--- a/.github/workflows/test-teradata.yml
+++ b/.github/workflows/test-teradata.yml
@@ -12,8 +12,9 @@ on:
         required: true
         type: string
       os:
-        required: true
+        required: false
         type: string
+        default: ubuntu-latest
 
 jobs:
   test-teradata:
@@ -24,16 +25,25 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
 
-    - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ inputs.python-version }}
-
     - name: Set up Java ${{ inputs.java-version }}
       uses: actions/setup-java@v3
       with:
         distribution: temurin
         java-version: ${{ inputs.java-version }}
+
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Cache Ivy
+      uses: actions/cache@v3
+      with:
+        path: ~/.ivy2
+        key: ${{ runner.os }}-ivy-${{ inputs.spark-version }}-tests-teradata-${{ hashFiles('onetl/connection/db_connection/*.py') }}
+        restore-keys: |
+          ${{ runner.os }}-ivy-${{ inputs.spark-version }}-tests-teradata-${{ hashFiles('onetl/connection/db_connection/*.py') }}
+          ${{ runner.os }}-ivy-${{ inputs.spark-version }}-tests-teradata-
 
     - name: Cache pip
       uses: actions/cache@v3

--- a/.github/workflows/test-webdav.yml
+++ b/.github/workflows/test-webdav.yml
@@ -9,8 +9,9 @@ on:
         required: true
         type: string
       os:
-        required: true
+        required: false
         type: string
+        default: ubuntu-latest
 
 jobs:
   test-webdav:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,6 +63,34 @@ jobs:
       python-version: ${{ matrix.python-version }}
       os: ${{ matrix.os }}
 
+  tests-greenplum:
+    name: Run Greenplum tests (server=${{ matrix.greenplum-version }}, spark=${{ matrix.spark-version }}, java=${{ matrix.java-version }}, python=${{ matrix.python-version }}, os=${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - greenplum-version: 6.8
+          spark-version: 2.4.8
+          java-version: 8
+          python-version: '3.7'
+          os: ubuntu-latest
+        - greenplum-version: 6.8
+          spark-version: 3.2.3  # Greenplum connector currently does not support Spark 3.3+
+          java-version: 11
+          python-version: '3.10'
+          os: ubuntu-latest
+
+    uses: ./.github/workflows/test-greenplum.yml
+    with:
+      greenplum-version: ${{ matrix.greenplum-version }}
+      spark-version: ${{ matrix.spark-version }}
+      java-version: ${{ matrix.java-version }}
+      python-version: ${{ matrix.python-version }}
+      os: ${{ matrix.os }}
+    secrets:
+      GREENPLUM_PACKAGES_USER: ${{ secrets.GREENPLUM_PACKAGES_USER }}
+      GREENPLUM_PACKAGES_PASSWORD: ${{ secrets.GREENPLUM_PACKAGES_PASSWORD }}
+
   tests-hive:
     name: Run Hive tests (spark=${{ matrix.spark-version }}, java=${{ matrix.java-version }}, python=${{ matrix.python-version }}, os=${{ matrix.os }})
     strategy:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,6 +4,6 @@ python:
   version: '3.8'
   install:
   - requirements: requirements/core.txt
-  - requirements: requirements/docs.txt
   - method: pip
     path: .[ftp, ftps, hdfs, s3, sftp, webdav, spark]
+  - requirements: requirements/docs.txt

--- a/README.rst
+++ b/README.rst
@@ -150,19 +150,22 @@ Firstly, you should install JDK. The exact installation instruction depends on y
     dnf install java-11-openjdk-devel  # CentOS 8 + Spark 3
     apt-get install openjdk-11-jdk  # Debian-based + Spark 3
 
-Compatibility matrix:
+.. _spark-compatibility-matrix:
 
-+--------------------------------------------------------------+-------------+-------------+
-| Spark                                                        | Java        | Python      |
-+==============================================================+=============+=============+
-| `2.3.x <https://spark.apache.org/docs/2.3.0/#downloading>`_  | 8 only      | 2.7 - 3.7   |
-+--------------------------------------------------------------+-------------+-------------+
-| `2.4.x <https://spark.apache.org/docs/2.4.8/#downloading>`_  | 8 only      | 2.7 - 3.7   |
-+--------------------------------------------------------------+-------------+-------------+
-| `3.2.x <https://spark.apache.org/docs/3.2.3/#downloading>`_  | 8u201 - 11  | 3.7 - 3.10  |
-+--------------------------------------------------------------+-------------+-------------+
-| `3.3.x <https://spark.apache.org/docs/3.3.2/#downloading>`_  | 8u201 - 17  | 3.7 - 3.10  |
-+--------------------------------------------------------------+-------------+-------------+
+Compatibility matrix
+^^^^^^^^^^^^^^^^^^^^
+
++--------------------------------------------------------------+-------------+-------------+-------+
+| Spark                                                        | Python      | Java        | Scala |
++==============================================================+=============+=============+=======+
+| `2.3.x <https://spark.apache.org/docs/2.3.0/#downloading>`_  | 2.7 - 3.7   | 8 only      | 2.11  |
++--------------------------------------------------------------+-------------+-------------+-------+
+| `2.4.x <https://spark.apache.org/docs/2.4.8/#downloading>`_  | 2.7 - 3.7   | 8 only      | 2.11  |
++--------------------------------------------------------------+-------------+-------------+-------+
+| `3.2.x <https://spark.apache.org/docs/3.2.3/#downloading>`_  | 3.7 - 3.10  | 8u201 - 11  | 2.12  |
++--------------------------------------------------------------+-------------+-------------+-------+
+| `3.3.x <https://spark.apache.org/docs/3.3.2/#downloading>`_  | 3.7 - 3.10  | 8u201 - 17  | 2.12  |
++--------------------------------------------------------------+-------------+-------------+-------+
 
 Then you should install PySpark via passing ``spark`` to ``extras``:
 
@@ -302,7 +305,7 @@ Create virtualenv and install dependencies:
         -r requirements/test/mysql.txt \
         -r requirements/test/oracle.txt \
         -r requirements/test/postgres.txt \
-        -r requirements/test/spark-3.2.0.txt
+        -r requirements/test/spark-3.3.2.txt
 
 Enable pre-commit hooks
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -394,6 +397,14 @@ Run tests locally
     and pass its path to ``ONETL_ORA_CLIENT_PATH`` environment variable, e.g. ``ONETL_ORA_CLIENT_PATH=/path/to/client64/lib``.
 
     It may also require to add the same path into ``LD_LIBRARY_PATH`` environment variable
+
+.. note::
+
+    To run Greenplum tests, you should:
+
+    * Download `Pivotal connector for Spark <https://onetl.org.readthedocs.build/en/latest/db_connection/greenplum/prerequisites.html>`_
+    * Either move it to ``~/.ivy2/jars/``, or pass file path to ``CLASSPATH``
+    * Set environment variable ``ONETL_DB_WITH_GREENPLUM=true`` to enable adding connector to Spark session
 
 Build image for running tests:
 

--- a/docs/db_connection/clickhouse.rst
+++ b/docs/db_connection/clickhouse.rst
@@ -13,7 +13,7 @@ Clickhouse connection
     Clickhouse.JDBCOptions
 
 .. autoclass:: Clickhouse
-    :members: __init__, check, sql, fetch, execute
+    :members: check, sql, fetch, execute
 
 .. currentmodule:: onetl.connection.db_connection.clickhouse.Clickhouse
 

--- a/docs/db_connection/greenplum/greenplum.rst
+++ b/docs/db_connection/greenplum/greenplum.rst
@@ -1,6 +1,6 @@
 .. _greenplum:
 
-Greenplum connection
+Greenplum connector
 ====================
 
 .. currentmodule:: onetl.connection.db_connection.greenplum

--- a/docs/db_connection/greenplum/index.rst
+++ b/docs/db_connection/greenplum/index.rst
@@ -1,0 +1,11 @@
+.. _greenplum:
+
+Greenplum connector
+====================
+
+.. toctree::
+    :maxdepth: 1
+    :caption: Greenplum connector
+
+    prerequisites
+    greenplum

--- a/docs/db_connection/greenplum/prerequisites.rst
+++ b/docs/db_connection/greenplum/prerequisites.rst
@@ -1,0 +1,169 @@
+.. _greenplum-prerequisites:
+
+Prerequisites
+=============
+
+Version Compatibility
+---------------------
+
+* Greenplum server versions: 5.x, 6.x
+* Spark versions: 2.3.x - 3.2.x (Spark 3.3.x is not supported yet)
+* Java versions: 8 - 11
+
+See `official documentation <https://docs.vmware.com/en/VMware-Tanzu-Greenplum-Connector-for-Apache-Spark/2.1/tanzu-greenplum-connector-spark/GUID-release_notes.html>`_.
+
+Installing PySpark
+------------------
+
+To use Greenplum connector you should have PySpark installed (or injected to ``sys.path``)
+BEFORE creating the connector instance.
+
+You can install PySpark as follows:
+
+.. code:: bash
+
+    pip install onetl pyspark=3.2.3  # pass specific PySpark version
+
+See :ref:`spark-install` instruction for more details.
+
+Downloading Pivotal package
+---------------------------
+
+To use Greenplum connector you should download connector ``.jar`` file from
+`Pivotal website <https://network.tanzu.vmware.com/products/vmware-greenplum#/releases/1287433/file_groups/13260>`_
+and then pass it to Spark session.
+
+There are several ways to do that.
+
+.. note::
+
+    Please pay attention to Spark <-> Scala version compatibility. See :ref:`spark-compatibility-matrix`.
+
+Using ``spark.jars``
+~~~~~~~~~~~~~~~~~~~~
+
+The most simple solution, but this requires to store/deploy ``.jar`` file in the local environment.
+
+* Download ``greenplum-connector-apache-spark-scala_2.12-2.1.4.jar`` file.
+* Create Spark session with passing ``.jar`` absolute file path to ``spark.jars`` Spark config option, e.g.
+
+.. code:: python
+
+    # no need to use spark.jars.packages
+    spark = (
+        SparkSession.builder.config("spark.app.name", "onetl")
+        .config("spark.jars", "/path/to/downloaded.jar")
+        .getOrCreate()
+    )
+
+Using ``spark.jars.repositories``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Can be used if you have access both to public repos (like Maven) and a private Artifactory/Nexus repo.
+
+* Setup private Maven repository in `JFrog Artifactory <https://jfrog.com/artifactory/>`_ or `Sonatype Nexus <https://www.sonatype.com/products/sonatype-nexus-repository>`_.
+* Download ``greenplum-connector-apache-spark-scala_2.12-2.1.4.jar`` file.
+* Upload ``.jar`` file to private repository (with ``groupId=io.pivotal``, ``artifactoryId=greenplum-spark_2.12``).
+* Pass repo URL to ``spark.jars.repositories`` Spark config option
+* Create Spark session with passing Greenplum package name to ``spark.jars.packages`` Spark config option.
+
+
+Example
+^^^^^^^
+
+.. code:: python
+
+    spark = (
+        SparkSession.builder.config("spark.app.name", "onetl")
+        .config("spark.jars.repositories", "http://nexus.domain.com/example-repo/")
+        .config("spark.jars.packages", Greenplum.package_spark_3_2)
+        .getOrCreate()
+    )
+
+
+Using ``spark.jars.ivySettings``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Same as above, but can be used even if there is no network access to public repos like Maven.
+
+* Setup private Maven repository in `JFrog Artifactory <https://jfrog.com/artifactory/>`_ or `Sonatype Nexus <https://www.sonatype.com/products/sonatype-nexus-repository>`_.
+* Download ``greenplum-connector-apache-spark-scala_2.12-2.1.4.jar`` file.
+* Upload ``.jar`` file to private repository (with ``groupId=io.pivotal``, ``artifactoryId=greenplum-spark_2.12``).
+* Create `ivysettings.xml <https://github.com/MobileTeleSystems/onetl/blob/develop/tests/ivysettings.xml>`_ file.
+* Add here a resolver with repository URL (and credentials, if required).
+* Pass ``ivysettings.xml`` absolute path to ``spark.jars.ivySettings`` Spark config option.
+* Create Spark session with passing Greenplum package name to ``spark.jars.packages`` Spark config option.
+
+Example
+^^^^^^^
+
+.. code:: xml
+    :name: ivysettings.xml
+
+    <ivysettings>
+        <settings defaultResolver="main"/>
+        <resolvers>
+            <chain name="main" returnFirst="true">
+                <!-- Use Maven cache -->
+                <ibiblio name="local-maven-cache" m2compatible="true" root="file://${user.home}/.m2/repository"/>
+                <!-- Use ~/.ivy2/jars/*.jar files -->
+                <ibiblio name="local-ivy2-cache" m2compatible="false" root="file://${user.home}/.ivy2/jars"/>
+                <!-- Download packages from Maven, remove if no network access -->
+                <ibiblio name="central" m2compatible="true" />
+                <!-- Download packages from SparkPackages, remove if no network access -->
+                <ibiblio name="spark-packages" m2compatible="true" root="https://repos.spark-packages.org/" />
+                <!-- Nexus repo-->
+                <ibiblio name="nexus-private" m2compatible="true" root="http://nexus.domain.com/example-repo/" />
+            </chain>
+        </resolvers>
+    </ivysettings>
+
+
+.. code:: python
+    :name: script.py
+
+    spark = (
+        SparkSession.builder.config("spark.app.name", "onetl")
+        .config("spark.jars.ivySettings", "/path/to/ivysettings.xml")
+        .config("spark.jars.packages", Greenplum.package_spark_3_2)
+        .getOrCreate()
+    )
+
+Moving ``.jar`` file to ``~/.ivy2/jars/``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Can be used to pass already downloaded file to Ivy, and skip resolving package from Maven.
+
+* Download ``greenplum-connector-apache-spark-scala_2.12-2.1.4.jar`` file.
+* Move it to ``~/.ivy2/jars/`` folder
+* Create Spark session with passing Greenplum package name to ``spark.jars.packages`` Spark config option.
+
+Example
+^^^^^^^
+
+.. code:: python
+
+    spark = (
+        SparkSession.builder.config("spark.app.name", "onetl")
+        .config("spark.jars.packages", Greenplum.package_spark_3_2)
+        .getOrCreate()
+    )
+
+Inserting ``.jar`` file to Spark jars folder
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Can be used to embed ``.jar`` files to a default Spark classpath.
+
+* Download ``greenplum-connector-apache-spark-scala_2.12-2.1.4.jar`` file.
+* Move it to ``$SPARK_HOME/jars/`` folder, e.g. ``~/.local/lib/python3.7/site-packages/pyspark/jars/`` or ``/opt/spark/3.2.3/jars/``.
+* Create Spark session **WITHOUT** passing Greenplum package name to ``spark.jars.packages``
+
+
+Manually adding ``.jar`` files to ``CLASSPATH``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Can be used to embed ``.jar`` files to a default Java classpath.
+
+* Download ``greenplum-connector-apache-spark-scala_2.12-2.1.4.jar`` file.
+* Set environment variable ``CLASSPATH`` to ``/path/to/downloader.jar``
+* Create Spark session **WITHOUT** passing Greenplum package name to ``spark.jars.packages``

--- a/docs/db_connection/index.rst
+++ b/docs/db_connection/index.rst
@@ -8,7 +8,7 @@ DB Connections
     :caption: DB Connections
 
     Clickhouse <clickhouse>
-    Greenplum <greenplum>
+    Greenplum <greenplum/index>
     Hive <hive>
     MongoDB <mongodb>
     MSSQL <mssql>

--- a/docs/db_connection/mongodb.rst
+++ b/docs/db_connection/mongodb.rst
@@ -13,7 +13,7 @@ MongoDB connection
     MongoDB.PipelineOptions
 
 .. autoclass:: MongoDB
-    :members: __init__, check, pipeline
+    :members: check, pipeline
 
 .. currentmodule:: onetl.connection.db_connection.mongo.MongoDB
 

--- a/onetl/connection/db_connection/mongo.py
+++ b/onetl/connection/db_connection/mongo.py
@@ -244,7 +244,7 @@ class MongoDB(DBConnection):
 
         spark = (
             SparkSession.builder.appName("spark-app-name")
-            .config("spark.jars.packages", MongoDB.package_spark_2_4)
+            .config("spark.jars.packages", MongoDB.package_spark_3_2)
             .getOrCreate()
         )
 

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -7,3 +7,6 @@ sphinx-design
 sphinx-tabs
 sphinx-toolbox
 sphinx_substitution_extensions
+# ReadTheDocs uses old OpenSSL version
+# https://github.com/urllib3/urllib3/issues/2168
+urllib3<2.0

--- a/requirements/tests/spark-3.2.3.txt
+++ b/requirements/tests/spark-3.2.3.txt
@@ -1,4 +1,4 @@
 numpy>=1.16,<1.24
 pandas>=1.0,<2
 pyarrow>=1.0
-pyspark==3.2.0
+pyspark==3.2.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -283,8 +283,8 @@ per-file-ignores =
         WPS432,
 # WPS235 Found too many imported names from a module
         WPS235,
-# WPS325 Found inconsistent `yield` statement
-    WPS325,
+# WPS202 Found too many module members: 36 > 35
+        WPS202,
     file_result.py:
 # E800  Found commented out code
         E800,

--- a/tests/ivysettings.xml
+++ b/tests/ivysettings.xml
@@ -1,0 +1,21 @@
+<ivysettings>
+    <settings defaultResolver="main"/>
+    <properties environment="env"/>
+    <property name="repo.username" value="${env.GREENPLUM_PACKAGES_USER}"/>
+    <property name="repo.pass" value="${env.GREENPLUM_PACKAGES_PASSWORD}"/>
+    <credentials host="maven.pkg.github.com" username="${repo.username}" passwd="${repo.pass}" realm="GitHub Package Registry" />
+    <resolvers>
+      <chain name="main" returnFirst="true">
+        <!-- Use Maven cache -->
+        <ibiblio name="local-maven-cache" m2compatible="true" root="file://${user.home}/.m2/repository"/>
+        <!-- Use ~/.ivy2/jars/*.jar files -->
+        <ibiblio name="local-ivy2-cache" m2compatible="false" root="file://${user.home}/.ivy2/jars"/>
+        <!-- Download packages from Maven -->
+        <ibiblio name="central" m2compatible="true" />
+        <!-- Download packages from SparkPackages -->
+        <ibiblio name="spark-packages" m2compatible="true" root="https://repos.spark-packages.org/" />
+        <!-- Download packages from private repo (requires credentials) -->
+        <ibiblio name="pivotal-greenplum-spark-connector" m2compatible="true" root="https://maven.pkg.github.com/MobileTeleSystems/pivotal-greenplum-spark-connector" />
+      </chain>
+    </resolvers>
+</ivysettings>

--- a/tests/tests_unit/tests_db_connection_unit/test_greenplum_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_greenplum_unit.py
@@ -8,9 +8,9 @@ pytestmark = pytest.mark.greenplum
 
 def test_greenplum_class_attributes():
     assert Greenplum.driver == "org.postgresql.Driver"
-    assert Greenplum.package_spark_2_3 == "io.pivotal:greenplum-spark_2.11:2.1.3"
-    assert Greenplum.package_spark_2_4 == "io.pivotal:greenplum-spark_2.11:2.1.3"
-    assert Greenplum.package_spark_3_2 == "io.pivotal:greenplum-spark_2.12:2.1.3"
+    assert Greenplum.package_spark_2_3 == "io.pivotal:greenplum-spark_2.11:2.1.4"
+    assert Greenplum.package_spark_2_4 == "io.pivotal:greenplum-spark_2.11:2.1.4"
+    assert Greenplum.package_spark_3_2 == "io.pivotal:greenplum-spark_2.12:2.1.4"
 
 
 def test_greenplum(spark_mock):


### PR DESCRIPTION
Added CI workflow for Greenplum.

* Greenplum connector .jar files were uploaded to https://github.com/MobileTeleSystems/pivotal-greenplum-spark-connector. Added `ivysettings.xml` and auth credentials to allow CI to download packages from a private repo.
* Because Greenplum CI requires access to repo secrets, it is disabled in forks.
* Local tests are not fetching Greenplum connector by default (due to missing credentials), but contrubutors can alter this by changing environment variable.
* Added [instruction](https://onetl--24.org.readthedocs.build/en/24/db_connection/greenplum/prerequisites.html) how user can add .jar files of connector to Spark (there are a lot of ways to do that).
* Added Scala version to compatibility table
* Updated Greenplum connector from 2.1.3 to 2.1.4
* Added cache for `~/.ivy2` folder to speed up downloading packages.