### PR TITLE
[DOP-4780] Update JDBC drivers to latest

### DIFF
--- a/onetl/connection/db_connection/mongodb.py
+++ b/onetl/connection/db_connection/mongodb.py
@@ -165,7 +165,7 @@ class MongoDB(DBConnection):
 
     .. dropdown:: Version compatibility
 
-        * MongoDB server versions: 2.6 - 4.2
+        * MongoDB server versions: 4.0 or higher
         * Spark versions: 3.2.x - 3.4.x
         * Java versions: 8 - 17
 

--- a/onetl/connection/db_connection/mssql.py
+++ b/onetl/connection/db_connection/mssql.py
@@ -25,17 +25,18 @@ from onetl.connection.db_connection.jdbc_connection import JDBCConnection
 class MSSQL(JDBCConnection):
     """MSSQL JDBC connection.
 
-    Based on Maven package ``com.microsoft.sqlserver:mssql-jdbc:10.2.1.jre8``
+    Based on Maven package ``com.microsoft.sqlserver:mssql-jdbc:12.2.0.jre8``
     (`official MSSQL JDBC driver
     <https://docs.microsoft.com/en-us/sql/connect/jdbc/download-microsoft-jdbc-driver-for-sql-server>`_).
 
     .. dropdown:: Version compatibility
 
-        * SQL Server versions: 2012 or higher
+        * SQL Server versions: 2014 - 2022
         * Spark versions: 2.3.x - 3.4.x
         * Java versions: 8 - 17
 
-        See `official documentation <https://learn.microsoft.com/en-us/sql/connect/jdbc/system-requirements-for-the-jdbc-driver>`_.
+        See `official documentation <https://learn.microsoft.com/en-us/sql/connect/jdbc/system-requirements-for-the-jdbc-driver>`_
+        and `official compatibility matrix <https://learn.microsoft.com/en-us/sql/connect/jdbc/microsoft-jdbc-driver-for-sql-server-support-matrix>`_.
 
     .. warning::
 
@@ -177,7 +178,7 @@ class MSSQL(JDBCConnection):
     extra: Extra = Extra()
 
     driver: ClassVar[str] = "com.microsoft.sqlserver.jdbc.SQLServerDriver"
-    package: ClassVar[str] = "com.microsoft.sqlserver:mssql-jdbc:10.2.1.jre8"
+    package: ClassVar[str] = "com.microsoft.sqlserver:mssql-jdbc:12.2.0.jre8"
     _check_query: ClassVar[str] = "SELECT 1 AS field"
 
     class Dialect(JDBCConnection.Dialect):

--- a/onetl/connection/db_connection/mysql.py
+++ b/onetl/connection/db_connection/mysql.py
@@ -25,12 +25,12 @@ from onetl.connection.db_connection.jdbc_connection import JDBCConnection
 class MySQL(JDBCConnection):
     """MySQL JDBC connection.
 
-    Based on Maven package ``mysql:mysql-connector-java:8.0.30``
+    Based on Maven package ``com.mysql:mysql-connector-j:8.0.33``
     (`official MySQL JDBC driver <https://dev.mysql.com/downloads/connector/j/8.0.html>`_).
 
     .. dropdown:: Version compatibility
 
-        * MySQL server versions: 5.6 or higher
+        * MySQL server versions: 5.7, 8.0
         * Spark versions: 2.3.x - 3.4.x
         * Java versions: 8 - 17
 
@@ -119,8 +119,8 @@ class MySQL(JDBCConnection):
     database: Optional[str] = None
     extra: Extra = Extra()
 
-    driver: ClassVar[str] = "com.mysql.jdbc.Driver"
-    package: ClassVar[str] = "mysql:mysql-connector-java:8.0.30"
+    driver: ClassVar[str] = "com.mysql.cj.jdbc.Driver"
+    package: ClassVar[str] = "com.mysql:mysql-connector-j:8.0.33"
 
     @property
     def jdbc_url(self):

--- a/onetl/connection/db_connection/oracle.py
+++ b/onetl/connection/db_connection/oracle.py
@@ -64,12 +64,12 @@ class ErrorPosition:
 class Oracle(JDBCConnection):
     """Oracle JDBC connection.
 
-    Based on Maven package ``com.oracle.database.jdbc:ojdbc8:21.6.0.0.1``
+    Based on Maven package ``com.oracle.database.jdbc:ojdbc8:23.2.0.0``
     (`official Oracle JDBC driver <https://www.oracle.com/cis/database/technologies/appdev/jdbc-downloads.html>`_).
 
     .. dropdown:: Version compatibility
 
-        * Oracle Server versions: 21c, 19c, 18c, and 12.2
+        * Oracle Server versions: 23c, 21c, 19c, 18c, and 12.2
         * Spark versions: 2.3.x - 3.4.x
         * Java versions: 8 - 17
 
@@ -167,7 +167,7 @@ class Oracle(JDBCConnection):
     service_name: Optional[str] = None
 
     driver: ClassVar[str] = "oracle.jdbc.driver.OracleDriver"
-    package: ClassVar[str] = "com.oracle.database.jdbc:ojdbc8:21.6.0.0.1"
+    package: ClassVar[str] = "com.oracle.database.jdbc:ojdbc8:23.2.0.0"
 
     _check_query: ClassVar[str] = "SELECT 1 FROM dual"
 

--- a/onetl/connection/db_connection/postgres.py
+++ b/onetl/connection/db_connection/postgres.py
@@ -36,7 +36,7 @@ from onetl.connection.db_connection.jdbc_connection import JDBCConnection
 class Postgres(JDBCConnection):
     """PostgreSQL JDBC connection.
 
-    Based on Maven package ``org.postgresql:postgresql:42.4.0``
+    Based on Maven package ``org.postgresql:postgresql:42.6.0``
     (`official Postgres JDBC driver <https://jdbc.postgresql.org/>`_).
 
     .. dropdown:: Version compatibility
@@ -126,7 +126,7 @@ class Postgres(JDBCConnection):
     port: int = 5432
 
     driver: ClassVar[str] = "org.postgresql.Driver"
-    package: ClassVar[str] = "org.postgresql:postgresql:42.4.0"
+    package: ClassVar[str] = "org.postgresql:postgresql:42.6.0"
 
     class Dialect(  # noqa: WPS215
         SupportTableWithDBSchema,

--- a/tests/tests_unit/tests_db_connection_unit/test_mssql_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_mssql_unit.py
@@ -7,7 +7,7 @@ pytestmark = pytest.mark.mssql
 
 def test_mssql_class_attributes():
     assert MSSQL.driver == "com.microsoft.sqlserver.jdbc.SQLServerDriver"
-    assert MSSQL.package == "com.microsoft.sqlserver:mssql-jdbc:10.2.1.jre8"
+    assert MSSQL.package == "com.microsoft.sqlserver:mssql-jdbc:12.2.0.jre8"
 
 
 def test_mssql(spark_mock):

--- a/tests/tests_unit/tests_db_connection_unit/test_mysql_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_mysql_unit.py
@@ -6,8 +6,8 @@ pytestmark = pytest.mark.mysql
 
 
 def test_mysql_class_attributes():
-    assert MySQL.driver == "com.mysql.jdbc.Driver"
-    assert MySQL.package == "mysql:mysql-connector-java:8.0.30"
+    assert MySQL.driver == "com.mysql.cj.jdbc.Driver"
+    assert MySQL.package == "com.mysql:mysql-connector-j:8.0.33"
 
 
 def test_mysql(spark_mock):

--- a/tests/tests_unit/tests_db_connection_unit/test_oracle_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_oracle_unit.py
@@ -7,7 +7,7 @@ pytestmark = pytest.mark.oracle
 
 def test_oracle_class_attributes():
     assert Oracle.driver == "oracle.jdbc.driver.OracleDriver"
-    assert Oracle.package == "com.oracle.database.jdbc:ojdbc8:21.6.0.0.1"
+    assert Oracle.package == "com.oracle.database.jdbc:ojdbc8:23.2.0.0"
 
 
 def test_oracle(spark_mock):

--- a/tests/tests_unit/tests_db_connection_unit/test_postgres_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_postgres_unit.py
@@ -7,7 +7,7 @@ pytestmark = pytest.mark.postgres
 
 def test_postgres_class_attributes():
     assert Postgres.driver == "org.postgresql.Driver"
-    assert Postgres.package == "org.postgresql:postgresql:42.4.0"
+    assert Postgres.package == "org.postgresql:postgresql:42.6.0"
 
 
 def test_postgres(spark_mock):


### PR DESCRIPTION
* MSSQL `10.2.1.jre8` -> `12.2.0.jre8` (breaking)
* MySQL `8.0.30` -> `8.0.33`. Also package was renamed to `com.mysql:mysql-connector-j`
* Oracle `21.6.0.0.1` -> `23.2.0.0`
* Postgres `42.4.0` -> `42.6.0`