### PR TITLE
[DOP-5632] Split FileLimit to separate limits

### DIFF
--- a/docs/file_filter/regexp.rst
+++ b/docs/file_filter/regexp.rst
@@ -1,7 +1,7 @@
 .. _regexp-filter:
 
 Regexp
-=====
+======
 
 .. currentmodule:: onetl.file.filter.regexp
 

--- a/docs/file_limit/base.rst
+++ b/docs/file_limit/base.rst
@@ -1,0 +1,16 @@
+.. _base-limit:
+
+Base interface
+==============
+
+.. currentmodule:: onetl.base.base_file_limit
+
+.. autosummary::
+
+    BaseFileLimit
+    BaseFileLimit.reset
+    BaseFileLimit.stops_at
+    BaseFileLimit.is_reached
+
+.. autoclass:: BaseFileLimit
+    :members: reset, stops_at, is_reached

--- a/docs/file_limit/index.rst
+++ b/docs/file_limit/index.rst
@@ -1,0 +1,19 @@
+.. _limit-root:
+
+File Limits
+===========
+
+.. toctree::
+    :maxdepth: 1
+    :caption: File limits
+
+    max_files_count
+
+.. toctree::
+    :maxdepth: 1
+    :caption: For developers
+
+    base
+    limits_stop_at
+    limits_reached
+    reset_limits

--- a/docs/file_limit/limits_reached.rst
+++ b/docs/file_limit/limits_reached.rst
@@ -1,0 +1,8 @@
+.. _limits-reached:
+
+limits_reached
+==============
+
+.. currentmodule:: onetl.file.limit.limits_reached
+
+.. autofunction:: limits_reached

--- a/docs/file_limit/limits_stop_at.rst
+++ b/docs/file_limit/limits_stop_at.rst
@@ -1,0 +1,8 @@
+.. _limits-stop-at:
+
+limits_stop_at
+==============
+
+.. currentmodule:: onetl.file.limit.limits_stop_at
+
+.. autofunction:: limits_stop_at

--- a/docs/file_limit/max_files_count.rst
+++ b/docs/file_limit/max_files_count.rst
@@ -1,0 +1,9 @@
+.. _max-files-count:
+
+MaxFilesCount
+=============
+
+.. currentmodule:: onetl.file.limit.max_files_count
+
+.. autoclass:: MaxFilesCount
+    :members: reset, stops_at, is_reached

--- a/docs/file_limit/reset_limits.rst
+++ b/docs/file_limit/reset_limits.rst
@@ -1,0 +1,8 @@
+.. _reset-limits:
+
+reset_limits
+============
+
+.. currentmodule:: onetl.file.limit.reset_limits
+
+.. autofunction:: reset_limits

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,6 +41,7 @@
     :hidden:
 
     file_filter/index
+    file_limit/index
 
 .. toctree::
     :maxdepth: 2

--- a/onetl/base/base_file_filter.py
+++ b/onetl/base/base_file_filter.py
@@ -21,11 +21,27 @@ from onetl.base.path_protocol import PathProtocol
 
 class BaseFileFilter(ABC):
     """
-    Base file filter interface
+    Base file filter interface.
+
+    Filters used by several onETL components, including :ref:`file-downloader` and :ref:`file-mover`,
+    to determine if a file should be handled or not.
+
+    All filters are stateless.
     """
 
     @abstractmethod
     def match(self, path: PathProtocol) -> bool:
         """
         Returns ``True`` if path is matching the filter, ``False`` otherwise
+
+        Examples
+        --------
+
+        .. code:: python
+
+            from onetl.impl import LocalPath
+
+            assert filter.match(LocalPath("/path/to/file.csv"))
+            assert not filter.match(LocalPath("/path/to/excluded.csv"))
+            assert filter.match(LocalPath("/path/to/file.csv"))
         """

--- a/onetl/base/base_file_limit.py
+++ b/onetl/base/base_file_limit.py
@@ -16,29 +16,99 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
+from typing_extensions import Self
+
 from onetl.base.path_protocol import PathProtocol
 
 
 class BaseFileLimit(ABC):
     """
-    Base file limit class
+    Base file limit interface.
+
+    Limits used by several onETL components, including :ref:`file-downloader` and :ref:`file-mover`,
+    to determine if internal loop should be stopped.
+
+    Unlike file filters, limits have internal state which can be updated or reset.
     """
 
     @abstractmethod
-    def reset(self):
+    def reset(self) -> Self:
         """
-        Resets the internal state
+        Resets the internal limit state.
+
+        Returns
+        -------
+        Returns a filter of the same type, but with non-reached state.
+
+        It could be the same filter or a new one, this is an implementation detail.
+
+        Examples
+        --------
+
+        .. code:: python
+
+            assert limit.is_reached
+
+            new_limit = limit.reset()
+            assert not new_limit.is_reached
         """
 
     @abstractmethod
     def stops_at(self, path: PathProtocol) -> bool:
         """
-        Update internal state and check if it is reached. Returns ``True`` if limit is reached
+        Update internal state and return current state.
+
+        Parameters
+        ----------
+        path : :obj:`onetl.base.path_protocol.PathProtocol`
+            Path to check
+
+        Returns
+        -------
+        ``True`` if limit is reached, ``False`` otherwise.
+
+        Examples
+        --------
+
+        .. code:: python
+
+            from onetl.impl import LocalPath
+
+            assert not limit.stops_at(LocalPath("/path/to/file.csv"))
+            # do this multiple times
+            ...
+
+            # stopped on some input
+            assert limit.stops_at(LocalPath("/path/to/another.csv"))
+
+            # at this point, .stops_at() and .is_reached will always return True,
+            # even on inputs that returned False before.
+            # it will be in the same state until .reset() is called
+            assert limit.stops_at(LocalPath("/path/to/file.csv"))
         """
 
     @property
     @abstractmethod
     def is_reached(self) -> bool:
         """
-        Returns ``True`` if limit is reached
+        Check if limit is reached.
+
+        Returns
+        -------
+        ``True`` if limit is reached, ``False`` otherwise.
+
+        Examples
+        --------
+
+        .. code:: python
+
+            from onetl.impl import LocalPath
+
+            assert not limit.is_reached
+
+            assert not limit.stops_at(LocalPath("/path/to/file.csv"))
+            assert not limit.is_reached
+
+            assert limit.stops_at(LocalPath("/path/to/file.csv"))
+            assert limit.is_reached
         """

--- a/onetl/core/file_filter/file_filter.py
+++ b/onetl/core/file_filter/file_filter.py
@@ -37,6 +37,11 @@ from onetl.log import log_with_indent
 class FileFilter(BaseFileFilter, FrozenModel):
     r"""Filter files or directories by their path.
 
+    .. deprecated:: 0.8.0
+
+        Use :obj:`Glob <onetl.file.filter.glob.Glob>`, :obj:`Regexp <onetl.file.filter.regexp.Regexp>`
+        or :obj:`ExcludeDir <onetl.file.filter.exclude_dir.ExcludeDir>` instead.
+
     Parameters
     ----------
 

--- a/onetl/file/filter/match_all_filters.py
+++ b/onetl/file/filter/match_all_filters.py
@@ -55,15 +55,14 @@ def match_all_filters(path: PathProtocol, filters: Iterable[BaseFileFilter]) -> 
         assert not match_all_filters(LocalPath("/excluded/path/file.csv"), filters)
     """
 
-    tested = False
+    empty = True
     not_match = []
     for file_filter in filters:
-        tested = True
+        empty = False
         if not file_filter.match(path):
             not_match.append(file_filter)
 
-    if not tested:
-        # no filters
+    if empty:
         return True
 
     if not_match:

--- a/onetl/file/limit/__init__.py
+++ b/onetl/file/limit/__init__.py
@@ -12,4 +12,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from onetl.core.file_limit.file_limit import FileLimit
+
+from onetl.file.limit.limits_reached import limits_reached
+from onetl.file.limit.limits_stop_at import limits_stop_at
+from onetl.file.limit.max_files_count import MaxFilesCount
+from onetl.file.limit.reset_limits import reset_limits

--- a/onetl/file/limit/limits_reached.py
+++ b/onetl/file/limit/limits_reached.py
@@ -1,0 +1,71 @@
+#  Copyright 2023 MTS (Mobile Telesystems)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable
+
+from onetl.base import BaseFileLimit
+
+log = logging.getLogger(__name__)
+
+
+def limits_reached(limits: Iterable[BaseFileLimit]) -> bool:
+    """
+    Check if any of limits reached.
+
+    Parameters
+    ----------
+    limits : Iterable of :obj:`onetl.base.base_file_limit.BaseFileLimit`
+        Limits to test.
+
+    Returns
+    -------
+    ``True`` if any of limits is reached, ``False`` otherwise.
+
+    If no limits are passed, returns ``False``.
+
+    Examples
+    --------
+
+    .. code:: python
+
+        from onetl.file.limit import MaxFilesCount, limits_reached, limits_stop_at
+        from onetl.impl import LocalPath
+
+        limits = [MaxFilesCount(2)]
+        assert not limits_reached(limits)
+
+        assert not limits_stop_at(LocalPath("/path/to/file.csv"), limits)
+        assert limits_stop_at(LocalPath("/path/to/file.csv"), limits)
+
+        assert limits_reached(limits)
+    """
+    debug = log.isEnabledFor(logging.DEBUG)
+
+    reached = []
+    for limit in limits:
+        if limit.is_reached:
+            if not debug:
+                # fast path
+                return True
+
+            reached.append(limit)
+
+    if reached:
+        log.debug("|FileLimit| Limits %r are reached", reached)
+        return True
+
+    return False

--- a/onetl/file/limit/limits_stop_at.py
+++ b/onetl/file/limit/limits_stop_at.py
@@ -17,16 +17,42 @@ from __future__ import annotations
 import logging
 from typing import Iterable
 
-from onetl.base import BaseFileLimit
-from onetl.impl import RemotePath
+from onetl.base import BaseFileLimit, PathProtocol
 
 log = logging.getLogger(__name__)
 
 
-def limits_reached(limits: Iterable[BaseFileLimit], path: RemotePath) -> bool:
-    if not limits:
-        return False
+def limits_stop_at(path: PathProtocol, limits: Iterable[BaseFileLimit]) -> bool:
+    """
+    Check if some of limits stops at given path.
 
+    Parameters
+    ----------
+    path : :obj:`onetl.base.path_protocol.PathProtocol`
+        Path to check.
+
+    limits : Iterable of :obj:`onetl.base.base_file_limit.BaseFileLimit`
+        Limits to test path against.
+
+    Returns
+    -------
+    ``True`` if any of limit is reached while handling the path, ``False`` otherwise.
+
+    If no limits are passed, returns ``False``.
+
+    Examples
+    --------
+
+    .. code:: python
+
+        from onetl.file.limit import MaxFilesCount, limits_stop_at
+        from onetl.impl import LocalPath
+
+        limits = [MaxFilesCount(1)]
+
+        assert not limits_stop_at(LocalPath("/path/to/file.csv"), limits)
+        assert limits_stop_at(LocalPath("/path/to/file.csv"), limits)
+    """
     reached = []
     for limit in limits:
         if limit.stops_at(path):

--- a/onetl/file/limit/max_files_count.py
+++ b/onetl/file/limit/max_files_count.py
@@ -1,0 +1,75 @@
+#  Copyright 2023 MTS (Mobile Telesystems)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from __future__ import annotations
+
+import logging
+
+from onetl.base import BaseFileLimit, PathProtocol
+from onetl.impl import FrozenModel
+
+log = logging.getLogger(__name__)
+
+
+class MaxFilesCount(BaseFileLimit, FrozenModel):
+    """Limits the total number of files handled by :ref:`file-downloader` or :ref:`file-mover`.
+
+    Parameters
+    ----------
+
+    limit : int
+
+        All files until ``limit`` (including) will be downloaded/moved, but ``limit+1`` will not.
+
+    Examples
+    --------
+
+    Create filter which allows to handle 100 files, but stops on 101:
+
+    .. code:: python
+
+        from onetl.file.limit import MaxFilesCount
+
+        limit = MaxFilesCount(100)
+    """
+
+    limit: int
+
+    _counter: int = 0
+
+    def __init__(self, limit: int):
+        # this is only to allow passing glob as positional argument
+        super().__init__(limit=limit)  # type: ignore
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self.limit})"
+
+    def reset(self):
+        self._counter = 0
+        return self
+
+    def stops_at(self, path: PathProtocol) -> bool:
+        if self.is_reached:
+            return True
+
+        if path.is_dir():
+            # directories count does not matter
+            return False
+
+        self._counter += 1
+        return self.is_reached
+
+    @property
+    def is_reached(self) -> bool:
+        return self._counter >= self.limit

--- a/onetl/file/limit/reset_limits.py
+++ b/onetl/file/limit/reset_limits.py
@@ -1,0 +1,58 @@
+#  Copyright 2023 MTS (Mobile Telesystems)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable
+
+from onetl.base import BaseFileLimit
+
+log = logging.getLogger(__name__)
+
+
+def reset_limits(limits: Iterable[BaseFileLimit]) -> list[BaseFileLimit]:
+    """
+    Reset limits state.
+
+    Parameters
+    ----------
+    limits : Iterable of :obj:`onetl.base.base_file_limit.BaseFileLimit`
+        Limits to reset.
+
+    Returns
+    -------
+    List with limits, but with reset state.
+
+    List may contain original filters with reset state, or new copies.
+    This is an implementation detail of :obj:`reset <onetl.base.base_file_limit.BaseFileLimit.reset>` method.
+
+    Examples
+    --------
+
+    .. code:: python
+
+        from onetl.file.limit import MaxFilesCount, limits_reached, reset_limits
+        from onetl.impl import LocalPath
+
+        limits = [MaxFilesCount(1)]
+
+        assert not limits_reached(limits)
+        # do something
+        assert limits_reached(limits)
+
+        new_limits = reset_limits(limits)
+        assert not limits_reached(new_limits)
+    """
+    return [limit.reset() for limit in limits]

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -12,5 +12,5 @@ platformdirs
 pydantic>=1.9.2,!=1.10.2,<2
 pyyaml
 # https://github.com/python/typing_extensions/pull/188
-typing_extensions!=4.6.1; python_version == "3.7"
-typing_extensions; python_version > "3.7"
+typing_extensions>=4.0.0,!=4.6.1; python_version == "3.7"
+typing_extensions>=4.0.0; python_version > "3.7"

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,5 @@
 black
-mypy==1.1.1
+mypy
 pre-commit
 types-Deprecated
 types-PyYAML

--- a/tests/tests_integration/tests_core_integration/test_file_downloader_integration.py
+++ b/tests/tests_integration/tests_core_integration/test_file_downloader_integration.py
@@ -156,7 +156,6 @@ def test_downloader_file_filter_exclude_dir(
     upload_test_files,
     path_type,
     tmp_path_factory,
-    caplog,
 ):
     local_path = tmp_path_factory.mktemp("local_path")
 
@@ -172,8 +171,7 @@ def test_downloader_file_filter_exclude_dir(
         source_path / "exclude_dir/file_5.txt",
     ]
 
-    with caplog.at_level(logging.DEBUG):
-        download_result = downloader.run()
+    download_result = downloader.run()
 
     assert not download_result.failed
     assert not download_result.skipped
@@ -203,8 +201,7 @@ def test_downloader_file_filter_glob(file_all_connections, source_path, upload_t
         source_path / "news_parse_zp/exclude_dir/file_3.txt",
     ]
 
-    with caplog.at_level(logging.DEBUG):
-        download_result = downloader.run()
+    download_result = downloader.run()
 
     assert not download_result.failed
     assert not download_result.skipped
@@ -767,17 +764,12 @@ def test_downloader_file_limit_custom(file_all_connections, source_path, upload_
         limit=FileLimit(count_limit=limit),
     )
 
-    with caplog.at_level(logging.DEBUG):
-        files = downloader.view_files()
-
-        assert f"Limits [FileLimit(count_limit={limit})] are reached" in caplog.text
-
+    files = downloader.view_files()
     assert len(files) == limit
 
-    with caplog.at_level(logging.DEBUG):
+    with caplog.at_level(logging.INFO):
         download_result = downloader.run()
         assert "    count_limit = 2" in caplog.text
-        assert f"Limits [FileLimit(count_limit={limit})] are reached" in caplog.text
 
     assert len(download_result.successful) == limit
 
@@ -792,19 +784,14 @@ def test_downloader_no_file_limit(file_all_connections, source_path, upload_test
         limit=None,
     )
 
-    with caplog.at_level(logging.DEBUG):
-        files = downloader.view_files()
-
-        assert "are reached" not in caplog.text
-
+    files = downloader.view_files()
     assert len(files) == len(upload_test_files)
 
-    with caplog.at_level(logging.DEBUG):
+    with caplog.at_level(logging.INFO):
         download_result = downloader.run()
 
         assert "limit = None" in caplog.text
         assert "count_limit = 2" not in caplog.text
-        assert "are reached" not in caplog.text
 
     assert sorted(download_result.successful) == sorted(
         local_path / file.relative_to(source_path) for file in upload_test_files
@@ -872,7 +859,6 @@ def test_downloader_detect_hwm_type_snap_batch_strategy(
     source_path,
     upload_test_files,
     tmp_path_factory,
-    caplog,
 ):
     local_path = tmp_path_factory.mktemp("local_path")
 
@@ -893,7 +879,6 @@ def test_downloader_detect_hwm_type_inc_batch_strategy(
     source_path,
     upload_test_files,
     tmp_path_factory,
-    caplog,
 ):
     local_path = tmp_path_factory.mktemp("local_path")
 
@@ -967,7 +952,6 @@ def test_downloader_file_hwm_strategy(
     source_path,
     upload_test_files,
     tmp_path_factory,
-    caplog,
     hwm_type,
 ):
     local_path = tmp_path_factory.mktemp("local_path")

--- a/tests/tests_integration/tests_core_integration/test_file_mover_integration.py
+++ b/tests/tests_integration/tests_core_integration/test_file_mover_integration.py
@@ -765,17 +765,12 @@ def test_mover_file_limit_custom(file_all_connections, source_path, upload_test_
         limit=FileLimit(count_limit=limit),
     )
 
-    with caplog.at_level(logging.DEBUG):
-        files = mover.view_files()
-
-        assert f"Limits [FileLimit(count_limit={limit})] are reached" in caplog.text
-
+    files = mover.view_files()
     assert len(files) == limit
 
-    with caplog.at_level(logging.DEBUG):
+    with caplog.at_level(logging.INFO):
         move_result = mover.run()
         assert "    count_limit = 2" in caplog.text
-        assert f"Limits [FileLimit(count_limit={limit})] are reached" in caplog.text
 
     assert len(move_result.successful) == limit
 
@@ -790,19 +785,14 @@ def test_mover_no_file_limit(file_all_connections, source_path, upload_test_file
         limit=None,
     )
 
-    with caplog.at_level(logging.DEBUG):
-        files = mover.view_files()
-
-        assert "are reached" not in caplog.text
-
+    files = mover.view_files()
     assert len(files) == len(upload_test_files)
 
-    with caplog.at_level(logging.DEBUG):
+    with caplog.at_level(logging.INFO):
         move_result = mover.run()
 
         assert "limit = None" in caplog.text
         assert "count_limit = 2" not in caplog.text
-        assert "are reached" not in caplog.text
 
     assert sorted(move_result.successful) == sorted(
         target_path / file.relative_to(source_path) for file in upload_test_files

--- a/tests/tests_unit/test_file/test_filter/test_match_all_filters.py
+++ b/tests/tests_unit/test_file/test_filter/test_match_all_filters.py
@@ -38,9 +38,9 @@ def test_match_all_filters(failed_filters, path, caplog):
 
         if failed_filters:
             filters_list_str = re.escape(repr(failed_filters))
-            message = f"Path '{path}'.* does NOT MATCH filters {filters_list_str}"
+            message = f"'{path}'.* does NOT MATCH filters {filters_list_str}"
         else:
-            message = f"Path '{path}'.* does match all filters"
+            message = f"'{path}'.* does match all filters"
 
         assert re.search(message, caplog.text)
 

--- a/tests/tests_unit/test_file/test_limit/test_limits_are_reached.py
+++ b/tests/tests_unit/test_file/test_limit/test_limits_are_reached.py
@@ -1,0 +1,27 @@
+import logging
+
+from onetl.file.limit import MaxFilesCount, limits_reached
+from onetl.impl import RemoteFile, RemotePathStat
+
+
+def test_limits_reached(caplog):
+    limit1 = MaxFilesCount(3)
+    limit2 = MaxFilesCount(10)
+    limits = [limit1, limit2]
+    assert not limits_reached(limits)
+
+    file = RemoteFile(path="file1.csv", stats=RemotePathStat(st_size=10 * 1024, st_mtime=50))
+
+    assert not limit1.stops_at(file)
+    assert not limits_reached(limits)
+
+    assert not limit1.stops_at(file)
+    assert not limits_reached(limits)
+
+    # limit is reached - all check are True, input does not matter
+    with caplog.at_level(logging.DEBUG):
+        assert limit1.stops_at(file)
+        assert limits_reached(limits)
+
+        message = "|FileLimit| Limits [MaxFilesCount(3)] are reached"
+        assert message in caplog.text

--- a/tests/tests_unit/test_file/test_limit/test_limits_stop_at.py
+++ b/tests/tests_unit/test_file/test_limit/test_limits_stop_at.py
@@ -1,0 +1,29 @@
+import logging
+
+from onetl.file.limit import MaxFilesCount, limits_stop_at
+from onetl.impl import RemoteFile, RemotePathStat
+
+
+def test_limits_stop_at(caplog):
+    limit1 = MaxFilesCount(3)
+    limit2 = MaxFilesCount(10)
+    limits = [limit1, limit2]
+
+    file = RemoteFile(path="file1.csv", stats=RemotePathStat(st_size=10 * 1024, st_mtime=50))
+
+    assert not limits_stop_at(file, limits)
+    assert not limit1.is_reached
+    assert not limit2.is_reached
+
+    assert not limits_stop_at(file, limits)
+    assert not limit1.is_reached
+    assert not limit2.is_reached
+
+    # limit is reached - all check are True, input does not matter
+    with caplog.at_level(logging.DEBUG):
+        assert limits_stop_at(file, limits)
+        assert limit1.is_reached
+        assert not limit2.is_reached
+
+        message = "|FileLimit| Limits [MaxFilesCount(3)] are reached"
+        assert message in caplog.text

--- a/tests/tests_unit/test_file/test_limit/test_max_files_count.py
+++ b/tests/tests_unit/test_file/test_limit/test_max_files_count.py
@@ -1,0 +1,46 @@
+from onetl.file.limit import MaxFilesCount
+from onetl.impl import RemoteDirectory, RemoteFile, RemotePathStat
+
+
+def test_max_files_count():
+    limit = MaxFilesCount(3)
+    assert not limit.is_reached
+
+    directory = RemoteDirectory("some")
+    file1 = RemoteFile(path="file1.csv", stats=RemotePathStat(st_size=10 * 1024, st_mtime=50))
+    file2 = RemoteFile(path="file2.csv", stats=RemotePathStat(st_size=10 * 1024, st_mtime=50))
+    file3 = RemoteFile(path="nested/file3.csv", stats=RemotePathStat(st_size=20 * 1024, st_mtime=50))
+    file4 = RemoteFile(path="nested/file4.csv", stats=RemotePathStat(st_size=20 * 1024, st_mtime=50))
+
+    assert not limit.stops_at(file1)
+    assert not limit.is_reached
+
+    assert not limit.stops_at(file2)
+    assert not limit.is_reached
+
+    # directories are not checked by limit
+    assert not limit.stops_at(directory)
+    assert not limit.is_reached
+
+    # limit is reached - all check are True, input does not matter
+    assert limit.stops_at(file3)
+    assert limit.is_reached
+
+    assert limit.stops_at(file4)
+    assert limit.is_reached
+
+    assert limit.stops_at(directory)
+    assert limit.is_reached
+
+    # reset internal state
+    limit.reset()
+
+    assert not limit.stops_at(file1)
+    assert not limit.is_reached
+
+    # limit does not remember each file, so if duplicates are present, they can affect the result
+    assert not limit.stops_at(file1)
+    assert not limit.is_reached
+
+    assert limit.stops_at(file1)
+    assert limit.is_reached

--- a/tests/tests_unit/test_file/test_limit/test_reset_limits.py
+++ b/tests/tests_unit/test_file/test_limit/test_reset_limits.py
@@ -1,0 +1,24 @@
+from onetl.file.limit import MaxFilesCount, reset_limits
+from onetl.impl import RemoteFile, RemotePathStat
+
+
+def test_reset_limits():
+    limit1 = MaxFilesCount(3)
+    limit2 = MaxFilesCount(10)
+    limits = [limit1, limit2]
+
+    file = RemoteFile(path="file1.csv", stats=RemotePathStat(st_size=10 * 1024, st_mtime=50))
+
+    for _ in range(3):
+        limit1.stops_at(file)
+        limit2.stops_at(file)
+
+    assert limit1.is_reached
+    assert not limit2.is_reached
+
+    new_limits = reset_limits(limits)
+    # new limits list is different from original, but may contain the same elements
+    assert new_limits is not limits
+
+    for limit in new_limits:
+        assert not limit.is_reached

--- a/tests/tests_unit/tests_core_unit/test_file_limit_unit.py
+++ b/tests/tests_unit/tests_core_unit/test_file_limit_unit.py
@@ -1,9 +1,31 @@
+import re
+import textwrap
+
+import pytest
+
 from onetl.core import FileLimit
 from onetl.impl import RemoteDirectory, RemoteFile, RemotePathStat
 
 
 def test_file_limit():
-    file_limit = FileLimit(count_limit=3)
+    warning_msg = textwrap.dedent(
+        """
+        Using FileLimit is deprecated since v0.8.0 and will be removed in v1.0.0.
+
+        Please replace:
+            from onetl.core import FileLimit
+
+            limit=FileLimit(count_limit=3)
+
+        With:
+            from onetl.file.limit import MaxFilesCount
+
+            limits=[MaxFilesCount(3)]
+        """,
+    ).strip()
+    with pytest.warns(UserWarning, match=re.escape(warning_msg)):
+        file_limit = FileLimit(count_limit=3)
+
     assert not file_limit.is_reached
 
     directory = RemoteDirectory("some")


### PR DESCRIPTION
- Added new `onetl.file.limit` module
- Replaced old class `FileLimit(count_limit=10)` class with `MaxFilesCount(10)`, placed new class to new module, added documentation & unit tests.
- Moved `limits_reached` to new module, renamed to `limits_stop_at`, to show that it checks a specific path against limits, added unit tests & documentation.
- Added new functions `limits_reached` and `reset_limits` which previously were a part of `FileConnection.list_dir` and `.walk`. They can help other developers to implement new modules in the future. Documented and tested them as well.
- Added documentation for `BaseFileLimit`
- Changed a bit the behavior of `BaseFileLimit.reset()` method - now the return value is used as a new limit, so it now depends on developer, should it resett a limit object state in-place or create a copy.

Documentation: https://onetl--44.org.readthedocs.build/en/44/file_limit/index.html