### PR TITLE
[DOP-5429] Add rename_dir method

### DIFF
--- a/onetl/base/supports_rename_dir.py
+++ b/onetl/base/supports_rename_dir.py
@@ -12,12 +12,25 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from onetl.base.base_connection import BaseConnection
-from onetl.base.base_db_connection import BaseDBConnection
-from onetl.base.base_file_connection import BaseFileConnection
-from onetl.base.base_file_filter import BaseFileFilter
-from onetl.base.base_file_limit import BaseFileLimit
-from onetl.base.contains_exception import ContainsException
-from onetl.base.path_protocol import PathProtocol, PathWithStatsProtocol
-from onetl.base.path_stat_protocol import PathStatProtocol
-from onetl.base.supports_rename_dir import SupportsRenameDir
+from __future__ import annotations
+
+import os
+
+from typing_extensions import Protocol, runtime_checkable
+
+from onetl.base.path_protocol import PathWithStatsProtocol
+
+
+@runtime_checkable
+class SupportsRenameDir(Protocol):
+    """
+    Protocol for objects containing ``rename_dir`` method
+    """
+
+    def rename_dir(
+        self,
+        source_dir_path: str | os.PathLike,
+        target_dir_path: str | os.PathLike,
+        replace: bool = False,
+    ) -> PathWithStatsProtocol:
+        ...

--- a/onetl/connection/file_connection/ftp.py
+++ b/onetl/connection/file_connection/ftp.py
@@ -20,6 +20,15 @@ import textwrap
 from logging import getLogger
 from typing import Optional
 
+from etl_entities.instance import Host
+from pydantic import SecretStr
+
+from onetl.base import PathStatProtocol
+from onetl.connection.file_connection.file_connection import FileConnection
+from onetl.connection.file_connection.mixins.rename_dir_mixin import RenameDirMixin
+from onetl.impl import LocalPath, RemotePath
+from onetl.impl.remote_path_stat import RemotePathStat
+
 try:
     from ftputil import FTPHost
     from ftputil import session as ftp_session
@@ -38,18 +47,10 @@ except (ImportError, NameError) as e:
         ).strip(),
     ) from e
 
-from etl_entities.instance import Host
-from pydantic import SecretStr
-
-from onetl.base import PathStatProtocol
-from onetl.connection.file_connection.file_connection import FileConnection
-from onetl.impl import LocalPath, RemotePath
-from onetl.impl.remote_path_stat import RemotePathStat
-
 log = getLogger(__name__)
 
 
-class FTP(FileConnection):
+class FTP(FileConnection, RenameDirMixin):
     """FTP file connection.
 
     Based on `FTPUtil library <https://pypi.org/project/ftputil/>`_.
@@ -146,6 +147,8 @@ class FTP(FileConnection):
 
     def _rename_file(self, source: RemotePath, target: RemotePath) -> None:
         self.client.rename(os.fspath(source), os.fspath(target))
+
+    _rename_dir = _rename_file
 
     def _download_file(self, remote_file_path: RemotePath, local_file_path: LocalPath) -> None:
         self.client.download(os.fspath(remote_file_path), os.fspath(local_file_path))

--- a/onetl/connection/file_connection/mixins/__init__.py
+++ b/onetl/connection/file_connection/mixins/__init__.py
@@ -1,0 +1,1 @@
+from onetl.connection.file_connection.mixins.rename_dir_mixin import RenameDirMixin

--- a/onetl/connection/file_connection/mixins/rename_dir_mixin.py
+++ b/onetl/connection/file_connection/mixins/rename_dir_mixin.py
@@ -1,0 +1,95 @@
+#  Copyright 2023 MTS (Mobile Telesystems)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from __future__ import annotations
+
+import os
+from abc import abstractmethod
+from logging import getLogger
+
+from onetl.base import BaseFileConnection
+from onetl.exception import DirectoryExistsError
+from onetl.impl import RemoteDirectory, RemotePath, path_repr
+
+log = getLogger(__name__)
+
+
+class RenameDirMixin(BaseFileConnection):
+    def rename_dir(
+        self,
+        source_dir_path: os.PathLike | str,
+        target_dir_path: os.PathLike | str,
+        replace: bool = False,
+    ) -> RemoteDirectory:
+        """
+        Rename or move dir on remote filesystem.
+
+        Parameters
+        ----------
+        source_dir_path : str or :obj:`os.PathLike`
+            Old directory path
+
+        target_dir_path : str or :obj:`os.PathLike`
+            New directory path
+
+        replace : bool, default ``False``
+            If ``True``, existing directory will be replaced.
+
+        Returns
+        -------
+        New directory path with stats.
+
+        Raises
+        ------
+        NotADirectoryError
+            Path is not a directory
+
+        :obj:`onetl.exception.DirectoryNotFoundError`
+            Path does not exist
+
+        :obj:`onetl.exception.DirectoryExistsError`
+            Directory already exists, and ``replace=False``
+
+        Examples
+        --------
+
+        .. code:: python
+
+            new_file = connection.rename_dir("/path/to/dir1", "/path/to/dir2")
+            assert connection.path_exists("/path/to/dir1")
+            assert not connection.path_exists("/path/to/dir2")
+        """
+
+        log.debug("|%s| Renaming directory '%s' to '%s'", self.__class__.__name__, source_dir_path, target_dir_path)
+
+        source_dir = self.resolve_dir(source_dir_path)
+        target_dir = RemotePath(target_dir_path)
+
+        if self.path_exists(target_dir):
+            directory = self.resolve_dir(target_dir)
+            if not replace:
+                raise DirectoryExistsError(f"Directory {path_repr(directory)} already exists")
+
+            log.warning("|%s| Directory %s already exists, removing", self.__class__.__name__, path_repr(directory))
+            self.remove_dir(target_dir, recursive=True)
+
+        self.create_dir(target_dir.parent)
+        self._rename_dir(source_dir, target_dir)
+        log.info("|%s| Successfully renamed file '%s' to '%s'", self.__class__.__name__, source_dir, target_dir)
+
+        return self.resolve_dir(target_dir)
+
+    @abstractmethod
+    def _rename_dir(self, source: RemotePath, target: RemotePath) -> None:
+        ...

--- a/onetl/connection/file_connection/webdav.py
+++ b/onetl/connection/file_connection/webdav.py
@@ -23,6 +23,14 @@ from logging import getLogger
 from ssl import SSLContext
 from typing import Any, Optional, Union
 
+from etl_entities.instance import Host
+from pydantic import DirectoryPath, FilePath, SecretStr, root_validator
+from typing_extensions import Literal
+
+from onetl.connection.file_connection.file_connection import FileConnection
+from onetl.connection.file_connection.mixins.rename_dir_mixin import RenameDirMixin
+from onetl.impl import LocalPath, RemotePath, RemotePathStat
+
 try:
     from webdav3.client import Client
 except (ImportError, NameError) as e:
@@ -40,18 +48,11 @@ except (ImportError, NameError) as e:
         ).strip(),
     ) from e
 
-from etl_entities.instance import Host
-from pydantic import DirectoryPath, FilePath, SecretStr, root_validator
-from typing_extensions import Literal
-
-from onetl.connection.file_connection.file_connection import FileConnection
-from onetl.impl import LocalPath, RemotePath, RemotePathStat
-
 log = getLogger(__name__)
 DATA_MODIFIED_FORMAT = "%a, %d %b %Y %H:%M:%S GMT"
 
 
-class WebDAV(FileConnection):
+class WebDAV(FileConnection, RenameDirMixin):
     """WebDAV file connection.
 
     Based on `WebdavClient3 library <https://pypi.org/project/webdavclient3/>`_.
@@ -191,6 +192,8 @@ class WebDAV(FileConnection):
     def _rename_file(self, source: RemotePath, target: RemotePath) -> None:
         res = self.client.resource(os.fspath(source))
         res.move(os.fspath(target))
+
+    _rename_dir = _rename_file
 
     def _scan_entries(self, path: RemotePath) -> list[dict]:
         return self.client.list(os.fspath(path), get_info=True)

--- a/onetl/exception.py
+++ b/onetl/exception.py
@@ -46,6 +46,12 @@ class NotAFileError(OSError):
     """
 
 
+class DirectoryExistsError(OSError):
+    """
+    Like ``FileExistsError``, but for directories.
+    """
+
+
 class DirectoryNotEmptyError(OSError):
     """
     Raised when trying to remove directory contains some files or other directories


### PR DESCRIPTION
* Added mixin `RenameDirMixin`. It contains `rename_dir` method implementation and `_rename_dir` abstract method which should be implemented by inherited class (usually just the same as `_rename_file`).
* Added corresponding protocol `SupportRenameDir`
* Added new exception type `DirectoryAlreadyExists` which is raised if someone tries to use some existing directory name as target name and if `replace=False`
* Added this mixin to FTP, FTPS, HDFS and SFTP. S3 does not have directories and corresponding method in client. That's why this method not in the `BaseFileConnection` interface
* Added test for new method with all parameter combinations