### PR TITLE
[DOP-4663] Improve internal logging functions

### DIFF
--- a/onetl/_internal.py
+++ b/onetl/_internal.py
@@ -211,7 +211,7 @@ def get_sql_query(
     ).strip()
 
 
-def spark_max_cores_with_config(spark: SparkSession, include_driver: bool = False) -> tuple[int, dict]:
+def spark_max_cores_with_config(spark: SparkSession, include_driver: bool = False) -> tuple[int | float, dict]:
     """
     Calculate maximum number of cores which can be used by Spark
 

--- a/onetl/connection/db_connection/jdbc_mixin.py
+++ b/onetl/connection/db_connection/jdbc_mixin.py
@@ -25,7 +25,7 @@ from pydantic import Field, SecretStr
 from onetl._internal import clear_statement, stringify, to_camel  # noqa: WPS436
 from onetl.exception import MISSING_JVM_CLASS_MSG
 from onetl.impl import FrozenModel, GenericOptions
-from onetl.log import log_with_indent
+from onetl.log import log_lines
 
 if TYPE_CHECKING:
     from pyspark.sql import DataFrame, SparkSession
@@ -148,7 +148,7 @@ class JDBCMixin(FrozenModel):
         self._log_parameters()  # type: ignore
 
         log.debug("|%s| Executing SQL query (on driver):", self.__class__.__name__)
-        log_with_indent(self._check_query, level=logging.DEBUG)
+        log_lines(self._check_query, level=logging.DEBUG)
 
         try:
             self._query_optional_on_driver(self._check_query, self.JDBCOptions(fetchsize=1))  # type: ignore
@@ -246,7 +246,7 @@ class JDBCMixin(FrozenModel):
         query = clear_statement(query)
 
         log.info("|%s| Executing SQL query (on driver):", self.__class__.__name__)
-        log_with_indent("%s", query)
+        log_lines(query)
 
         df = self._query_on_driver(query, self.JDBCOptions.parse(options))
 
@@ -360,7 +360,7 @@ class JDBCMixin(FrozenModel):
         statement = clear_statement(statement)
 
         log.info("|%s| Executing statement (on driver):", self.__class__.__name__)
-        log_with_indent("%s", statement)
+        log_lines(statement)
 
         call_options = self.JDBCOptions.parse(options)
         df = self._call_on_driver(statement, call_options)

--- a/onetl/connection/db_connection/oracle.py
+++ b/onetl/connection/db_connection/oracle.py
@@ -27,7 +27,7 @@ from pydantic import root_validator
 
 from onetl._internal import clear_statement  # noqa: WPS436
 from onetl.connection.db_connection.jdbc_connection import JDBCConnection
-from onetl.log import BASE_LOG_INDENT, log_with_indent
+from onetl.log import BASE_LOG_INDENT, log_lines
 
 # do not import PySpark here, as we allow user to use `Oracle.package` for creating Spark session
 
@@ -231,7 +231,7 @@ class Oracle(JDBCConnection):
         statement = clear_statement(statement)
 
         log.info("|%s| Executing statement (on driver):", self.__class__.__name__)
-        log_with_indent("%s", statement)
+        log_lines(statement)
 
         call_options = self.JDBCOptions.parse(options)
         df = self._call_on_driver(statement, call_options)
@@ -374,7 +374,7 @@ class Oracle(JDBCConnection):
         fail = any(error.level == logging.ERROR for error in aggregated_errors)
 
         message = self._build_error_message(aggregated_errors)
-        log_with_indent("%s", message, level=logging.ERROR if fail else logging.WARNING)
+        log_lines(message, level=logging.ERROR if fail else logging.WARNING)
 
         if fail:
             raise ValueError(message)

--- a/onetl/core/file_downloader/file_downloader.py
+++ b/onetl/core/file_downloader/file_downloader.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import os
 import shutil
-from enum import Enum
 from logging import getLogger
 from typing import Iterable, Optional, Tuple, Type
 
@@ -42,7 +41,7 @@ from onetl.impl import (
     RemotePath,
     path_repr,
 )
-from onetl.log import entity_boundary_log, log_with_indent
+from onetl.log import entity_boundary_log, log_lines, log_options, log_with_indent
 from onetl.strategy import StrategyManager
 from onetl.strategy.batch_hwm_strategy import BatchHWMStrategy
 from onetl.strategy.hwm_strategy import HWMStrategy
@@ -528,11 +527,7 @@ class FileDownloader(FrozenModel):
         else:
             log_with_indent("limit = None")
 
-        log_with_indent("options:")
-        for option, value in self.options.dict(by_alias=True).items():
-            value_wrapped = f"'{value}'" if isinstance(value, Enum) else repr(value)
-            log_with_indent("%s = %s", option, value_wrapped, indent=4)
-        log_with_indent("")
+        log_options(self.options.dict(by_alias=True))
 
         if self.options.delete_source:
             log.warning("|%s| SOURCE FILES WILL BE PERMANENTLY DELETED AFTER DOWNLOADING !!!", self.__class__.__name__)
@@ -609,7 +604,7 @@ class FileDownloader(FrozenModel):
         files = FileSet(item[0] for item in to_download)
 
         log.info("|%s| Files to be downloaded:", self.__class__.__name__)
-        log_with_indent("%s", str(files))
+        log_lines(str(files))
         log_with_indent("")
         log.info("|%s| Starting the download process", self.__class__.__name__)
 
@@ -706,7 +701,7 @@ class FileDownloader(FrozenModel):
     def _log_result(self, result: DownloadResult) -> None:
         log_with_indent("")
         log.info("|%s| Download result:", self.__class__.__name__)
-        log_with_indent("%s", str(result))
+        log_lines(str(result))
         entity_boundary_log(msg=f"{self.__class__.__name__} ends", char="-")
 
     @staticmethod

--- a/onetl/core/file_uploader/file_uploader.py
+++ b/onetl/core/file_uploader/file_uploader.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 import os
-from enum import Enum
 from logging import getLogger
 from typing import Iterable, Optional, Tuple
 
@@ -36,7 +35,7 @@ from onetl.impl import (
     RemotePath,
     path_repr,
 )
-from onetl.log import entity_boundary_log, log_with_indent
+from onetl.log import entity_boundary_log, log_lines, log_options, log_with_indent
 
 log = getLogger(__name__)
 
@@ -345,11 +344,7 @@ class FileUploader(FrozenModel):
         log_with_indent("target_path = '%s'", self.target_path)
         log_with_indent("temp_path = '%s'", f"'{self.temp_path}'" if self.temp_path else "None")
 
-        log_with_indent("options:")
-        for option, value in self.options.dict(by_alias=True).items():
-            value_wrapped = f"'{value}'" if isinstance(value, Enum) else repr(value)
-            log_with_indent("%s = %s", option, value_wrapped, indent=4)
-        log_with_indent("")
+        log_options(self.options.dict(by_alias=True))
 
         if self.options.delete_local:
             log.warning("|%s| LOCAL FILES WILL BE PERMANENTLY DELETED AFTER UPLOADING !!!", self.__class__.__name__)
@@ -420,7 +415,7 @@ class FileUploader(FrozenModel):
         files = FileSet(item[0] for item in to_upload)
 
         log.info("|%s| Files to be uploaded:", self.__class__.__name__)
-        log_with_indent("%s", str(files))
+        log_lines(str(files))
         log_with_indent("")
         log.info("|%s| Starting the upload process", self.__class__.__name__)
 
@@ -491,5 +486,5 @@ class FileUploader(FrozenModel):
     def _log_result(self, result: UploadResult) -> None:
         log.info("")
         log.info("|%s| Upload result:", self.__class__.__name__)
-        log_with_indent("%s", str(result))
+        log_lines(str(result))
         entity_boundary_log(msg=f"{self.__class__.__name__} ends", char="-")

--- a/onetl/log.py
+++ b/onetl/log.py
@@ -12,11 +12,20 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from __future__ import annotations
+
+import io
+import json
 import logging
+from contextlib import redirect_stdout
+from enum import Enum
 from textwrap import dedent
-from typing import Collection
+from typing import TYPE_CHECKING, Any, Iterable
 
 from deprecated import deprecated
+
+if TYPE_CHECKING:
+    from pyspark.sql import DataFrame
 
 log = logging.getLogger(__name__)
 onetl_log = logging.getLogger("onetl")
@@ -143,19 +152,210 @@ def set_default_logging_format() -> None:
 
 
 def log_with_indent(inp: str, *args, indent: int = 0, level: int = logging.INFO, **kwargs) -> None:
-    for line in dedent(inp).splitlines():
-        log.log(level, "%s" + line, " " * (BASE_LOG_INDENT + indent), *args, **kwargs)
+    """Log a message with indentation.
+
+    Supports all positional and keyword arguments which ``logging.log`` support.
+
+    Example
+    -------
+
+    .. code:: python
+
+        log_with_indent("message")
+        log_with_indent("message with additional %s", "indent", indent=4, level=logging.DEBUG)
+
+    .. code-block:: text
+
+        INFO  onetl.module        message
+        DEBUG onetl.module            message with additional indent
+
+    """
+    log.log(level, "%s" + inp, " " * (BASE_LOG_INDENT + indent), *args, **kwargs)
 
 
-def log_collection(name: str, items: Collection, indent: int = 0, level: int = logging.INFO):
+def log_lines(inp: str, name: str | None = None, indent: int = 0, level: int = logging.INFO):
+    r"""Log input multiline string with indentation.
+
+    Any input indentation is being stripped.
+
+    Does NOT support variable substitution.
+
+    Examples
+    --------
+
+    .. code:: python
+
+        log_lines("line1\nline2")
+        log_lines("  line1\n      line2\n  line3", level=logging.DEBUG)
+
+    .. code-block:: text
+
+        INFO  onetl.module        line1
+        INFO  onetl.module        line2
+
+        DEBUG onetl.module        line1
+        DEBUG onetl.module            line2
+        DEBUG onetl.module        line3
+
+    """
+
+    base_indent = " " * (BASE_LOG_INDENT + indent)
+    for index, line in enumerate(dedent(inp).splitlines()):
+        if name and not index:
+            log.log(level, "%s%s = %s", base_indent, name, line)
+        else:
+            log.log(level, "%s%s", base_indent, line)
+
+
+def log_json(inp: Any, name: str | None = None, indent: int = 0, level: int = logging.INFO):
+    """Log input object in JSON notation.
+
+    Does NOT support variable substitution.
+
+    Examples
+    --------
+
+    .. code:: python
+
+        log_json(["item1", {"item2": "value2"}, None])
+
+        log_json({"item2": "value2"}, name="myvar", level=logging.DEBUG)
+
+    .. code-block:: text
+
+        INFO  onetl.module        [
+        INFO  onetl.module            "item1",
+        INFO  onetl.module            {"item2": "value2"},
+        INFO  onetl.module            null
+        INFO  onetl.module        ]
+
+        DEBUG onetl.module        myvar = {
+        DEBUG onetl.module            "item2": "value2"
+        DEBUG onetl.module        }
+
+    """
+
+    log_lines(json.dumps(inp, indent=4), name, indent, level)
+
+
+def log_collection(name: str, collection: Iterable, indent: int = 0, level: int = logging.INFO):
+    """Log input collection.
+
+    Does NOT support variable substitution.
+
+    Examples
+    --------
+
+    .. code:: python
+
+        log_collection("myvar", ["item1", {"item2": "value2"}, None])
+
+        log_collection("myvar", ["item1", "item2"], level=logging.DEBUG)
+
+    .. code-block:: text
+
+        INFO  onetl.module        myvar = [
+        INFO  onetl.module            'item1',
+        INFO  onetl.module            {'item2': 'value2'},
+        INFO  onetl.module            None,
+        INFO  onetl.module        ]
+
+        DEBUG onetl.module        myvar = [
+        DEBUG onetl.module            'item1',
+        DEBUG onetl.module            'item2',
+        DEBUG onetl.module        ]
+
+    """
+
     base_indent = " " * (BASE_LOG_INDENT + indent)
     nested_indent = " " * (BASE_LOG_INDENT + indent + 4)
     log.log(level, "%s%s = [", base_indent, name)
-    for item in items:
-        log.log(level, "%s%r", nested_indent, item)
+    for item in collection:
+        log.log(level, "%s%r,", nested_indent, item)
     log.log(level, "%s]", base_indent)
 
 
 def entity_boundary_log(msg: str, char: str = "=") -> None:
+    """Prints message with boundary characters.
+
+    Examples
+    --------
+
+    .. code:: python
+
+        entity_boundary_log("Begin")
+        entity_boundary_log("End", "-")
+
+    .. code-block:: text
+
+        =================== Begin ====================
+        ------------------- End ----------------------
+
+    """
     filing = char * (HALF_SCREEN_SIZE - len(msg) // 2)
     log.info("%s %s %s", filing, msg, filing)
+
+
+def log_options(options: dict | None, indent: int = 0):
+    """Log options dict in following format:
+
+    Examples
+    --------
+
+    .. code:: python
+
+        log_options(Options(some="value", abc=1, bcd=None, cde=True, feg=SomeEnum.VALUE))
+        log_options(None)
+
+    .. code-block:: text
+
+        INFO  onetl.module        options = {
+        INFO  onetl.module            'some': 'value',
+        INFO  onetl.module            'abc': 1,
+        INFO  onetl.module            'bcd': None,
+        INFO  onetl.module            'cde': True,
+        INFO  onetl.module            'feg': SomeEnum.VALUE,
+        INFO  onetl.module        }
+
+        INFO  onetl.module        options = None
+
+    """
+
+    if options:
+        log_with_indent("options = {", indent=indent)
+        for option, value in options.items():
+            value_wrapped = f"'{value}'" if isinstance(value, Enum) else repr(value)
+            log_with_indent("%r: %s,", option, value_wrapped, indent=indent + 4)
+        log_with_indent("}")
+    else:
+        log_with_indent("options = %r", None)
+
+
+def log_dataframe_schema(df: DataFrame):
+    """Log dataframe schema in the following format:
+
+    Examples
+    --------
+
+    .. code:: python
+
+        log_dataframe_schema(df)
+
+    .. code-block:: text
+
+        root
+        |-- age: integer (nullable = true)
+        |-- name: string (nullable = true)
+
+    """
+
+    log_with_indent("df_schema:")
+
+    schema_tree = io.StringIO()
+    with redirect_stdout(schema_tree):
+        # unfortunately, printSchema immediately prints tree instead of returning it
+        # so we need a hack
+        df.printSchema()
+
+    for line in schema_tree.getvalue().splitlines():
+        log_with_indent("%s", line, indent=4)


### PR DESCRIPTION
1. Implemented new logging functions (internal use only):

* `log_lines` - prints already formatter multiline string to logs. Replaces `log_with_indent("%s", ...)`
* `log_options` - prints options dict content in the following syntax:

```python
options = {
  'some': 'value',
  'another': 123,
}
```

Replaces ad-hoc implementations in several classes.

Note: previous logging format was:
```
options:
  some = 'value'
  another = 123
```

But this is not a valid Python expression, so copying this value from logs required manual changes before it can be used in code.

* `log_json` - prints to logs any value which can be converted to JSON, with proper indentation. Used mostly for printing MongoDB pipeline values.

For example, previously DBReader logs were formatted as follows:
```python
table = 'some.table'
where = 'hwm_int = 100 AND business_dt < cast('2021-01-01' as date')
hint = 'index(some.table hwm_int_idx)'
```

But MongoDB it was quite ugly:
```python
table = 'some.table'
where = frozendict({"hwm_int": {"$eq": 1}})
hint =  frozendict({"hwm_int": 1})
```

Now it is:
```python
table = 'some.table'
where = {
    "hwm_int": {"$eq": 1}
}
hint =  {"hwm_int": 1}
```

* `log_dataframe_schema` - was implemented before as `DBWriter._log_dataframe_schema`, moved to a separated function so it can be used elsewhere.

2. Updated existing classes to use new functions instead old ones.
3. Added logging to `MongoDB.pipeline` to match the output with `JDBCConnection.sql` and similar methods.