### PR TITLE
[DOP-5797] Add changelog for 0.7.x and 0.8.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,18 +52,47 @@ jobs:
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}
 
-    - name: Generate changelog
+    - name: Get changelog
       run: |
-        towncrier build --draft > release_notes.rst
+        cat docs/changelog/${{ github.ref_name }}.rst > changelog.rst
+
+    - name: Fix Github links
+      run: |
+        # Replace Github links from Sphinx syntax with Markdown
+        sed -i -E "s/:github:issue:`(.*)`/#\1/g" changelog.rst
+        sed -i -E "s/:github:pull:`(.*)`/#\1/g" changelog.rst
+        sed -i -E "s/:github:user:`(.*)`/@\1/g" changelog.rst
+        sed -i -E "s/:github:org:`(.*)`/@\1/g" changelog.rst
 
     - name: Convert changelog to markdown
       uses: docker://pandoc/core:2.9
       with:
         args: >-
-          --output=release_notes.md
+          --output=changelog.md
           --from=rst
-          --to=markdown
-          release_notes.rst
+          --to=gfm
+          --wrap=none
+          changelog.rst
+
+    - name: Fix Github code blocks
+      run: |
+        # Replace ``` {.python caption="abc"} with ```python caption="abc"
+        sed -i -E "s/``` \{\.(.*)\}/```\1/g" changelog.md
+
+        # Replace ``` python with ```python
+        sed -i -E "s/``` (\w+)/```\1/g" changelog.md
+
+    - name: Get release name
+      id: release-name
+      run: |
+        # Release name looks like: 0.7.0 (2023-05-15)
+        echo -n name= > "$GITHUB_OUTPUT"
+        cat changelog.md | head -1 | sed -E "s/#*\s*//g" >> "$GITHUB_OUTPUT"
+
+    - name: Fix headers
+      run: |
+        # Remove header with release name
+        sed -i -e "1,2d" changelog.md
 
     - name: Create Github release
       id: create_release
@@ -72,6 +101,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         draft: false
         prerelease: false
-        body_path: release_notes.md
+        name: ${{ steps.release-name.outputs.name }}
+        body_path: changelog.md
         files: |
           dist/*

--- a/docs/changelog/0.7.0.rst
+++ b/docs/changelog/0.7.0.rst
@@ -1,0 +1,246 @@
+0.7.0 (2023-05-15)
+--------------------------
+
+🎉 onETL is now open source 🎉
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+That was long road, but we finally did it!
+
+Breaking Changes
+^^^^^^^^^^^^^^^^
+
+* Changed installation method.
+
+  **TL;DR What should I change to restore previous behavior**
+
+  Simple way:
+
+  +-------------------+-----------------------------------+
+  | onETL < 0.7.0     | onETL >= 0.7.0                    |
+  +===================+===================================+
+  | pip install onetl | pip install onetl[files,kerberos] |
+  +-------------------+-----------------------------------+
+
+  Right way - enumerate connectors should be installed:
+
+  .. code-block:: bash
+
+      pip install onetl[hdfs,ftp,kerberos]  # except DB connections
+
+  **Details**
+
+  In onetl<0.7 the package installation looks like:
+
+  .. code-block:: bash
+      :caption: before
+
+      pip install onetl
+
+  But this includes all dependencies for all connectors, even if user does not use them.
+  This caused some issues, for example user had to install Kerberos libraries to be able to install onETL, even if user uses only S3 (without Kerberos support).
+
+  Since 0.7.0 installation process was changed:
+
+  .. code-block:: bash
+      :caption: after
+
+      pip install onetl  # minimal installation, only onETL core
+      # there is no extras for DB connections because they are using Java packages which are installed in runtime
+
+      pip install onetl[ftp,ftps,hdfs,sftp,s3,webdav]  # install dependencies for specified file connections
+      pip install onetl[files]  # install dependencies for all file connections
+
+      pip install onetl[kerberos]  # Kerberos auth support
+      pip install onetl[spark]  # install PySpark to use DB connections
+
+      pip install onetl[spark,kerberos,files]  # all file connections + Kerberos + PySpark
+      pip install onetl[all]  # alias for previous case
+
+  There are corresponding documentation items for each extras.
+
+  Also onETL checks that some requirements are missing, and raises exception with recommendation how to install them:
+
+  .. code-block:: text
+      :caption: exception while import Clickhouse connection
+
+      Cannot import module "pyspark".
+
+      Since onETL v0.7.0 you should install package as follows:
+          pip install onetl[spark]
+
+      or inject PySpark to sys.path in some other way BEFORE creating MongoDB instance.
+
+  .. code-block:: text
+      :caption: exception while import FTP connection
+
+      Cannot import module "ftputil".
+
+      Since onETL v0.7.0 you should install package as follows:
+          pip install onetl[ftp]
+
+      or
+          pip install onetl[files]
+
+* Added new ``cluster`` argument to ``Hive`` and ``HDFS`` connections.
+
+  ``Hive`` qualified name (used in HWM) contains cluster name. But in onETL<0.7.0 cluster name had hard coded value ``rnd-dwh`` which was not OK for some users.
+
+  ``HDFS`` connection qualified name contains host (active namenode of Hadoop cluster), but its value can change over time, leading to creating of new HWM.
+
+  Since onETL 0.7.0 both ``Hive`` and ``HDFS`` connections have ``cluster`` attribute which can be set to a specific cluster name.
+  For ``Hive`` it is mandatory, for ``HDFS`` it can be omitted (using host as a fallback).
+
+  But passing cluster name every time could lead to errors.
+
+  Now ``Hive`` and ``HDFS`` have nested class named ``slots`` with methods:
+
+  * ``normalize_cluster_name``
+  * ``get_known_clusters``
+  * ``get_current_cluster``
+  * ``normalize_namenode_host`` (only ``HDFS``)
+  * ``get_cluster_namenodes`` (only ``HDFS``)
+  * ``get_webhdfs_port`` (only ``HDFS``)
+  * ``is_namenode_active`` (only ``HDFS``)
+
+  And new method ``HDFS.get_current`` / ``Hive.get_current``.
+
+  Developers can implement hooks validating user input or substituting values for automatic cluster detection.
+  This should improve user experience while using these connectors.
+
+  See slots documentation.
+
+* Update JDBC connection drivers.
+
+  * Greenplum ``2.1.3`` → ``2.1.4``.
+  * MSSQL ``10.2.1.jre8`` → ``12.2.0.jre8``. Minimal supported version of MSSQL is now 2014 instead 2021.
+  * MySQL ``8.0.30`` → ``8.0.33``:
+  * * Package was renamed ``mysql:mysql-connector-java`` → ``com.mysql:mysql-connector-j``.
+  * * Driver class was renamed ``com.mysql.jdbc.Driver`` → ``com.mysql.cj.jdbc.Driver``.
+  * Oracle ``21.6.0.0.1`` → ``23.2.0.0``.
+  * Postgres ``42.4.0`` → ``42.6.0``.
+  * Teradata ``17.20.00.08`` → ``17.20.00.15``:
+  * * Package was renamed ``com.teradata.jdbc:terajdbc4`` → ``com.teradata.jdbc:terajdbc``.
+  * * Teradata driver is now published to Maven.
+
+  See :github:pull:`31`.
+
+Features
+^^^^^^^^
+
+* Added MongoDB connection.
+
+  Using official `MongoDB connector for Spark v10 <https://www.mongodb.com/docs/spark-connector/current/>`_. Only Spark 3.2+ is supported.
+
+  There are some differences between MongoDB and other database sources:
+
+  * Instead of ``mongodb.sql`` method there is ``mongodb.pipeline``.
+  * No methods ``mongodb.fetch`` and ``mongodb.execute``.
+  * ``DBReader.hint`` and ``DBReader.where`` have different types than in SQL databases:
+
+  .. code-block:: python
+
+      where = {
+          "col1": {
+              "$eq": 10,
+          },
+      }
+
+      hint = {
+          "col1": 1,
+      }
+
+  * Because MongoDB does not have schemas of collections, but Spark cannot create dataframe with dynamic schema, new option ``DBReader.df_schema`` was introduced.
+    It is mandatory for MongoDB, but optional for other sources.
+  * Currently DBReader cannot be used with MongoDB and hwm expression, e.g. ``hwm_column=("mycolumn", {"$cast": {"col1": "date"}})``
+
+  Because there are no tables in MongoDB, some options were renamed in core classes:
+
+  * ``DBReader(table=...)`` → ``DBReader(source=...)``
+  * ``DBWriter(table=...)`` → ``DBWriter(target=...)``
+
+  Old names can be used too, they are not deprecated (:github:pull:`30`).
+
+* Added option for disabling some plugins during import.
+
+  Previously if some plugin were failing during the import, the only way to import onETL would be to disable all plugins
+  using environment variable.
+
+  Now there are several variables with different behavior:
+
+  * ``ONETL_PLUGINS_ENABLED=false`` - disable all plugins autoimport. Previously it was named ``ONETL_ENABLE_PLUGINS``.
+  * ``ONETL_PLUGINS_BLACKLIST=plugin-name,another-plugin`` - set list of plugins which should NOT be imported automatically.
+  * ``ONETL_PLUGINS_WHITELIST=plugin-name,another-plugin`` - set list of plugins which should ONLY be imported automatically.
+
+  Also we improved exception message with recommendation how to disable a failing plugin:
+
+  .. code-block:: text
+      :caption: exception message example
+
+      Error while importing plugin 'mtspark' from package 'mtspark' v4.0.0.
+
+      Statement:
+          import mtspark.onetl
+
+      Check if plugin is compatible with current onETL version 0.7.0.
+
+      You can disable loading this plugin by setting environment variable:
+          ONETL_PLUGINS_BLACKLIST='mtspark,failing-plugin'
+
+      You can also define a whitelist of packages which can be loaded by onETL:
+          ONETL_PLUGINS_WHITELIST='not-failing-plugin1,not-failing-plugin2'
+
+      Please take into account that plugin name may differ from package or module name.
+      See package metadata for more details
+
+Improvements
+^^^^^^^^^^^^
+
+* Added compatibility with Python 3.11 and PySpark 3.4.0.
+
+  File connections were OK, but ``jdbc.fetch`` and ``jdbc.execute`` were failing. Fixed in :github:pull:`28`.
+
+* Added check for missing Java packages.
+
+  Previously if DB connection tried to use some Java class which were not loaded into Spark version, it raised an exception
+  with long Java stacktrace. Most users failed to interpret this trace.
+
+  Now onETL shows the following error message:
+
+  .. code-block:: text
+      :caption: exception message example
+
+      |Spark| Cannot import Java class 'com.mongodb.spark.sql.connector.MongoTableProvider'.
+
+      It looks like you've created Spark session without this option:
+          SparkSession.builder.config("spark.jars.packages", MongoDB.package_spark_3_2)
+
+      Please call `spark.stop()`, restart the interpreter,
+      and then create new SparkSession with proper options.
+
+* Documentation improvements.
+
+  * Changed documentation site theme - using `furo <https://github.com/pradyunsg/furo>`_
+    instead of default `ReadTheDocs <https://github.com/readthedocs/sphinx_rtd_theme>`_.
+
+    New theme supports wide screens and dark mode.
+    See :github:pull:`10`.
+
+  * Now each connection class have compatibility table for Spark + Java + Python.
+  * Added global compatibility table for Spark + Java + Python + Scala.
+
+Bug Fixes
+^^^^^^^^^^^^
+
+* Fixed several SFTP issues.
+
+  * If SSH config file ``~/.ssh/config`` contains some options not recognized by Paramiko (unknown syntax, unknown option name),
+    previous versions were raising exception until fixing or removing this file. Since 0.7.0 exception is replaced with warning.
+
+  * If user passed ``host_key_check=False`` but server changed SSH keys, previous versions raised exception until new key is accepted.
+    Since 0.7.0 exception is replaced with warning if option value is ``False``.
+
+    Fixed in :github:pull:`19`.
+
+* Fixed several S3 issues.
+
+  There was a bug in S3 connection which prevented handling files in the root of a bucket - they were invisible for the connector. Fixed in :github:pull:`29`.

--- a/docs/changelog/0.7.1.rst
+++ b/docs/changelog/0.7.1.rst
@@ -1,0 +1,43 @@
+
+0.7.1 (2023-05-23)
+--------------------------
+
+Bug Fixes
+^^^^^^^^^^^^
+
+* Fixed ``setup_logging`` function.
+
+  In onETL==0.7.0 calling ``onetl.log.setup_logging()`` broke the logging:
+
+  .. code-block:: text
+      :caption: exception message
+
+      Traceback (most recent call last):
+      File "/opt/anaconda/envs/py39/lib/python3.9/logging/__init__.py", line 434, in format
+          return self._format(record)
+      File "/opt/anaconda/envs/py39/lib/python3.9/logging/__init__.py", line 430, in _format
+          return self._fmt % record.dict
+      KeyError: 'levelname:8s'
+
+* Fixed installation examples.
+
+  In onETL==0.7.0 there are examples of installing onETL with extras:
+
+  .. code-block:: bash
+      :caption: before
+
+      pip install onetl[files, kerberos, spark]
+
+  But pip fails to install such package:
+
+  .. code-block:: text
+      :caption: exception
+
+      ERROR: Invalid requirement: 'onet[files,'
+
+  This is because of spaces in extras clause. Fixed:
+
+  .. code-block:: bash
+      :caption: after
+
+      pip install onetl[files,kerberos,spark]

--- a/docs/changelog/0.7.2.rst
+++ b/docs/changelog/0.7.2.rst
@@ -1,0 +1,39 @@
+0.7.2 (2023-05-24)
+--------------------------
+
+Dependencies
+^^^^^^^^^^^^
+
+* Limited ``typing-extensions`` version.
+
+  ``typing-extensions==4.6.0`` release contains some breaking changes causing errors like:
+
+  .. code-block:: text
+      :caption: typing-extensions 4.6.0
+
+      Traceback (most recent call last):
+      File "/Users/project/lib/python3.9/typing.py", line 852, in __subclasscheck__
+          return issubclass(cls, self.__origin__)
+      TypeError: issubclass() arg 1 must be a class
+
+  ``typing-extensions==4.6.1`` was causing another error:
+
+  .. code-block:: text
+      :caption: typing-extensions 4.6.1
+
+      Traceback (most recent call last):
+      File "/home/maxim/Repo/typing_extensions/1.py", line 33, in <module>
+          isinstance(file, ContainsException)
+      File "/home/maxim/Repo/typing_extensions/src/typing_extensions.py", line 599, in __instancecheck__
+          if super().__instancecheck__(instance):
+      File "/home/maxim/.pyenv/versions/3.7.8/lib/python3.7/abc.py", line 139, in __instancecheck__
+          return _abc_instancecheck(cls, instance)
+      File "/home/maxim/Repo/typing_extensions/src/typing_extensions.py", line 583, in __subclasscheck__
+          return super().__subclasscheck__(other)
+      File "/home/maxim/.pyenv/versions/3.7.8/lib/python3.7/abc.py", line 143, in __subclasscheck__
+          return _abc_subclasscheck(cls, subclass)
+      File "/home/maxim/Repo/typing_extensions/src/typing_extensions.py", line 661, in _proto_hook
+          and other._is_protocol
+      AttributeError: type object 'PathWithFailure' has no attribute '_is_protocol'
+
+  We updated requirements with ``typing-extensions<4.6`` until fixing compatibility issues.

--- a/docs/changelog/README.rst
+++ b/docs/changelog/README.rst
@@ -70,18 +70,18 @@ Examples for adding changelog entries to your Pull Requests
 .. code-block:: rst
     :caption: docs/changelog/next_release/1234.doc.1.rst
 
-    Added a ``:user:`` role to Sphinx config -- by :user:`someuser`
+    Added a ``:github:user:`` role to Sphinx config -- by :github:user:`someuser`
 
 .. code-block:: rst
     :caption: docs/changelog/next_release/2345.bugfix.rst
 
-    Fixed behavior of ``WebDAV`` connector -- by :user:`someuser`
+    Fixed behavior of ``WebDAV`` connector -- by :github:user:`someuser`
 
 .. code-block:: rst
     :caption: docs/changelog/next_release/3456.feature.rst
 
     Added support of ``timeout`` in ``S3`` connector
-    -- by :user:`someuser`, :user:`anotheruser` and :user:`otheruser`
+    -- by :github:user:`someuser`, :github:user:`anotheruser` and :github:user:`otheruser`
 
 .. tip::
 

--- a/docs/changelog/index.rst
+++ b/docs/changelog/index.rst
@@ -4,3 +4,6 @@
 
     DRAFT
     NEXT_RELEASE
+    0.7.2
+    0.7.1
+    0.7.0

--- a/docs/changelog/next_release/32.misc.rst
+++ b/docs/changelog/next_release/32.misc.rst
@@ -1,0 +1,8 @@
+Improved CI workflow for tests.
+
+* If developer haven't changed source core of a specific connector or its dependencies,
+  run tests only against maximum supported versions of Spark, Python, Java and db/file server.
+* If developed made some changes in a specific connector, or in core classes, or in dependencies,
+  run tests for both minimal and maximum versions.
+* Once a week run all aganst for minimal and latest versions to detect breaking changes in dependencies
+* Minimal tested Spark version is 2.3.1 instead on 2.4.8.

--- a/docs/changelog/next_release/36.breaking.rst
+++ b/docs/changelog/next_release/36.breaking.rst
@@ -1,0 +1,9 @@
+Rename methods of ``FileConnection`` classes:
+
+* ``get_directory`` → ``resolve_dir``
+* ``get_file`` → ``resolve_file``
+* ``listdir`` → ``list_dir``
+* ``mkdir`` → ``create_dir``
+* ``rmdir`` → ``remove_dir``
+
+They were undocumented in previous versions, but someone could use these methods, so this is a breaking change.

--- a/docs/changelog/next_release/39.improvement.1.rst
+++ b/docs/changelog/next_release/39.improvement.1.rst
@@ -1,0 +1,16 @@
+Document all public methods in ``FileConnection`` classes:
+
+* ``download_file``
+* ``resolve_dir``
+* ``resolve_file``
+* ``get_stat``
+* ``is_dir``
+* ``is_file``
+* ``list_dir``
+* ``create_dir``
+* ``path_exists``
+* ``remove_file``
+* ``rename_file``
+* ``remove_dir``
+* ``upload_file``
+* ``walk``

--- a/docs/changelog/next_release/39.improvement.2.rst
+++ b/docs/changelog/next_release/39.improvement.2.rst
@@ -1,0 +1,1 @@
+Update documentation of ``check`` method of all connections - add usage example and document result type.

--- a/docs/changelog/next_release/39.improvement.3.rst
+++ b/docs/changelog/next_release/39.improvement.3.rst
@@ -1,0 +1,4 @@
+Add new exception type ``FileSizeMismatchError``.
+
+Methods ``connection.download_file`` and ``connection.upload_file`` now raise new exception type instead of ``RuntimeError``,
+if target file after download/upload has different size than source.

--- a/docs/changelog/next_release/40.feature.rst
+++ b/docs/changelog/next_release/40.feature.rst
@@ -1,0 +1,13 @@
+Add ``rename_dir`` method.
+
+Method was added to following connections:
+
+* ``FTP``
+* ``FTPS``
+* ``HDFS``
+* ``SFTP``
+* ``WebDAV``
+
+It allows to rename/move directory to new path with all its content.
+
+``S3`` does not have directories, so there is no such method in that class.

--- a/docs/changelog/next_release/40.improvement.rst
+++ b/docs/changelog/next_release/40.improvement.rst
@@ -1,0 +1,1 @@
+Add new exception type ``DirectoryExistsError`` - it is raised if target directory already exists.

--- a/docs/changelog/next_release/42.feature.rst
+++ b/docs/changelog/next_release/42.feature.rst
@@ -1,0 +1,4 @@
+Add ``onetl.file.FileMover`` class.
+
+It allows to move files between directories of remote file system.
+Signature is almost the same as in ``FileDownloader``, but without HWM support.

--- a/docs/changelog/next_release/42.improvement.1.rst
+++ b/docs/changelog/next_release/42.improvement.1.rst
@@ -1,0 +1,4 @@
+Improved ``FileDownloader`` / ``FileUploader`` exception logging.
+
+If ``DEBUG`` logging is enabled, print exception with stacktrace instead of
+printing only exception message.

--- a/docs/changelog/next_release/42.improvement.2.rst
+++ b/docs/changelog/next_release/42.improvement.2.rst
@@ -1,0 +1,5 @@
+Updated documentation of ``FileUploader``.
+
+* Class does not support read strategies, added note to documentation.
+* Added examples of using ``run`` method with explicit files list passing, both absolute and relative paths.
+* Fix outdated imports and class names in examples.

--- a/docs/changelog/next_release/42.improvement.3.rst
+++ b/docs/changelog/next_release/42.improvement.3.rst
@@ -1,0 +1,1 @@
+Updated documentation of ``DownloadResult`` class - fix outdated imports and class names.

--- a/docs/changelog/next_release/43.breaking.rst
+++ b/docs/changelog/next_release/43.breaking.rst
@@ -1,0 +1,7 @@
+Deprecate ``onetl.core.FileFilter`` class, replace it with new classes:
+
+* ``onetl.file.filter.Glob``
+* ``onetl.file.filter.Regexp``
+* ``onetl.file.filter.ExcludeDir``
+
+Old class will be removed in v1.0.0.

--- a/docs/changelog/next_release/43.improvement.rst
+++ b/docs/changelog/next_release/43.improvement.rst
@@ -1,0 +1,3 @@
+Improved file filters documentation section.
+
+Document interface class ``onetl.base.BaseFileFilter`` and function ``match_all_filters``.

--- a/docs/changelog/next_release/44.breaking.1.rst
+++ b/docs/changelog/next_release/44.breaking.1.rst
@@ -1,0 +1,3 @@
+Deprecate ``onetl.core.FileLimit`` class, replace it with new class ``onetl.file.limit.MaxFilesCount``.
+
+Old class will be removed in v1.0.0.

--- a/docs/changelog/next_release/44.breaking.2.rst
+++ b/docs/changelog/next_release/44.breaking.2.rst
@@ -1,0 +1,4 @@
+Change behavior of ``BaseFileLimit.reset`` method.
+
+This method should now return ``self`` instead of ``None``.
+Return value could be the same limit object or a copy, this is an implementation detail.

--- a/docs/changelog/next_release/44.improvement.rst
+++ b/docs/changelog/next_release/44.improvement.rst
@@ -1,0 +1,3 @@
+Improved file limits documentation section.
+
+Document interface class ``onetl.base.BaseFileLimit`` and functions ``limits_stop_at`` / ``limits_reached`` / ``reset_limits``.

--- a/docs/changelog/next_release/45.breaking.1.rst
+++ b/docs/changelog/next_release/45.breaking.1.rst
@@ -1,0 +1,23 @@
+Replaced ``FileDownloader.filter`` and ``.limit`` with new options ``.filters`` and ``.limits``:
+
+.. code-block:: python
+    :caption: onETL < 0.8.0
+
+    FileDownloader(
+        ...,
+        filter=FileFilter(glob="*.txt", exclude_dir="/path"),
+        limit=FileLimit(count_limit=10),
+    )
+
+.. code-block:: python
+    :caption: onETL >= 0.8.0
+
+    FileDownloader(
+        ...,
+        filters=[Glob("*.txt"), ExcludeDir("/path")],
+        limits=[MaxFilesCount(10)],
+    )
+
+This allows to developers to implement their own filter and limit classes, and combine them with existing ones.
+
+Old behavior still supported, but it will be removed in v1.0.0.

--- a/docs/changelog/next_release/45.breaking.2.rst
+++ b/docs/changelog/next_release/45.breaking.2.rst
@@ -1,0 +1,1 @@
+Removed default value for ``FileDownloader.limits``, user should pass limits list explicitly.

--- a/docs/changelog/next_release/46.breaking.rst
+++ b/docs/changelog/next_release/46.breaking.rst
@@ -1,0 +1,28 @@
+Move classes from module ``onetl.core``:
+
+.. code-block:: python
+    :caption: before
+
+    from onetl.core import DBReader
+    from onetl.core import DBWriter
+    from onetl.core import FileDownloader
+    from onetl.core import FileUploader
+    from onetl.core import FileResult
+    from onetl.core import FileSet
+
+with new modules ``onetl.db`` and ``onetl.file``:
+
+.. code-block:: python
+    :caption: after
+
+    from onetl.db import DBReader
+    from onetl.db import DBWriter
+
+    from onetl.file import FileDownloader
+    from onetl.file import FileUploader
+
+    # not a public interface
+    from onetl.file.file_result import FileResult
+    from onetl.file.file_set import FileSet
+
+Imports from old module ``onetl.core`` still can be used, but marked as deprecated. Module will be removed in v1.0.0.

--- a/docs/changelog/next_release/47.improvement.rst
+++ b/docs/changelog/next_release/47.improvement.rst
@@ -1,3 +1,3 @@
-Add changelog.
+Added changelog.
 
 Changelog is generated from separated news files using `towncrier <https://pypi.org/project/towncrier/>`_.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,6 +50,7 @@ extensions = [
     "sphinx_substitution_extensions",
     "sphinx_tabs.tabs",
     "sphinx_toolbox.more_autodoc.autoprotocol",
+    "sphinx_toolbox.github",
     "sphinx_copybutton",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
@@ -66,9 +67,12 @@ autodoc_pydantic_model_show_validator_members = False
 autodoc_pydantic_field_list_validators = False
 sphinx_tabs_disable_tab_closing = True
 
-towncrier_draft_autoversion_mode = "draft"  # or: 'sphinx-version', 'sphinx-release'
+towncrier_draft_autoversion_mode = "draft"
 towncrier_draft_include_empty = True
 towncrier_draft_working_directory = PROJECT_ROOT_DIR
+
+github_username = "MobileTeleSystems"
+github_repository = "onetl"
 
 rst_prolog = f"""
 .. |support_hooks| image:: https://img.shields.io/badge/%20-support%20hooks-blue

--- a/docs/file_connection/ftp.rst
+++ b/docs/file_connection/ftp.rst
@@ -6,4 +6,4 @@ FTP connection
 .. currentmodule:: onetl.connection.file_connection.ftp
 
 .. autoclass:: FTP
-    :members: __init__, check, path_exists, is_file, is_dir, get_stat, resolve_dir, resolve_file, create_dir, remove_file, remove_dir, rename_file, list_dir, walk, download_file, upload_file
+    :members: __init__, check, path_exists, is_file, is_dir, get_stat, resolve_dir, resolve_file, create_dir, remove_file, remove_dir, rename_dir, rename_file, list_dir, walk, download_file, upload_file

--- a/docs/file_connection/ftps.rst
+++ b/docs/file_connection/ftps.rst
@@ -6,4 +6,4 @@ FTPS connection
 .. currentmodule:: onetl.connection.file_connection.ftps
 
 .. autoclass:: FTPS
-    :members: __init__, check, path_exists, is_file, is_dir, get_stat, resolve_dir, resolve_file, create_dir, remove_file, remove_dir, rename_file, list_dir, walk, download_file, upload_file
+    :members: __init__, check, path_exists, is_file, is_dir, get_stat, resolve_dir, resolve_file, create_dir, remove_file, remove_dir, rename_dir, rename_file, list_dir, walk, download_file, upload_file

--- a/docs/file_connection/hdfs.rst
+++ b/docs/file_connection/hdfs.rst
@@ -11,7 +11,7 @@ HDFS connection
     HDFS.slots
 
 .. autoclass:: HDFS
-    :members: __init__, check, path_exists, is_file, is_dir, get_stat, resolve_dir, resolve_file, create_dir, remove_file, remove_dir, rename_file, list_dir, walk, download_file, upload_file
+    :members: __init__, check, path_exists, is_file, is_dir, get_stat, resolve_dir, resolve_file, create_dir, remove_file, remove_dir, rename_dir, rename_file, list_dir, walk, download_file, upload_file
 
 .. currentmodule:: onetl.connection.file_connection.hdfs.HDFS
 

--- a/docs/file_connection/sftp.rst
+++ b/docs/file_connection/sftp.rst
@@ -6,4 +6,4 @@ SFTP connection
 .. currentmodule:: onetl.connection.file_connection.sftp
 
 .. autoclass:: SFTP
-    :members: __init__, check, path_exists, is_file, is_dir, get_stat, resolve_dir, resolve_file, create_dir, remove_file, remove_dir, rename_file, list_dir, walk, download_file, upload_file
+    :members: __init__, check, path_exists, is_file, is_dir, get_stat, resolve_dir, resolve_file, create_dir, remove_file, remove_dir, rename_dir, rename_file, list_dir, walk, download_file, upload_file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ package = "onetl"
 filename = "docs/changelog/NEXT_RELEASE.rst"
 directory = "docs/changelog/next_release/"
 title_format = "{version} ({project_date})"
-issue_format = "`#{issue} <https://github.com/MobileTeleSystems/onetl/issues/{issue}>`_"
+issue_format = ":github:pull:`{issue}`"
 
 [[tool.towncrier.type]]
 directory = "breaking"


### PR DESCRIPTION
## Change Summary

* Add changelog entries for 0.7.x and 0.8.0 releases.
* Add workaround in release process to covert Sphinx syntax of changelog to Github Markdown - e.g. ``` :github:pull:`123` ``` is converted to `#123`, ```.. code-block: python``` to ```` ```python ````
* Changelog should be generated before the release, not during release
* Fixed missing documentation for `rename_dir` method in Sphinx

See https://onetl--48.org.readthedocs.build/en/48/changelog.html