### PR TITLE
[DOP-4663] Update MongoDB connector to v10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -120,7 +120,7 @@ jobs:
       matrix:
         include:
         - mongodb-version: 5.0.16
-          spark-version: 2.4.8
+          spark-version: 3.2.3  # MongoDB connector does not support Spark 2.x
           java-version: 8
           python-version: '3.7'
           os: ubuntu-latest

--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,7 @@ Supported storages
 +            +------------+----------------------------------------------------------------------------------------------------------+
 |            | Greenplum  | Pivotal `Greenplum Spark connector <https://network.tanzu.vmware.com/products/vmware-tanzu-greenplum>`_  |
 +            +------------+----------------------------------------------------------------------------------------------------------+
-|            | MongoDB    | `MongoDB Spark connector <https://www.mongodb.com/docs/spark-connector/master/>`_                        |
+|            | MongoDB    | `MongoDB Spark connector <https://www.mongodb.com/docs/spark-connector/current>`_                        |
 +------------+------------+----------------------------------------------------------------------------------------------------------+
 | File       | HDFS       | `HDFS Python client <https://pypi.org/project/hdfs/>`_                                                   |
 +            +------------+----------------------------------------------------------------------------------------------------------+

--- a/conftest.py
+++ b/conftest.py
@@ -352,7 +352,6 @@ def spark_packages():
     pyspark_version = ".".join(pyspark.__version__.split(".")[:2])
 
     if pyspark_version == "2.4":
-        packages.extend([MongoDB.package_spark_2_4])
         if with_greenplum:
             packages.extend([Greenplum.package_spark_2_4])
         return packages

--- a/onetl/base/base_db_connection.py
+++ b/onetl/base/base_db_connection.py
@@ -74,7 +74,7 @@ class BaseDBConnection(BaseConnection):
 
         @classmethod
         @abstractmethod
-        def _where_condition(cls, result: list[Any]) -> Any:
+        def _merge_conditions(cls, conditions: list[Any]) -> Any:
             """
             Convert multiple WHERE conditions to one
             """

--- a/onetl/connection/__init__.py
+++ b/onetl/connection/__init__.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from onetl.connection.db_connection.clickhouse import Clickhouse
     from onetl.connection.db_connection.greenplum import Greenplum
     from onetl.connection.db_connection.hive import Hive
-    from onetl.connection.db_connection.mongo import MongoDB
+    from onetl.connection.db_connection.mongodb import MongoDB
     from onetl.connection.db_connection.mssql import MSSQL
     from onetl.connection.db_connection.mysql import MySQL
     from onetl.connection.db_connection.oracle import Oracle
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
 db_connection_modules = {
     "Clickhouse": "clickhouse",
     "Greenplum": "greenplum",
-    "MongoDB": "mongo",
+    "MongoDB": "mongodb",
     "Hive": "hive",
     "MSSQL": "mssql",
     "MySQL": "mysql",

--- a/setup.cfg
+++ b/setup.cfg
@@ -299,7 +299,7 @@ per-file-ignores =
     *connection.py:
 # WPS437 Found protected attribute usage: spark._sc._gateway
         WPS437,
-    onetl/connection/db_connection/mongo.py:
+    onetl/connection/db_connection/mongodb.py:
 # WPS437 Found protected attribute usage: self.Dialect._
         WPS437,
     onetl/connection/db_connection/jdbc_mixin.py:


### PR DESCRIPTION
Upgrade MongoDB connection from v2-3 to v10.
Minimal supported Spark version for MongoDB is now 3.2.x.

Also:
* Refactored several methods in `MongoDB.Dialect` - now there is only one method for prepairing `pipeline` dict/list and for converting it to string (using just `json.dumps`, it is already compatible with MongoDB pipeline syntax.
* Refactored `Dialect._merge_conditions` - now it converts list of WHERE condition to one condition, checks for `None` and empty list were moved to other method.
* Fixed getting min/max values of HWM in aggregation pipeline - new connector version returns dataframe with the save order of columns that were passed into pipeline, getting column by index was broken, using names instead.