### PR TITLE
[DOP-4663] Move default validate_hwm_expression to a mixin

### DIFF
--- a/onetl/base/contains_get_df_schema.py
+++ b/onetl/base/contains_get_df_schema.py
@@ -36,3 +36,4 @@ class ContainsGetDFSchemaMethod(Protocol):
         """
         Description of the dataframe schema.
         """
+        ...

--- a/onetl/connection/db_connection/db_connection.py
+++ b/onetl/connection/db_connection/db_connection.py
@@ -40,10 +40,6 @@ class DBConnection(BaseDBConnection, FrozenModel):
 
     class Dialect(BaseDBConnection.Dialect):
         @classmethod
-        def validate_hwm_expression(cls, connection: BaseDBConnection, value: Any) -> str | None:
-            return value
-
-        @classmethod
         def _expression_with_alias(cls, expression: str, alias: str) -> str:
             return f"{expression} AS {alias}"
 

--- a/onetl/connection/db_connection/dialect_mixins/__init__.py
+++ b/onetl/connection/db_connection/dialect_mixins/__init__.py
@@ -19,6 +19,9 @@ from onetl.connection.db_connection.dialect_mixins.support_hint_str import (
 from onetl.connection.db_connection.dialect_mixins.support_hwm_expression_none import (
     SupportHWMExpressionNone,
 )
+from onetl.connection.db_connection.dialect_mixins.support_hwm_expression_str import (
+    SupportHWMExpressionStr,
+)
 from onetl.connection.db_connection.dialect_mixins.support_where_str import (
     SupportWhereStr,
 )

--- a/onetl/connection/db_connection/dialect_mixins/support_hwm_expression_str.py
+++ b/onetl/connection/db_connection/dialect_mixins/support_hwm_expression_str.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Any
+
+from onetl.base import BaseDBConnection
+
+
+class SupportHWMExpressionStr:
+    @classmethod
+    def validate_hwm_expression(cls, connection: BaseDBConnection, value: Any) -> str | None:
+        if value is None:
+            return None
+
+        if not isinstance(value, str):
+            raise TypeError(
+                f"{connection.__class__.__name__} requires 'hwm_expression' parameter type to be 'str', "
+                f"got {value.__class__.__name__!r}",
+            )
+
+        return value

--- a/onetl/connection/db_connection/greenplum.py
+++ b/onetl/connection/db_connection/greenplum.py
@@ -35,6 +35,7 @@ from onetl.connection.db_connection.dialect_mixins import (
     SupportColumnsList,
     SupportDfSchemaNone,
     SupportHintNone,
+    SupportHWMExpressionStr,
     SupportWhereStr,
 )
 from onetl.connection.db_connection.dialect_mixins.support_table_with_dbschema import (
@@ -443,6 +444,7 @@ class Greenplum(JDBCMixin, DBConnection):
         SupportDfSchemaNone,
         SupportWhereStr,
         SupportHintNone,
+        SupportHWMExpressionStr,
         DBConnection.Dialect,
     ):
         @classmethod

--- a/onetl/connection/db_connection/hive.py
+++ b/onetl/connection/db_connection/hive.py
@@ -29,6 +29,7 @@ from onetl.connection.db_connection.dialect_mixins import (
     SupportColumnsList,
     SupportDfSchemaNone,
     SupportHintStr,
+    SupportHWMExpressionStr,
     SupportWhereStr,
 )
 from onetl.connection.db_connection.dialect_mixins.support_table_with_dbschema import (
@@ -501,6 +502,7 @@ class Hive(DBConnection):
         SupportDfSchemaNone,
         SupportWhereStr,
         SupportHintStr,
+        SupportHWMExpressionStr,
         DBConnection.Dialect,
     ):
         pass

--- a/onetl/connection/db_connection/jdbc_connection.py
+++ b/onetl/connection/db_connection/jdbc_connection.py
@@ -29,6 +29,7 @@ from onetl.connection.db_connection.dialect_mixins import (
     SupportColumnsList,
     SupportDfSchemaNone,
     SupportHintStr,
+    SupportHWMExpressionStr,
     SupportWhereStr,
 )
 from onetl.connection.db_connection.dialect_mixins.support_table_with_dbschema import (
@@ -144,6 +145,7 @@ class JDBCConnection(SupportDfSchemaNone, JDBCMixin, DBConnection):  # noqa: WPS
         SupportDfSchemaNone,
         SupportWhereStr,
         SupportHintStr,
+        SupportHWMExpressionStr,
         DBConnection.Dialect,
     ):
         pass

--- a/onetl/connection/db_connection/postgres.py
+++ b/onetl/connection/db_connection/postgres.py
@@ -22,6 +22,7 @@ from onetl.connection.db_connection.dialect_mixins import (
     SupportColumnsList,
     SupportDfSchemaNone,
     SupportHintNone,
+    SupportHWMExpressionStr,
     SupportWhereStr,
 )
 from onetl.connection.db_connection.dialect_mixins.support_table_with_dbschema import (
@@ -132,6 +133,7 @@ class Postgres(JDBCConnection):
         SupportColumnsList,
         SupportDfSchemaNone,
         SupportWhereStr,
+        SupportHWMExpressionStr,
         SupportHintNone,
         DBConnection.Dialect,
     ):


### PR DESCRIPTION
Default `validate_hwm_expression` implementation is moved to a separated mixin, which is imported only in DBConnection children.

Other validators (table, where, hint, etc) were already implemented as mixins. MongoDB already had `validate_hwm_expression` implementation using a mixin.