### PR TITLE
[DOP-5431] Add docstrings to FileConnection methods

### DIFF
--- a/docs/file_connection/ftp.rst
+++ b/docs/file_connection/ftp.rst
@@ -6,4 +6,4 @@ FTP connection
 .. currentmodule:: onetl.connection.file_connection.ftp
 
 .. autoclass:: FTP
-    :members: __init__, check
+    :members: __init__, check, path_exists, is_file, is_dir, get_stat, resolve_dir, resolve_file, create_dir, remove_file, remove_dir, rename_file, list_dir, walk, download_file, upload_file

--- a/docs/file_connection/ftps.rst
+++ b/docs/file_connection/ftps.rst
@@ -6,4 +6,4 @@ FTPS connection
 .. currentmodule:: onetl.connection.file_connection.ftps
 
 .. autoclass:: FTPS
-    :members: __init__, check
+    :members: __init__, check, path_exists, is_file, is_dir, get_stat, resolve_dir, resolve_file, create_dir, remove_file, remove_dir, rename_file, list_dir, walk, download_file, upload_file

--- a/docs/file_connection/hdfs.rst
+++ b/docs/file_connection/hdfs.rst
@@ -11,7 +11,7 @@ HDFS connection
     HDFS.slots
 
 .. autoclass:: HDFS
-    :members: __init__, check
+    :members: __init__, check, path_exists, is_file, is_dir, get_stat, resolve_dir, resolve_file, create_dir, remove_file, remove_dir, rename_file, list_dir, walk, download_file, upload_file
 
 .. currentmodule:: onetl.connection.file_connection.hdfs.HDFS
 

--- a/docs/file_connection/s3.rst
+++ b/docs/file_connection/s3.rst
@@ -6,4 +6,4 @@ S3 connection
 .. currentmodule:: onetl.connection.file_connection.s3
 
 .. autoclass:: S3
-    :members: __init__, check
+    :members: __init__, check, path_exists, is_file, is_dir, get_stat, resolve_dir, resolve_file, create_dir, remove_file, remove_dir, rename_file, list_dir, walk, download_file, upload_file

--- a/docs/file_connection/sftp.rst
+++ b/docs/file_connection/sftp.rst
@@ -6,4 +6,4 @@ SFTP connection
 .. currentmodule:: onetl.connection.file_connection.sftp
 
 .. autoclass:: SFTP
-    :members: __init__, check
+    :members: __init__, check, path_exists, is_file, is_dir, get_stat, resolve_dir, resolve_file, create_dir, remove_file, remove_dir, rename_file, list_dir, walk, download_file, upload_file

--- a/docs/file_connection/webdav.rst
+++ b/docs/file_connection/webdav.rst
@@ -6,4 +6,4 @@ WebDAV connection
 .. currentmodule:: onetl.connection.file_connection.webdav
 
 .. autoclass:: WebDAV
-    :members: __init__, check
+    :members: __init__, check, path_exists, is_file, is_dir, get_stat, resolve_dir, resolve_file, create_dir, remove_file, remove_dir, rename_file, list_dir, walk, download_file, upload_file

--- a/onetl/base/base_connection.py
+++ b/onetl/base/base_connection.py
@@ -24,8 +24,21 @@ class BaseConnection(ABC):
     def check(self):
         """Check source availability.
 
+        If not, an exception will be raised.
+
+        Returns
+        -------
+        Connection itself
+
         Raises
         ------
         RuntimeError
             If the connection is not available
+
+        Examples
+        --------
+
+        .. code:: python
+
+            connection.check()
         """

--- a/onetl/base/base_db_connection.py
+++ b/onetl/base/base_db_connection.py
@@ -142,31 +142,6 @@ class BaseDBConnection(BaseConnection):
         """Instance URL"""
 
     @abstractmethod
-    def check(self):
-        """
-        Check if database is accessible.
-
-        If not, an exception will be raised.
-
-        Executes some simple query, like ``SELECT 1``, in the database.
-
-        Examples
-        --------
-
-        Database is online:
-
-        .. code:: python
-
-            connection.check()
-
-        Database is offline or not accessible:
-
-        .. code:: python
-
-            connection.check()  # raises RuntimeError exception
-        """
-
-    @abstractmethod
     # Some heirs may have a different number of parameters.
     # For example, the 'options' parameter may be present. This is fine.
     def read_df(

--- a/onetl/base/base_file_connection.py
+++ b/onetl/base/base_file_connection.py
@@ -21,7 +21,7 @@ from typing import Iterable
 from onetl.base.base_connection import BaseConnection
 from onetl.base.base_file_filter import BaseFileFilter
 from onetl.base.base_file_limit import BaseFileLimit
-from onetl.base.path_protocol import PathProtocol, PathWithStatsProtocol
+from onetl.base.path_protocol import PathWithStatsProtocol
 from onetl.base.path_stat_protocol import PathStatProtocol
 
 
@@ -31,36 +31,274 @@ class BaseFileConnection(BaseConnection):
     """
 
     @abstractmethod
-    def download_file(
-        self,
-        remote_file_path: os.PathLike | str,
-        local_file_path: os.PathLike | str,
-    ) -> PathWithStatsProtocol:
+    def path_exists(self, path: os.PathLike | str) -> bool:
         """
-        Downloads file from the remote filesystem to a local path
+        Check if specified path exists on remote filesystem.
+
+        Parameters
+        ----------
+        path : str or :obj:`os.PathLike`
+            Path to check
+
+        Returns
+        -------
+        ``True`` if path exists, ``False`` otherwise
+
+        Examples
+        --------
+
+        .. code:: python
+
+            assert connection.path_exists("/path/to/file.csv")
+            assert connection.path_exists("/path/to/dir")
+            assert not connection.path_exists("/path/to/missing")
         """
 
     @abstractmethod
-    def remove_file(self, remote_file_path: os.PathLike | str) -> None:
+    def is_file(self, path: os.PathLike | str) -> bool:
         """
-        Removes file on remote filesystem
+        Check if specified path is a file.
+
+        Parameters
+        ----------
+        path : str or :obj:`os.PathLike`
+            Path to check
+
+        Returns
+        -------
+        ``True`` if path is a file, ``False`` otherwise.
+
+        Raises
+        ------
+        FileNotFoundError
+            Path does not exist
+
+        Examples
+        --------
+
+        .. code:: python
+
+            assert connection.is_file("/path/to/dir/file.csv")
+            assert not connection.is_file("/path/to/dir")
         """
 
     @abstractmethod
-    def create_dir(self, path: os.PathLike | str) -> PathProtocol:
+    def is_dir(self, path: os.PathLike | str) -> bool:
         """
-        Creates directory tree on remote filesystem
+        Check if specified path is a directory.
+
+        Parameters
+        ----------
+        path : str or :obj:`os.PathLike`
+            Path to check
+
+        Returns
+        -------
+        ``True`` if path is a directory, ``False`` otherwise.
+
+        Raises
+        ------
+        :obj:`onetl.exception.DirectoryNotFoundError`
+            Path does not exist
+
+        Examples
+        --------
+
+        .. code:: python
+
+            assert connection.is_dir("/path/to/dir")
+            assert not connection.is_dir("/path/to/dir/file.csv")
         """
 
     @abstractmethod
-    def upload_file(
-        self,
-        local_file_path: os.PathLike | str,
-        remote_file_path: os.PathLike | str,
-        replace: bool = False,
-    ) -> PathWithStatsProtocol:
+    def get_stat(self, path: os.PathLike | str) -> PathStatProtocol:
         """
-        Uploads local file to path on remote filesystem
+        Returns stats for a specific path.
+
+        Parameters
+        ----------
+        path : str or :obj:`os.PathLike`
+            Path to get stats for
+
+        Returns
+        -------
+        Stats object
+
+        Raises
+        ------
+        Any underlying client exception
+
+        Examples
+        --------
+
+        .. code:: python
+
+            stat = connection.get_stat("/path/to/file.csv")
+            assert stat.st_size > 0
+            assert stat.st_uid == 12345  # owner id
+        """
+
+    @abstractmethod
+    def resolve_dir(self, path: os.PathLike | str) -> PathWithStatsProtocol:
+        """
+        Returns directory at specific path, with stats.
+
+        Parameters
+        ----------
+        path : str or :obj:`os.PathLike`
+            Path to resolve
+
+        Returns
+        -------
+        Directory path with stats
+
+        Raises
+        ------
+        :obj:`onetl.exception.DirectoryNotFoundError`
+            Path does not exist
+
+        NotADirectoryError
+            Path is not a directory
+
+        Examples
+        --------
+
+        .. code:: python
+
+            dir_path = connection.resolve_dir("/path/to/dir")
+            assert os.fspath(dir_path) == "/path/to/dir"
+            assert dir_path.stat.st_uid == 12345  # owner id
+        """
+
+    @abstractmethod
+    def resolve_file(self, path: os.PathLike | str) -> PathWithStatsProtocol:
+        """
+        Returns file at specific path, with stats.
+
+        Parameters
+        ----------
+        path : str or :obj:`os.PathLike`
+            Path to resolve
+
+        Returns
+        -------
+        File path with stats
+
+        Raises
+        ------
+        FileNotFoundError
+            Path does not exist
+
+        :obj:`onetl.exception.NotAFileError`
+            Path is not a file
+
+        Examples
+        --------
+
+        .. code:: python
+
+            file_path = connection.resolve_file("/path/to/dir/file.csv")
+            assert os.fspath(file_path) == "/path/to/dir/file.csv"
+            assert file_path.stat.st_uid == 12345  # owner id
+        """
+
+    @abstractmethod
+    def create_dir(self, path: os.PathLike | str) -> PathWithStatsProtocol:
+        """
+        Creates directory tree on remote filesystem.
+
+        Parameters
+        ----------
+        path : str or :obj:`os.PathLike`
+            Directory path
+
+        Returns
+        -------
+        Created directory with stats
+
+        Raises
+        ------
+        :obj:`onetl.exception.NotAFileError`
+            Path is not a file
+
+        Examples
+        --------
+
+        .. code:: python
+
+            dir_path = connection.create_dir("/path/to/dir")
+        """
+
+    @abstractmethod
+    def remove_file(self, path: os.PathLike | str) -> bool:
+        """
+        Removes file on remote filesystem.
+
+        If file does not exist, no exception is raised.
+
+        .. warning::
+
+            Supports only one file removal per call. Directory removal is **NOT** supported, use :obj:`~remove_dir` instead.
+
+        Parameters
+        ----------
+        path : str or :obj:`os.PathLike`
+            File path
+
+        Returns
+        -------
+        ``True`` if file was removed, ``False`` if file does not exist in the first place.
+
+        Raises
+        ------
+        :obj:`onetl.exception.NotAFileError`
+            Path is not a file
+
+        Examples
+        --------
+
+        .. code:: python
+
+            assert connection.remove_file("/path/to/file.csv")
+            assert not connection.path_exists("/path/to/dir/file.csv")
+
+            assert not connection.remove_file("/path/to/file.csv")  # already deleted
+        """
+
+    @abstractmethod
+    def remove_dir(self, path: os.PathLike | str, recursive: bool = False) -> bool:
+        """
+        Remove directory or directory tree.
+
+        If directory does not exist, no exception is raised.
+
+        Parameters
+        ----------
+        path : str or :obj:`os.PathLike`
+            Directory path to remote
+
+        recursive : bool, default ``False``
+            If ``True``, remove directory tree recursively.
+
+        Returns
+        -------
+        ``True`` if directory was removed, ``False`` if directory does not exist in the first place.
+
+        Raises
+        ------
+        NotADirectoryError
+            Path is not a directory
+
+        Examples
+        --------
+
+        .. code:: python
+
+            assert connection.remove_dir("/path/to/dir")
+            assert not connection.path_exists("/path/to/dir/file.csv")
+            assert not connection.path_exists("/path/to/dir")
+
+            assert not connection.remove_dir("/path/to/dir")  # already deleted
         """
 
     @abstractmethod
@@ -71,83 +309,319 @@ class BaseFileConnection(BaseConnection):
         replace: bool = False,
     ) -> PathWithStatsProtocol:
         """
-        Rename or move file on remote filesystem
-        """
+        Rename or move file on remote filesystem.
 
-    @abstractmethod
-    def path_exists(self, path: os.PathLike | str) -> bool:
-        """
-        Check if specified path exists on remote filesystem
+        .. warning::
+
+            Supports only one file move per call. Directory move/rename is **NOT** supported.
+
+        Parameters
+        ----------
+        source_file_path : str or :obj:`os.PathLike`
+            Old file path
+
+        target_file_path : str or :obj:`os.PathLike`
+            New file path
+
+        replace : bool, default ``False``
+            If ``True``, existing file will be replaced.
+
+        Returns
+        -------
+        New file path with stats.
+
+        Raises
+        ------
+        :obj:`onetl.exception.NotAFileError`
+            Source or target path is not a file
+
+        FileNotFoundError
+            File does not exist
+
+        FileExistsError
+            File already exists, and ``replace=False``
+
+        Examples
+        --------
+
+        .. code:: python
+
+            new_file = connection.rename_file("/path/to/file1.csv", "/path/to/file2.csv")
+            assert connection.path_exists("/path/to/file2.csv")
+            assert not connection.path_exists("/path/to/file1.csv")
         """
 
     @abstractmethod
     def list_dir(
         self,
-        directory: os.PathLike | str,
+        path: os.PathLike | str,
         filters: Iterable[BaseFileFilter] | None = None,
         limits: Iterable[BaseFileLimit] | None = None,
     ) -> list[PathWithStatsProtocol]:
         """
-        Return list of files in specific directory on remote filesystem
+        Return list of child files/directories in a specific directory.
+
+        Parameters
+        ----------
+        path : str or :obj:`os.PathLike`
+            Directory path to list contents.
+
+        filters : list of :obj:`onetl.base.BaseFileFilter`, optional
+            Return only files/directories matching these filters.
+
+        limits : list of :obj:`onetl.base.BaseFileLimit`, optional
+            Apply limits to the list of files/directories, and stop if one of the limits is reached.
+
+        Returns
+        -------
+        List of :obj:`onetl.base.PathWithStatsProtocol`
+
+        Raises
+        ------
+        NotADirectoryError
+            Path is not a directory
+
+        :obj:`onetl.exception.DirectoryNotFoundError`
+            Path does not exist
+
+        Examples
+        --------
+
+        .. code:: python
+
+            dir_content = connection.list_dir("/path/to/dir")
+            assert os.fspath(dir_content[0]) == "/path/to/dir/file.csv"
+            assert connection.path_exists("/path/to/dir/file.csv")
         """
 
     @abstractmethod
     def walk(
         self,
-        top: os.PathLike | str,
+        root: os.PathLike | str,
+        topdown: bool = True,
         filters: Iterable[BaseFileFilter] | None = None,
         limits: Iterable[BaseFileLimit] | None = None,
     ) -> Iterable[tuple[PathWithStatsProtocol, list[PathWithStatsProtocol], list[PathWithStatsProtocol]]]:
         """
-        Walk into directory tree on remote filesystem, just like ``os.walk``
+        Walk into directory tree, and iterate over its content in all nesting levels.
+
+        Just like :obj:`os.walk`, but with additional filter/limit logic.
+
+        Parameters
+        ----------
+        root : str or :obj:`os.PathLike`
+            Directory path to walk into.
+
+        topdown : bool, default ``True``
+            If ``True``, walk in top-down order, otherwise walk in bottom-up order.
+
+        filters : list of :obj:`onetl.base.BaseFileFilter`, optional
+            Return only files/directories matching these filters.
+
+        limits : list of :obj:`onetl.base.BaseFileLimit`, optional
+            Apply limits to the list of files/directories, and stop if one of the limits is reached.
+
+        Returns
+        -------
+        ``Iterator[tuple[root, dirs, files]]``, like :obj:`os.walk`.
+
+        But all the paths are not strings, instead path classes with embedded stats are returned.
+
+        Raises
+        ------
+        NotADirectoryError
+            Path is not a directory
+
+        :obj:`onetl.exception.DirectoryNotFoundError`
+            Path does not exist
+
+        Examples
+        --------
+
+        .. code:: python
+
+            for root, dirs, files in connection.walk("/path/to/dir"):
+                assert os.fspath(root) == "/path/to/dir"
+                assert dirs == []
+                assert os.fspath(files[0]) == "/path/to/dir/file.csv"
+                assert connection.path_exists("/path/to/dir/file.csv")
         """
 
     @abstractmethod
-    def remove_dir(self, path: os.PathLike | str, recursive: bool = False) -> None:
+    def download_file(
+        self,
+        remote_file_path: os.PathLike | str,
+        local_file_path: os.PathLike | str,
+        replace: bool = True,
+    ) -> PathWithStatsProtocol:
         """
-        Remove directory or directory tree on remote filesystem
+        Downloads file from the remote filesystem to a local path.
+
+        .. warning::
+
+            Supports only one file download per call. Directory download is **NOT** supported, use :ref:`file-downloader` instead.
+
+        Parameters
+        ----------
+        remote_file_path : str or :obj:`os.PathLike`
+            Remote file path to read from
+
+        local_file_path : str or :obj:`os.PathLike`
+            Local file path to create
+
+        replace : bool, default ``False``
+            If ``True``, existing file will be replaced
+
+        Returns
+        -------
+        Local file with stats.
+
+        Raises
+        ------
+        :obj:`onetl.exception.NotAFileError`
+            Remote or local path is not a file
+
+        FileNotFoundError
+            Remote file does not exist
+
+        FileExistsError
+            Local file already exists, and ``replace=False``
+
+        :obj:`onetl.exception.FileSizeMismatchError`
+            Target file size after download is different from source file size.
+
+        Examples
+        --------
+
+        .. code:: python
+
+            local_file = connection.download_file(
+                remote_file_path="/path/to/source.csv", local_file_path="/path/to/target.csv"
+            )
+            assert local_file.exists()
+            assert os.fspath(local_file) == "/path/to/target.csv"
+            assert local_file.stat().st_size == connection.get_stat("/path/to/source.csv").st_size
         """
 
     @abstractmethod
-    def is_file(self, path: os.PathLike | str) -> bool:
+    def upload_file(
+        self,
+        local_file_path: os.PathLike | str,
+        remote_file_path: os.PathLike | str,
+        replace: bool = False,
+    ) -> PathWithStatsProtocol:
         """
-        Check if specified path is a file on remote filesystem
-        """
+        Uploads local file to a remote filesystem.
 
-    @abstractmethod
-    def is_dir(self, path: os.PathLike | str) -> bool:
-        """
-        Check if specified path is a directory on remote filesystem
-        """
+        .. warning::
 
-    @abstractmethod
-    def get_stat(self, path: os.PathLike | str) -> PathStatProtocol:
-        """
-        Returns stats for a specific path on remote filesystem
-        """
+            Supports only one file upload per call. Directory upload is **NOT** supported, use :ref:`file-uploader` instead.
 
-    @abstractmethod
-    def resolve_dir(self, path: os.PathLike | str) -> PathWithStatsProtocol:
-        """
-        Returns directory with stats for a specific path on remote filesystem
-        """
+        Parameters
+        ----------
+        local_file_path : str or :obj:`os.PathLike`
+            Local file path to read from
 
-    @abstractmethod
-    def resolve_file(self, path: os.PathLike | str) -> PathWithStatsProtocol:
-        """
-        Returns file with stats for a specific path on remote filesystem
+        remote_file_path : str or :obj:`os.PathLike`
+            Remote file path to create
+
+        replace : bool, default ``False``
+            If ``True``, existing file will be replaced
+
+        Returns
+        -------
+        Remote file with stats.
+
+        Raises
+        ------
+        :obj:`onetl.exception.NotAFileError`
+            Remote or local path is not a file
+
+        FileNotFoundError
+            Local file does not exist
+
+        FileExistsError
+            Remote file already exists, and ``replace=False``
+
+        :obj:`onetl.exception.FileSizeMismatchError`
+            Target file size after upload is different from source file size.
+
+        Examples
+        --------
+
+        .. code:: python
+
+            remote_file = connection.upload(
+                local_file_path="/path/to/source.csv",
+                remote_file_path="/path/to/target.csv",
+            )
+            assert connection.path_exists("/path/to/target.csv")
+            assert remote_file.stat().st_size == os.stat("/path/to/source.csv").st_size
         """
 
     @abstractmethod
     def read_text(self, path: os.PathLike | str, encoding: str = "utf-8") -> str:
-        """
-        Returns string content of a file at specific path on remote filesystem
+        r"""
+        Returns string content of a file at specific path.
+
+        Parameters
+        ----------
+        path : str or :obj:`os.PathLike`
+            File path to read
+
+        encoding : str, default ``utf-8``
+            File content encoding
+
+        Returns
+        -------
+        File content
+
+        Raises
+        ------
+        FileNotFoundError
+            Path does not exist
+
+        :obj:`onetl.exception.NotAFileError`
+            Path is not a file
+
+        Examples
+        --------
+
+        .. code:: python
+
+            content = connection.read_text("/path/to/dir/file.csv")
+            assert content == "some;header\n1;2"
         """
 
     @abstractmethod
     def read_bytes(self, path: os.PathLike | str) -> bytes:
         """
-        Returns binary content of a file at specific path on remote filesystem
+        Returns binary content of a file at specific path.
+
+        Parameters
+        ----------
+        path : str or :obj:`os.PathLike`
+            File path to read
+
+        Returns
+        -------
+        File content
+
+        Raises
+        ------
+        FileNotFoundError
+            Path does not exist
+
+        :obj:`onetl.exception.NotAFileError`
+            Path is not a file
+
+        Examples
+        --------
+
+        .. code:: python
+
+            content = connection.read_bytes("/path/to/dir/file.csv")
+            assert content == b"0xdeadbeef"
         """
 
     @abstractmethod
@@ -157,14 +631,81 @@ class BaseFileConnection(BaseConnection):
         content: str,
         encoding: str = "utf-8",
     ) -> PathWithStatsProtocol:
-        """
-        Writes string to a specific path on remote filesystem
+        r"""
+        Writes string content to a file at specific path.
+
+        .. warning::
+
+            If file already exists, its content will be replaced.
+
+        Parameters
+        ----------
+        path : str or :obj:`os.PathLike`
+            File path to write
+
+        content : str
+            File content
+
+        encoding : str, default ``utf-8``
+            File content encoding
+
+        Returns
+        -------
+        File path with stats after write
+
+        Raises
+        ------
+        TypeError
+            Content is not a string
+
+        :obj:`onetl.exception.NotAFileError`
+            Path is not a file
+
+        Examples
+        --------
+
+        .. code:: python
+
+            file_path = connection.write_text("/path/to/dir/file.csv", "some;header\n1;2")
+            assert file_path.stat.st_size > 0
         """
 
     @abstractmethod
     def write_bytes(self, path: os.PathLike | str, content: bytes) -> PathWithStatsProtocol:
         """
-        Writes bytes to a specific path on remote filesystem
+        Writes bytes content to a file at specific path.
+
+        .. warning::
+
+            If file already exists, its content will be replaced.
+
+        Parameters
+        ----------
+        path : str or :obj:`os.PathLike`
+            File path to write
+
+        content : bytes
+            File content
+
+        Returns
+        -------
+        File path with stats after write
+
+        Raises
+        ------
+        TypeError
+            Content is not a string
+
+        :obj:`onetl.exception.NotAFileError`
+            Path is not a file
+
+        Examples
+        --------
+
+        .. code:: python
+
+            file_path = connection.write_bytes("/path/to/dir/file.csv", b"0xdeadbeef")
+            assert file_path.stat.st_size > 0
         """
 
     @property

--- a/onetl/exception.py
+++ b/onetl/exception.py
@@ -46,6 +46,12 @@ class NotAFileError(OSError):
     """
 
 
+class FileSizeMismatchError(OSError):
+    """
+    File size mismatch
+    """
+
+
 class DirectoryNotEmptyError(OSError):
     """
     Raised when trying to remove directory contains some files or other directories


### PR DESCRIPTION
* Added documentation for all public methods of `BaseFileConnection` (except `read*` and `write*`). See https://onetl--39.org.readthedocs.build/en/39/file_connection/ftp.html
* Updated documentation of `BaseConnection.check()`
* Replaced `RuntimeError` in `download_file`/`upload_file` with new `FileSizeMismatchError`
* Updated `remove_file`/`remove_dir` to return boolean which indicates whether file/dir were present before method call or not.
* Moved `resolve_dir(...)` at the top of `list_dir`/`walk` to raise exception if path is missing or wrong type as soon as possible.