### PR TITLE
[DOP-3709] Add @slot to methods of public interfaces

### DIFF
--- a/docs/changelog/next_release/49.feature.rst
+++ b/docs/changelog/next_release/49.feature.rst
@@ -1,0 +1,9 @@
+Add ``@slot`` decorator to public methods of:
+
+* ``DBConnection``
+* ``FileConnection``
+* ``DBReader``
+* ``DBWriter``
+* ``FileDownloader``
+* ``FileUploader``
+* ``FileMover``

--- a/docs/changelog/next_release/49.improvement.rst
+++ b/docs/changelog/next_release/49.improvement.rst
@@ -1,0 +1,1 @@
+Add documentation for HWM store ``.get`` and ``.save`` methods.

--- a/docs/hwm_store/memory_hwm_store.rst
+++ b/docs/hwm_store/memory_hwm_store.rst
@@ -6,4 +6,4 @@ In-memory HWM Store (ephemeral)
 .. currentmodule:: onetl.hwm.store.memory_hwm_store
 
 .. autoclass:: MemoryHWMStore
-    :members: __init__
+    :members: get, save, clear, __enter__

--- a/docs/hwm_store/yaml_hwm_store.rst
+++ b/docs/hwm_store/yaml_hwm_store.rst
@@ -6,4 +6,4 @@ YAML HWM Store (local, default)
 .. currentmodule:: onetl.hwm.store.yaml_hwm_store
 
 .. autoclass:: YAMLHWMStore
-    :members: __init__
+    :members: get, save, __enter__

--- a/onetl/_internal.py
+++ b/onetl/_internal.py
@@ -55,7 +55,6 @@ def clear_statement(statement: str) -> str:
     """
 
     statement = statement.rstrip().lstrip("\n\r").rstrip(";")
-
     if statement.lower().strip().endswith("end"):
         statement += ";"
     return statement

--- a/onetl/base/base_connection.py
+++ b/onetl/base/base_connection.py
@@ -22,7 +22,7 @@ class BaseConnection(ABC):
 
     @abstractmethod
     def check(self):
-        """Check source availability.
+        """Check source availability. |support_hooks|
 
         If not, an exception will be raised.
 

--- a/onetl/base/base_db_connection.py
+++ b/onetl/base/base_db_connection.py
@@ -155,7 +155,7 @@ class BaseDBConnection(BaseConnection):
         end_at: Statement | None = None,
     ) -> DataFrame:
         """
-        Reads the source to dataframe.
+        Reads the source to dataframe. |support_hooks|
         """
 
     @abstractmethod
@@ -165,7 +165,7 @@ class BaseDBConnection(BaseConnection):
         target: str,
     ) -> None:
         """
-        Saves dataframe to a specific target
+        Saves dataframe to a specific target. |support_hooks|
         """
 
     @abstractmethod
@@ -178,5 +178,5 @@ class BaseDBConnection(BaseConnection):
         where: Any | None = None,
     ) -> tuple[Any, Any]:
         """
-        Get MIN and MAX values for the column in the source
+        Get MIN and MAX values for the column in the source. |support_hooks|
         """

--- a/onetl/base/base_file_connection.py
+++ b/onetl/base/base_file_connection.py
@@ -33,7 +33,7 @@ class BaseFileConnection(BaseConnection):
     @abstractmethod
     def path_exists(self, path: os.PathLike | str) -> bool:
         """
-        Check if specified path exists on remote filesystem.
+        Check if specified path exists on remote filesystem. |support_hooks|
 
         Parameters
         ----------
@@ -57,7 +57,7 @@ class BaseFileConnection(BaseConnection):
     @abstractmethod
     def is_file(self, path: os.PathLike | str) -> bool:
         """
-        Check if specified path is a file.
+        Check if specified path is a file. |support_hooks|
 
         Parameters
         ----------
@@ -85,7 +85,7 @@ class BaseFileConnection(BaseConnection):
     @abstractmethod
     def is_dir(self, path: os.PathLike | str) -> bool:
         """
-        Check if specified path is a directory.
+        Check if specified path is a directory. |support_hooks|
 
         Parameters
         ----------
@@ -113,7 +113,7 @@ class BaseFileConnection(BaseConnection):
     @abstractmethod
     def get_stat(self, path: os.PathLike | str) -> PathStatProtocol:
         """
-        Returns stats for a specific path.
+        Returns stats for a specific path. |support_hooks|
 
         Parameters
         ----------
@@ -141,7 +141,7 @@ class BaseFileConnection(BaseConnection):
     @abstractmethod
     def resolve_dir(self, path: os.PathLike | str) -> PathWithStatsProtocol:
         """
-        Returns directory at specific path, with stats.
+        Returns directory at specific path, with stats. |support_hooks|
 
         Parameters
         ----------
@@ -173,7 +173,7 @@ class BaseFileConnection(BaseConnection):
     @abstractmethod
     def resolve_file(self, path: os.PathLike | str) -> PathWithStatsProtocol:
         """
-        Returns file at specific path, with stats.
+        Returns file at specific path, with stats. |support_hooks|
 
         Parameters
         ----------
@@ -205,7 +205,7 @@ class BaseFileConnection(BaseConnection):
     @abstractmethod
     def create_dir(self, path: os.PathLike | str) -> PathWithStatsProtocol:
         """
-        Creates directory tree on remote filesystem.
+        Creates directory tree on remote filesystem. |support_hooks|
 
         Parameters
         ----------
@@ -232,7 +232,7 @@ class BaseFileConnection(BaseConnection):
     @abstractmethod
     def remove_file(self, path: os.PathLike | str) -> bool:
         """
-        Removes file on remote filesystem.
+        Removes file on remote filesystem. |support_hooks|
 
         If file does not exist, no exception is raised.
 
@@ -268,7 +268,7 @@ class BaseFileConnection(BaseConnection):
     @abstractmethod
     def remove_dir(self, path: os.PathLike | str, recursive: bool = False) -> bool:
         """
-        Remove directory or directory tree.
+        Remove directory or directory tree. |support_hooks|
 
         If directory does not exist, no exception is raised.
 
@@ -309,7 +309,7 @@ class BaseFileConnection(BaseConnection):
         replace: bool = False,
     ) -> PathWithStatsProtocol:
         """
-        Rename or move file on remote filesystem.
+        Rename or move file on remote filesystem. |support_hooks|
 
         .. warning::
 
@@ -359,7 +359,7 @@ class BaseFileConnection(BaseConnection):
         limits: Iterable[BaseFileLimit] | None = None,
     ) -> list[PathWithStatsProtocol]:
         """
-        Return list of child files/directories in a specific directory.
+        Return list of child files/directories in a specific directory. |support_hooks|
 
         Parameters
         ----------
@@ -404,7 +404,7 @@ class BaseFileConnection(BaseConnection):
         limits: Iterable[BaseFileLimit] | None = None,
     ) -> Iterable[tuple[PathWithStatsProtocol, list[PathWithStatsProtocol], list[PathWithStatsProtocol]]]:
         """
-        Walk into directory tree, and iterate over its content in all nesting levels.
+        Walk into directory tree, and iterate over its content in all nesting levels. |support_hooks|
 
         Just like :obj:`os.walk`, but with additional filter/limit logic.
 
@@ -457,7 +457,7 @@ class BaseFileConnection(BaseConnection):
         replace: bool = True,
     ) -> PathWithStatsProtocol:
         """
-        Downloads file from the remote filesystem to a local path.
+        Downloads file from the remote filesystem to a local path. |support_hooks|
 
         .. warning::
 
@@ -513,7 +513,7 @@ class BaseFileConnection(BaseConnection):
         replace: bool = False,
     ) -> PathWithStatsProtocol:
         """
-        Uploads local file to a remote filesystem.
+        Uploads local file to a remote filesystem. |support_hooks|
 
         .. warning::
 
@@ -564,7 +564,7 @@ class BaseFileConnection(BaseConnection):
     @abstractmethod
     def read_text(self, path: os.PathLike | str, encoding: str = "utf-8") -> str:
         r"""
-        Returns string content of a file at specific path.
+        Returns string content of a file at specific path. |support_hooks|
 
         Parameters
         ----------
@@ -598,7 +598,7 @@ class BaseFileConnection(BaseConnection):
     @abstractmethod
     def read_bytes(self, path: os.PathLike | str) -> bytes:
         """
-        Returns binary content of a file at specific path.
+        Returns binary content of a file at specific path. |support_hooks|
 
         Parameters
         ----------
@@ -634,7 +634,7 @@ class BaseFileConnection(BaseConnection):
         encoding: str = "utf-8",
     ) -> PathWithStatsProtocol:
         r"""
-        Writes string content to a file at specific path.
+        Writes string content to a file at specific path. |support_hooks|
 
         .. warning::
 
@@ -675,7 +675,7 @@ class BaseFileConnection(BaseConnection):
     @abstractmethod
     def write_bytes(self, path: os.PathLike | str, content: bytes) -> PathWithStatsProtocol:
         """
-        Writes bytes content to a file at specific path.
+        Writes bytes content to a file at specific path. |support_hooks|
 
         .. warning::
 

--- a/onetl/base/contains_get_df_schema.py
+++ b/onetl/base/contains_get_df_schema.py
@@ -34,6 +34,6 @@ class ContainsGetDFSchemaMethod(Protocol):
         columns: list[str] | None = None,
     ) -> StructType:
         """
-        Description of the dataframe schema.
+        Description of the dataframe schema. |support_hooks|
         """
         ...

--- a/onetl/connection/db_connection/clickhouse.py
+++ b/onetl/connection/db_connection/clickhouse.py
@@ -28,7 +28,7 @@ log = logging.getLogger(__name__)
 
 
 class Clickhouse(JDBCConnection):
-    """Clickhouse JDBC connection.
+    """Clickhouse JDBC connection. |support_hooks|
 
     Based on Maven package ``ru.yandex.clickhouse:clickhouse-jdbc:0.3.2``
     (`official Clickhouse JDBC driver <https://github.com/ClickHouse/clickhouse-jdbc>`_).

--- a/onetl/connection/db_connection/greenplum.py
+++ b/onetl/connection/db_connection/greenplum.py
@@ -43,6 +43,7 @@ from onetl.connection.db_connection.dialect_mixins.support_table_with_dbschema i
 )
 from onetl.connection.db_connection.jdbc_mixin import JDBCMixin
 from onetl.exception import MISSING_JVM_CLASS_MSG, TooManyParallelJobsError
+from onetl.hooks import slot, support_hooks
 from onetl.hwm import Statement
 from onetl.impl import GenericOptions
 from onetl.log import log_lines, log_with_indent
@@ -121,8 +122,9 @@ class ConnectionLimits:
         ).strip()
 
 
+@support_hooks
 class Greenplum(JDBCMixin, DBConnection):
-    """Greenplum connection.
+    """Greenplum connection. |support_hooks|
 
     Based on package ``io.pivotal:greenplum-spark:2.1.4``
     (`Pivotal connector for Spark <https://network.tanzu.vmware.com/products/vmware-greenplum#/releases/1287433/file_groups/13260>`_).
@@ -486,6 +488,7 @@ class Greenplum(JDBCMixin, DBConnection):
         parameters = "&".join(f"{k}={v}" for k, v in sorted(extra.items()))
         return f"jdbc:postgresql://{self.host}:{self.port}/{self.database}?{parameters}".rstrip("?")
 
+    @slot
     def read_df(
         self,
         source: str,
@@ -516,6 +519,7 @@ class Greenplum(JDBCMixin, DBConnection):
         log.info("|Spark| DataFrame successfully created from SQL statement ")
         return df
 
+    @slot
     def write_df(
         self,
         df: DataFrame,
@@ -536,6 +540,7 @@ class Greenplum(JDBCMixin, DBConnection):
 
         log.info("|%s| Table %r is successfully written", self.__class__.__name__, target)
 
+    @slot
     def get_df_schema(
         self,
         source: str,
@@ -555,6 +560,7 @@ class Greenplum(JDBCMixin, DBConnection):
 
         return df.schema
 
+    @slot
     def get_min_max_bounds(
         self,
         source: str,

--- a/onetl/connection/db_connection/hive.py
+++ b/onetl/connection/db_connection/hive.py
@@ -66,6 +66,7 @@ class HiveWriteMode(str, Enum):
             return cls.OVERWRITE_PARTITIONS
 
 
+@support_hooks
 class Hive(DBConnection):
     """Spark connection with Hive MetaStore support. |support_hooks|
 
@@ -525,10 +526,11 @@ class Hive(DBConnection):
 
         return validated_cluster
 
+    @slot
     @classmethod
     def get_current(cls, spark: SparkSession):
         """
-        Create connection for current cluster.
+        Create connection for current cluster. |support_hooks|
 
         .. note::
 
@@ -568,6 +570,7 @@ class Hive(DBConnection):
     def instance_url(self) -> str:
         return self.cluster
 
+    @slot
     def check(self):
         log.debug("|%s| Detecting current cluster...", self.__class__.__name__)
         current_cluster = self.slots.get_current_cluster()
@@ -589,12 +592,13 @@ class Hive(DBConnection):
 
         return self
 
+    @slot
     def sql(
         self,
         query: str,
     ) -> DataFrame:
         """
-        Lazily execute SELECT statement and return DataFrame.
+        Lazily execute SELECT statement and return DataFrame. |support_hooks|
 
         Same as ``spark.sql(query)``.
 
@@ -635,12 +639,13 @@ class Hive(DBConnection):
         log.info("|Spark| DataFrame successfully created from SQL statement")
         return df
 
+    @slot
     def execute(
         self,
         statement: str,
     ) -> None:
         """
-        Execute DDL or DML statement.
+        Execute DDL or DML statement. |support_hooks|
 
         Parameters
         ----------
@@ -693,6 +698,7 @@ class Hive(DBConnection):
         self._execute_sql(statement).collect()
         log.info("|%s| Call succeeded", self.__class__.__name__)
 
+    @slot
     def write_df(
         self,
         df: DataFrame,
@@ -718,6 +724,7 @@ class Hive(DBConnection):
             # mode="overwrite_table" should be used
             self._save_as_table(df, target, options)
 
+    @slot
     def read_df(
         self,
         source: str,
@@ -738,6 +745,7 @@ class Hive(DBConnection):
 
         return self.sql(sql_text)
 
+    @slot
     def get_df_schema(
         self,
         source: str,
@@ -753,6 +761,7 @@ class Hive(DBConnection):
         log.info("|%s| Schema fetched", self.__class__.__name__)
         return df.schema
 
+    @slot
     def get_min_max_bounds(
         self,
         source: str,

--- a/onetl/connection/db_connection/jdbc_mixin.py
+++ b/onetl/connection/db_connection/jdbc_mixin.py
@@ -24,6 +24,7 @@ from pydantic import Field, SecretStr
 
 from onetl._internal import clear_statement, stringify, to_camel  # noqa: WPS436
 from onetl.exception import MISSING_JVM_CLASS_MSG
+from onetl.hooks import slot, support_hooks
 from onetl.impl import FrozenModel, GenericOptions
 from onetl.log import log_lines
 
@@ -51,6 +52,7 @@ class StatementType(Enum):
     CALL = auto()
 
 
+@support_hooks
 class JDBCMixin(FrozenModel):
     """
     Compatibility layer between Python and Java SQL Module.
@@ -107,9 +109,10 @@ class JDBCMixin(FrozenModel):
     def jdbc_url(self) -> str:
         """JDBC Connection URL"""
 
+    @slot
     def close(self):
         """
-        Close all connections, opened by ``.fetch()``, ``.execute()`` or ``.check()`` methods.
+        Close all connections, opened by ``.fetch()``, ``.execute()`` or ``.check()`` methods. |support_hooks|
 
         Examples
         --------
@@ -142,6 +145,7 @@ class JDBCMixin(FrozenModel):
         # If current object is collected by GC, close all opened connections
         self.close()
 
+    @slot
     def check(self):
         self._check_driver_imported()
         log.info("|%s| Checking connection availability...", self.__class__.__name__)
@@ -159,13 +163,14 @@ class JDBCMixin(FrozenModel):
 
         return self
 
+    @slot
     def fetch(
         self,
         query: str,
         options: JDBCMixin.JDBCOptions | dict | None = None,
     ) -> DataFrame:
         """
-        **Immediately** execute SELECT statement **on Spark driver** and return in-memory DataFrame.
+        **Immediately** execute SELECT statement **on Spark driver** and return in-memory DataFrame. |support_hooks|
 
         Works almost the same like :obj:`~sql`, but calls JDBC driver directly.
 
@@ -257,13 +262,14 @@ class JDBCMixin(FrozenModel):
         )
         return df
 
+    @slot
     def execute(
         self,
         statement: str,
         options: JDBCMixin.JDBCOptions | dict | None = None,
     ) -> DataFrame | None:
         """
-        **Immediately** execute DDL, DML or procedure/function **on Spark driver**.
+        **Immediately** execute DDL, DML or procedure/function **on Spark driver**. |support_hooks|
 
         Returns DataFrame only if input is DML statement with ``RETURNING ...`` clause, or a procedure/function call.
         In other cases returns ``None``.

--- a/onetl/connection/db_connection/mongodb.py
+++ b/onetl/connection/db_connection/mongodb.py
@@ -36,6 +36,7 @@ from onetl.connection.db_connection.dialect_mixins.support_table_without_dbschem
     SupportTableWithoutDBSchema,
 )
 from onetl.exception import MISSING_JVM_CLASS_MSG
+from onetl.hooks import slot, support_hooks
 from onetl.hwm import Statement
 from onetl.impl import GenericOptions
 from onetl.log import log_dataframe_schema, log_json, log_options, log_with_indent
@@ -157,8 +158,9 @@ KNOWN_WRITE_OPTIONS = frozenset(
 )
 
 
+@support_hooks
 class MongoDB(DBConnection):
-    """MongoDB connection.
+    """MongoDB connection. |support_hooks|
 
     Based on package ``org.mongodb.spark:mongo-spark-connector``
     (`MongoDB connector for Spark <https://www.mongodb.com/docs/spark-connector/current/>`_)
@@ -528,6 +530,7 @@ class MongoDB(DBConnection):
                         "field. You cannot use aggregations or 'groupBy' clauses in 'where'",
                     )
 
+    @slot
     def pipeline(
         self,
         collection: str,
@@ -536,7 +539,7 @@ class MongoDB(DBConnection):
         options: PipelineOptions | dict | None = None,
     ):
         """
-        Execute a pipeline for a specific collection, and return DataFrame.
+        Execute a pipeline for a specific collection, and return DataFrame. |support_hooks|
 
         Almost like `Aggregation pipeline syntax <https://www.mongodb.com/docs/manual/core/aggregation-pipeline/>`_
         in MongoDB:
@@ -671,6 +674,7 @@ class MongoDB(DBConnection):
     def instance_url(self) -> str:
         return f"{self.__class__.__name__.lower()}://{self.host}:{self.port}/{self.database}"
 
+    @slot
     def check(self):
         self._check_driver_imported()
         log.info("|%s| Checking connection availability...", self.__class__.__name__)
@@ -687,6 +691,7 @@ class MongoDB(DBConnection):
 
         return self
 
+    @slot
     def get_min_max_bounds(
         self,
         source: str,
@@ -732,6 +737,7 @@ class MongoDB(DBConnection):
 
         return min_value, max_value
 
+    @slot
     def read_df(
         self,
         source: str,
@@ -779,6 +785,7 @@ class MongoDB(DBConnection):
         log.info("|Spark| DataFrame successfully created from SQL statement ")
         return df
 
+    @slot
     def write_df(
         self,
         df: DataFrame,

--- a/onetl/connection/db_connection/mssql.py
+++ b/onetl/connection/db_connection/mssql.py
@@ -23,7 +23,7 @@ from onetl.connection.db_connection.jdbc_connection import JDBCConnection
 
 
 class MSSQL(JDBCConnection):
-    """MSSQL JDBC connection.
+    """MSSQL JDBC connection. |support_hooks|
 
     Based on Maven package ``com.microsoft.sqlserver:mssql-jdbc:12.2.0.jre8``
     (`official MSSQL JDBC driver

--- a/onetl/connection/db_connection/mysql.py
+++ b/onetl/connection/db_connection/mysql.py
@@ -23,7 +23,7 @@ from onetl.connection.db_connection.jdbc_connection import JDBCConnection
 
 
 class MySQL(JDBCConnection):
-    """MySQL JDBC connection.
+    """MySQL JDBC connection. |support_hooks|
 
     Based on Maven package ``com.mysql:mysql-connector-j:8.0.33``
     (`official MySQL JDBC driver <https://dev.mysql.com/downloads/connector/j/8.0.html>`_).

--- a/onetl/connection/db_connection/oracle.py
+++ b/onetl/connection/db_connection/oracle.py
@@ -27,6 +27,7 @@ from pydantic import root_validator
 
 from onetl._internal import clear_statement  # noqa: WPS436
 from onetl.connection.db_connection.jdbc_connection import JDBCConnection
+from onetl.hooks import slot, support_hooks
 from onetl.log import BASE_LOG_INDENT, log_lines
 
 # do not import PySpark here, as we allow user to use `Oracle.package` for creating Spark session
@@ -61,8 +62,9 @@ class ErrorPosition:
         return 100 - self.level, self.line, self.position
 
 
+@support_hooks
 class Oracle(JDBCConnection):
-    """Oracle JDBC connection.
+    """Oracle JDBC connection. |support_hooks|
 
     Based on Maven package ``com.oracle.database.jdbc:ojdbc8:23.2.0.0``
     (`official Oracle JDBC driver <https://www.oracle.com/cis/database/technologies/appdev/jdbc-downloads.html>`_).
@@ -223,6 +225,7 @@ class Oracle(JDBCConnection):
 
         return f"{super().instance_url}/{self.service_name}"
 
+    @slot
     def execute(
         self,
         statement: str,

--- a/onetl/connection/db_connection/postgres.py
+++ b/onetl/connection/db_connection/postgres.py
@@ -34,7 +34,7 @@ from onetl.connection.db_connection.jdbc_connection import JDBCConnection
 
 
 class Postgres(JDBCConnection):
-    """PostgreSQL JDBC connection.
+    """PostgreSQL JDBC connection. |support_hooks|
 
     Based on Maven package ``org.postgresql:postgresql:42.6.0``
     (`official Postgres JDBC driver <https://jdbc.postgresql.org/>`_).

--- a/onetl/connection/db_connection/teradata.py
+++ b/onetl/connection/db_connection/teradata.py
@@ -23,7 +23,7 @@ from onetl.connection.db_connection.jdbc_connection import JDBCConnection
 
 
 class Teradata(JDBCConnection):
-    """Teradata JDBC connection.
+    """Teradata JDBC connection. |support_hooks|
 
     Based on package ``com.teradata.jdbc:terajdbc:17.20.00.15``
     (`official Teradata JDBC driver <https://downloads.teradata.com/download/connectivity/jdbc-driver>`_).

--- a/onetl/connection/file_connection/ftp.py
+++ b/onetl/connection/file_connection/ftp.py
@@ -26,6 +26,7 @@ from pydantic import SecretStr
 from onetl.base import PathStatProtocol
 from onetl.connection.file_connection.file_connection import FileConnection
 from onetl.connection.file_connection.mixins.rename_dir_mixin import RenameDirMixin
+from onetl.hooks import slot, support_hooks
 from onetl.impl import LocalPath, RemotePath
 from onetl.impl.remote_path_stat import RemotePathStat
 
@@ -50,8 +51,9 @@ except (ImportError, NameError) as e:
 log = getLogger(__name__)
 
 
+@support_hooks
 class FTP(FileConnection, RenameDirMixin):
-    """FTP file connection.
+    """FTP file connection. |support_hooks|
 
     Based on `FTPUtil library <https://pypi.org/project/ftputil/>`_.
 
@@ -111,6 +113,7 @@ class FTP(FileConnection, RenameDirMixin):
     def instance_url(self) -> str:
         return f"ftp://{self.host}:{self.port}"
 
+    @slot
     def path_exists(self, path: os.PathLike | str) -> bool:
         return self.client.path.exists(os.fspath(path))
 

--- a/onetl/connection/file_connection/ftps.py
+++ b/onetl/connection/file_connection/ftps.py
@@ -54,7 +54,7 @@ class TLSfix(ftplib.FTP_TLS):  # noqa: N801
 
 
 class FTPS(FTP):
-    """FTPS file connection.
+    """FTPS file connection. |support_hooks|
 
     Based on `FTPUtil library <https://pypi.org/project/ftputil/>`_.
 

--- a/onetl/connection/file_connection/hdfs.py
+++ b/onetl/connection/file_connection/hdfs.py
@@ -54,8 +54,9 @@ log = getLogger(__name__)
 ENTRY_TYPE = Tuple[str, dict]
 
 
+@support_hooks
 class HDFS(FileConnection, RenameDirMixin):
-    """HDFS file connection.
+    """HDFS file connection. |support_hooks|
 
     Powered by `HDFS Python client <https://pypi.org/project/hdfs/>`_.
 
@@ -573,10 +574,11 @@ class HDFS(FileConnection, RenameDirMixin):
 
         return values
 
+    @slot
     @classmethod
     def get_current(cls, **kwargs):
         """
-        Create connection for current cluster.
+        Create connection for current cluster. |support_hooks|
 
         Automatically sets up current cluster name as ``cluster``.
 
@@ -621,6 +623,7 @@ class HDFS(FileConnection, RenameDirMixin):
             return self.cluster
         return f"hdfs://{self.host}:{self.webhdfs_port}"
 
+    @slot
     def path_exists(self, path: os.PathLike | str) -> bool:
         return self.client.status(os.fspath(path), strict=False)
 

--- a/onetl/connection/file_connection/s3.py
+++ b/onetl/connection/file_connection/s3.py
@@ -20,6 +20,8 @@ import textwrap
 from logging import getLogger
 from typing import Any, Optional, Union
 
+from onetl.hooks import slot, support_hooks
+
 try:
     from minio import Minio, commonconfig
     from minio.datatypes import Object
@@ -48,8 +50,9 @@ from onetl.impl import LocalPath, RemoteDirectory, RemotePath, RemotePathStat
 log = getLogger(__name__)
 
 
+@support_hooks
 class S3(FileConnection):
-    """S3 file connection.
+    """S3 file connection. |support_hooks|
 
     Based on `minio-py client <https://pypi.org/project/minio/>`_.
 
@@ -131,6 +134,7 @@ class S3(FileConnection):
     def instance_url(self) -> str:
         return f"s3://{self.host}:{self.port}"
 
+    @slot
     def create_dir(self, path: os.PathLike | str) -> RemoteDirectory:
         # the method is overridden because S3 does not create a directory
         # and the method must return the created directory
@@ -145,6 +149,7 @@ class S3(FileConnection):
         log.info("|%s| Successfully created directory '%s'", self.__class__.__name__, remote_directory)
         return RemoteDirectory(path=remote_directory, stats=RemotePathStat())
 
+    @slot
     def path_exists(self, path: os.PathLike | str) -> bool:
         remote_path = RemotePath(os.fspath(path))
         if self._is_root(remote_path):

--- a/onetl/connection/file_connection/sftp.py
+++ b/onetl/connection/file_connection/sftp.py
@@ -26,6 +26,7 @@ from pydantic import FilePath, SecretStr
 
 from onetl.connection.file_connection.file_connection import FileConnection
 from onetl.connection.file_connection.mixins.rename_dir_mixin import RenameDirMixin
+from onetl.hooks import slot, support_hooks
 from onetl.impl import LocalPath, RemotePath
 
 try:
@@ -53,8 +54,9 @@ SSH_CONFIG_PATH = LocalPath("~/.ssh/config").expanduser().resolve()
 log = getLogger(__name__)
 
 
+@support_hooks
 class SFTP(FileConnection, RenameDirMixin):
-    """SFTP file connection.
+    """SFTP file connection. |support_hooks|
 
     Based on `Paramiko library <https://pypi.org/project/paramiko/>`_.
 
@@ -126,6 +128,7 @@ class SFTP(FileConnection, RenameDirMixin):
     def instance_url(self) -> str:
         return f"sftp://{self.host}:{self.port}"
 
+    @slot
     def path_exists(self, path: os.PathLike | str) -> bool:
         try:
             self.client.stat(os.fspath(path))

--- a/onetl/connection/file_connection/webdav.py
+++ b/onetl/connection/file_connection/webdav.py
@@ -29,6 +29,7 @@ from typing_extensions import Literal
 
 from onetl.connection.file_connection.file_connection import FileConnection
 from onetl.connection.file_connection.mixins.rename_dir_mixin import RenameDirMixin
+from onetl.hooks import slot, support_hooks
 from onetl.impl import LocalPath, RemotePath, RemotePathStat
 
 try:
@@ -52,8 +53,9 @@ log = getLogger(__name__)
 DATA_MODIFIED_FORMAT = "%a, %d %b %Y %H:%M:%S GMT"
 
 
+@support_hooks
 class WebDAV(FileConnection, RenameDirMixin):
-    """WebDAV file connection.
+    """WebDAV file connection. |support_hooks|
 
     Based on `WebdavClient3 library <https://pypi.org/project/webdavclient3/>`_.
 
@@ -135,6 +137,7 @@ class WebDAV(FileConnection, RenameDirMixin):
     def instance_url(self) -> str:
         return f"webdav://{self.host}:{self.port}"
 
+    @slot
     def path_exists(self, path: os.PathLike | str) -> bool:
         return self.client.check(os.fspath(path))
 

--- a/onetl/db/db_reader/db_reader.py
+++ b/onetl/db/db_reader/db_reader.py
@@ -11,6 +11,7 @@ from pydantic import Field, root_validator, validator
 from onetl._internal import uniq_ignore_case  # noqa: WPS436
 from onetl.base import BaseDBConnection
 from onetl.base.contains_get_df_schema import ContainsGetDFSchemaMethod
+from onetl.hooks import slot, support_hooks
 from onetl.impl import FrozenModel, GenericOptions
 from onetl.log import (
     entity_boundary_log,
@@ -28,9 +29,10 @@ if TYPE_CHECKING:
     from pyspark.sql.types import StructType
 
 
+@support_hooks
 class DBReader(FrozenModel):
     """Allows you to read data from a table with specified database connection
-    and parameters, and return its content as Spark dataframe
+    and parameters, and return its content as Spark dataframe. |support_hooks|
 
     .. note::
 
@@ -487,9 +489,10 @@ class DBReader(FrozenModel):
             **self._get_read_kwargs(),
         )
 
+    @slot
     def run(self) -> DataFrame:
         """
-        Reads data from source table and saves as Spark dataframe.
+        Reads data from source table and saves as Spark dataframe. |support_hooks|
 
         .. note::
 

--- a/onetl/db/db_writer/db_writer.py
+++ b/onetl/db/db_writer/db_writer.py
@@ -21,6 +21,7 @@ from etl_entities import Table
 from pydantic import Field, validator
 
 from onetl.base import BaseDBConnection
+from onetl.hooks import slot, support_hooks
 from onetl.impl import FrozenModel, GenericOptions
 from onetl.log import (
     entity_boundary_log,
@@ -35,8 +36,9 @@ if TYPE_CHECKING:
 log = getLogger(__name__)
 
 
+@support_hooks
 class DBWriter(FrozenModel):
-    """Class specifies schema and table where you can write your dataframe.
+    """Class specifies schema and table where you can write your dataframe. |support_hooks|
 
     Parameters
     ----------
@@ -174,9 +176,10 @@ class DBWriter(FrozenModel):
 
         return None
 
+    @slot
     def run(self, df: DataFrame):
         """
-        Method for writing your df to specified target.
+        Method for writing your df to specified target. |support_hooks|
 
         Parameters
         ----------

--- a/onetl/file/file_downloader/file_downloader.py
+++ b/onetl/file/file_downloader/file_downloader.py
@@ -30,6 +30,7 @@ from onetl.base.path_protocol import PathProtocol
 from onetl.file.file_downloader.download_result import DownloadResult
 from onetl.file.file_set import FileSet
 from onetl.file.filter.file_hwm import FileHWMFilter
+from onetl.hooks import slot, support_hooks
 from onetl.hwm.store import HWMClassRegistry
 from onetl.impl import (
     FailedRemoteFile,
@@ -58,9 +59,10 @@ log = logging.getLogger(__name__)
 DOWNLOAD_ITEMS_TYPE = OrderedSet[Tuple[RemotePath, LocalPath, Optional[LocalPath]]]
 
 
+@support_hooks
 class FileDownloader(FrozenModel):
     """Allows you to download files from a remote source with specified file connection
-    and parameters, and return an object with download result summary.
+    and parameters, and return an object with download result summary. |support_hooks|
 
     .. note::
 
@@ -231,9 +233,10 @@ class FileDownloader(FrozenModel):
 
     options: Options = Options()
 
+    @slot
     def run(self, files: Iterable[str | os.PathLike] | None = None) -> DownloadResult:  # noqa: WPS231
         """
-        Method for downloading files from source to local directory.
+        Method for downloading files from source to local directory. |support_hooks|
 
         .. note::
 
@@ -389,10 +392,11 @@ class FileDownloader(FrozenModel):
         self._log_result(result)
         return result
 
+    @slot
     def view_files(self) -> FileSet[RemoteFile]:
         """
         Get file list in the ``source_path``,
-        after ``filter``, ``limit`` and ``hwm`` applied (if any).
+        after ``filter``, ``limit`` and ``hwm`` applied (if any). |support_hooks|
 
         .. note::
 

--- a/onetl/file/file_mover/file_mover.py
+++ b/onetl/file/file_mover/file_mover.py
@@ -25,6 +25,7 @@ from onetl.base import BaseFileConnection, BaseFileFilter, BaseFileLimit
 from onetl.base.path_protocol import PathProtocol
 from onetl.file.file_mover.move_result import MoveResult
 from onetl.file.file_set import FileSet
+from onetl.hooks import slot, support_hooks
 from onetl.impl import (
     FailedRemoteFile,
     FileWriteMode,
@@ -48,9 +49,10 @@ log = logging.getLogger(__name__)
 MOVE_ITEMS_TYPE = OrderedSet[Tuple[RemotePath, RemotePath]]
 
 
+@support_hooks
 class FileMover(FrozenModel):
     """Allows you to move files between different directories in a filesystem,
-    and return an object with move result summary.
+    and return an object with move result summary. |support_hooks|
 
     .. note::
 
@@ -164,9 +166,10 @@ class FileMover(FrozenModel):
 
     options: Options = Options()
 
+    @slot
     def run(self, files: Iterable[str | os.PathLike] | None = None) -> MoveResult:  # noqa: WPS231
         """
-        Method for moving files from source to target directory.
+        Method for moving files from source to target directory. |support_hooks|
 
         Parameters
         ----------
@@ -304,10 +307,11 @@ class FileMover(FrozenModel):
         self._log_result(result)
         return result
 
+    @slot
     def view_files(self) -> FileSet[RemoteFile]:
         """
         Get file list in the ``source_path``,
-        after ``filter`` and ``limit`` applied (if any).
+        after ``filter`` and ``limit`` applied (if any). |support_hooks|
 
         Raises
         -------

--- a/onetl/file/file_uploader/file_uploader.py
+++ b/onetl/file/file_uploader/file_uploader.py
@@ -26,6 +26,7 @@ from onetl.base import BaseFileConnection
 from onetl.exception import DirectoryNotFoundError, NotAFileError
 from onetl.file.file_set import FileSet
 from onetl.file.file_uploader.upload_result import UploadResult
+from onetl.hooks import slot, support_hooks
 from onetl.impl import (
     FailedLocalFile,
     FileWriteMode,
@@ -43,9 +44,10 @@ log = logging.getLogger(__name__)
 UPLOAD_ITEMS_TYPE = OrderedSet[Tuple[LocalPath, RemotePath, Optional[RemotePath]]]
 
 
+@support_hooks
 class FileUploader(FrozenModel):
     """Allows you to upload files to a remote source with specified file connection
-    and parameters, and return an object with upload result summary.
+    and parameters, and return an object with upload result summary. |support_hooks|
 
     .. note::
 
@@ -158,9 +160,10 @@ class FileUploader(FrozenModel):
 
     options: Options = Options()
 
+    @slot
     def run(self, files: Iterable[str | os.PathLike] | None = None) -> UploadResult:
         """
-        Method for uploading files to remote host.
+        Method for uploading files to remote host. |support_hooks|
 
         Parameters
         ----------
@@ -318,9 +321,10 @@ class FileUploader(FrozenModel):
         self._log_result(result)
         return result
 
+    @slot
     def view_files(self) -> FileSet[LocalPath]:
         """
-        Get file list in the ``local_path``.
+        Get file list in the ``local_path``. |support_hooks|
 
         Raises
         -------

--- a/onetl/hooks/slot.py
+++ b/onetl/hooks/slot.py
@@ -6,7 +6,6 @@ import textwrap
 from collections import defaultdict
 from contextlib import ExitStack, suppress
 from functools import partial, wraps
-from types import FunctionType
 from typing import Any, Callable, ContextManager, TypeVar
 
 from typing_extensions import Protocol
@@ -31,7 +30,7 @@ def _unwrap_method(method: Callable) -> Callable:
 def get_hooks(cls: type, method_name: str) -> HookCollection:
     """Return all hooks registered for a specific method"""
 
-    method = _unwrap_method(cls.__dict__[method_name])
+    method = _unwrap_method(cls.__dict__.get(method_name, None))
     return getattr(method, "__hooks__", HookCollection())
 
 
@@ -446,7 +445,8 @@ def register_slot(cls: type, method_name: str):  # noqa: WPS231, WPS213, WPS212
 
 def _is_method(method: Callable) -> bool:
     """Checks whether class method is callable"""
-    return isinstance(method, (FunctionType, classmethod, staticmethod))
+    method = _unwrap_method(method)
+    return callable(method)
 
 
 def _is_private(method: Callable) -> bool:

--- a/onetl/hwm/store/base_hwm_store.py
+++ b/onetl/hwm/store/base_hwm_store.py
@@ -29,6 +29,19 @@ log = logging.getLogger(__name__)
 
 class BaseHWMStore(BaseModel, ABC):
     def __enter__(self):
+        """
+        HWM store context manager.
+
+        Enter this context to use this HWM store instance as current one (instead default).
+
+        Examples
+        --------
+
+        .. code:: python
+
+            with hwm_store:
+                db_reader.run()
+        """
         # hack to avoid circular imports
         from onetl.hwm.store import HWMStoreManager
 
@@ -45,16 +58,56 @@ class BaseHWMStore(BaseModel, ABC):
         HWMStoreManager.pop()
         return False
 
-    def __str__(self):
-        return self.__class__.__name__
-
     @abstractmethod
     def get(self, name: str) -> HWM | None:
-        ...
+        """
+        Get HWM by qualified name from HWM store. |support_hooks|
+
+        Parameters
+        ----------
+        name : str
+            HWM qualified name
+
+        Returns
+        -------
+        HWM object, if it exists in HWM store, or None
+
+        Examples
+        --------
+
+        .. code:: python
+
+            from etl_entities import IntHWM
+
+            # just to generate qualified name using HWM parts
+            empty_hwm = IntHWM(column=..., table=..., process=...)
+            real_hwm = hwm_store.get(empty_hwm.qualified_name)
+        """
 
     @abstractmethod
     def save(self, hwm: HWM) -> Any:
-        ...
+        """
+        Save HWM object to HWM Store. |support_hooks|
+
+        Parameters
+        ----------
+        hwm : :obj:`etl_entities.hwm.HWM`
+            HWM object
+
+        Returns
+        -------
+        HWM location, like URL of file path.
+
+        Examples
+        --------
+
+        .. code:: python
+
+            from etl_entities import IntHWM
+
+            hwm = IntHWM(value=..., column=..., table=..., process=...)
+            hwm_location = hwm_store.save(hwm)
+        """
 
     def _log_parameters(self) -> None:
         log.info("|onETL| Using %s as HWM Store", self.__class__.__name__)

--- a/onetl/hwm/store/memory_hwm_store.py
+++ b/onetl/hwm/store/memory_hwm_store.py
@@ -19,13 +19,15 @@ from typing import Dict
 from etl_entities import HWM
 from pydantic import PrivateAttr
 
+from onetl.hooks import slot, support_hooks
 from onetl.hwm.store.base_hwm_store import BaseHWMStore
 from onetl.hwm.store.hwm_store_class_registry import register_hwm_store_class
 
 
 @register_hwm_store_class("memory", "in-memory")
+@support_hooks
 class MemoryHWMStore(BaseHWMStore):
-    """In-memory local store for HWM values
+    """In-memory local store for HWM values. |support_hooks|
 
     .. note::
 
@@ -81,11 +83,17 @@ class MemoryHWMStore(BaseHWMStore):
 
     _data: Dict[str, HWM] = PrivateAttr(default_factory=dict)
 
+    @slot
     def get(self, name: str) -> HWM | None:
         return self._data.get(name, None)
 
+    @slot
     def save(self, hwm: HWM) -> None:
         self._data[hwm.qualified_name] = hwm
 
+    @slot
     def clear(self) -> None:
+        """
+        Clears all stored HWM values. |support_hooks|
+        """
         self._data.clear()

--- a/onetl/hwm/store/yaml_hwm_store.py
+++ b/onetl/hwm/store/yaml_hwm_store.py
@@ -23,6 +23,7 @@ from etl_entities import HWM, HWMTypeRegistry
 from platformdirs import user_data_dir
 from pydantic import validator
 
+from onetl.hooks import slot, support_hooks
 from onetl.hwm.store.base_hwm_store import BaseHWMStore
 from onetl.hwm.store.hwm_store_class_registry import (
     default_hwm_store_class,
@@ -35,8 +36,9 @@ DATA_PATH = LocalPath(user_data_dir("onETL", "ONEtools"))
 
 @default_hwm_store_class
 @register_hwm_store_class("yaml", "yml")
+@support_hooks
 class YAMLHWMStore(BaseHWMStore, FrozenModel):
-    r"""YAML local store for HWM values. Used as default HWM store.
+    r"""YAML local store for HWM values. Used as default HWM store. |support_hooks|
 
     Parameters
     ----------
@@ -166,6 +168,7 @@ class YAMLHWMStore(BaseHWMStore, FrozenModel):
         path.mkdir(parents=True, exist_ok=True)
         return path
 
+    @slot
     def get(self, name: str) -> HWM | None:
         data = self._load(name)
 
@@ -175,6 +178,7 @@ class YAMLHWMStore(BaseHWMStore, FrozenModel):
         latest = sorted(data, key=operator.itemgetter("modified_time"))[-1]
         return HWMTypeRegistry.parse(latest)
 
+    @slot
     def save(self, hwm: HWM) -> LocalPath:
         data = self._load(hwm.qualified_name)
         self._dump(hwm.qualified_name, [hwm.serialize()] + data)


### PR DESCRIPTION
## Change Summary

Added `@slot` decorator to public methods of classes.
`__init__` methods do not support hooks yet because pydantic v1 does not have method or validator type which returns `self`: https://github.com/pydantic/pydantic/issues/691

Small documentation improvements, see changelog.