### PR TITLE
[DOP-7051] Support parallel operations in file classes

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -173,12 +173,6 @@ Without docker-compose
     * Either move it to ``~/.ivy2/jars/``, or pass file path to ``CLASSPATH``
     * Set environment variable ``ONETL_DB_WITH_GREENPLUM=true`` to enable adding connector to Spark session
 
-Build image for running tests:
-
-.. code:: bash
-
-    docker-compose build
-
 Start all containers with dependencies:
 
 .. code:: bash

--- a/docs/changelog/next_release/57.feature.rst
+++ b/docs/changelog/next_release/57.feature.rst
@@ -1,0 +1,3 @@
+Add ``workers`` field to ``FileDownloader`` / ``FileUploader`` / ``FileMover``.``Options`` classes.
+
+This allows to speed up all file operations using parallel threads.

--- a/docs/changelog/next_release/57.improvement.1.rst
+++ b/docs/changelog/next_release/57.improvement.1.rst
@@ -1,0 +1,1 @@
+Remove duplicated checks for source file existence in ``FileDownloader`` / ``FileMover``.

--- a/docs/changelog/next_release/57.improvement.2.rst
+++ b/docs/changelog/next_release/57.improvement.2.rst
@@ -1,0 +1,1 @@
+Update default logging format to include thread name.

--- a/docs/file/file_downloader/file_downloader.rst
+++ b/docs/file/file_downloader/file_downloader.rst
@@ -16,5 +16,5 @@ File Downloader
 .. currentmodule:: onetl.file.file_downloader.file_downloader.FileDownloader
 
 .. autopydantic_model:: Options
-    :members: mode, delete_source
+    :members: mode, delete_source, workers
     :member-order: bysource

--- a/docs/file/file_mover/file_mover.rst
+++ b/docs/file/file_mover/file_mover.rst
@@ -19,4 +19,5 @@ File Mover
 .. currentmodule:: onetl.file.file_mover.file_mover.FileMover
 
 .. autopydantic_model:: Options
-    :members: mode
+    :members: mode, workers
+    :member-order: bysource

--- a/docs/file/file_uploader/file_uploader.rst
+++ b/docs/file/file_uploader/file_uploader.rst
@@ -19,4 +19,5 @@ File Uploader
 .. currentmodule:: onetl.file.file_uploader.file_uploader.FileUploader
 
 .. autopydantic_model:: Options
-    :members: mode, delete_local
+    :members: mode, delete_local, workers
+    :member-order: bysource

--- a/onetl/connection/file_connection/ftp.py
+++ b/onetl/connection/file_connection/ftp.py
@@ -136,11 +136,11 @@ class FTP(FileConnection, RenameDirMixin):
             session_factory=session_factory,
         )
 
-    def _is_client_closed(self) -> bool:
-        return self._client.closed
+    def _is_client_closed(self, client: FTPHost) -> bool:
+        return client.closed
 
-    def _close_client(self) -> None:
-        self._client.close()
+    def _close_client(self, client: FTPHost) -> None:
+        client.close()
 
     def _remove_dir(self, path: RemotePath) -> None:
         self.client.rmdir(os.fspath(path))

--- a/onetl/connection/file_connection/hdfs.py
+++ b/onetl/connection/file_connection/hdfs.py
@@ -31,7 +31,7 @@ from onetl.hooks import slot, support_hooks
 from onetl.impl import LocalPath, RemotePath, RemotePathStat
 
 try:
-    from hdfs import InsecureClient
+    from hdfs import Client, InsecureClient
 
     if TYPE_CHECKING:
         from hdfs.ext.kerberos import KerberosClient
@@ -676,12 +676,12 @@ class HDFS(FileConnection, RenameDirMixin):
 
         raise RuntimeError(f"Host {self.host!r} is not an active namenode")
 
-    def _get_client(self) -> KerberosClient | InsecureClient:
+    def _get_client(self) -> Client:
         host = self._get_host()
         conn_str = f"http://{host}:{self.webhdfs_port}"  # NOSONAR
 
         if self.user and (self.keytab or self.password):
-            from hdfs.ext.kerberos import KerberosClient
+            from hdfs.ext.kerberos import KerberosClient  # noqa: F811
 
             kinit(
                 self.user,
@@ -690,18 +690,16 @@ class HDFS(FileConnection, RenameDirMixin):
             )
             client = KerberosClient(conn_str, timeout=self.timeout)
         else:
-            from hdfs import InsecureClient  # noqa: F401, WPS442
+            from hdfs import InsecureClient  # noqa: F401, WPS442, F811
 
             client = InsecureClient(conn_str, user=self.user)
 
         return client
 
-    def _is_client_closed(self) -> bool:
-        # Underlying client does not support closing
+    def _is_client_closed(self, client: Client):
         return False
 
-    def _close_client(self) -> None:  # NOSONAR
-        # Underlying client does not support closing
+    def _close_client(self, client: Client) -> None:  # NOSONAR
         pass
 
     def _remove_dir(self, path: RemotePath) -> None:

--- a/onetl/connection/file_connection/s3.py
+++ b/onetl/connection/file_connection/s3.py
@@ -18,7 +18,7 @@ import io
 import os
 import textwrap
 from logging import getLogger
-from typing import Any, Optional, Union
+from typing import Optional, Union
 
 from onetl.hooks import slot, support_hooks
 
@@ -164,7 +164,7 @@ class S3(FileConnection):
 
         return False
 
-    def _get_client(self) -> Any:
+    def _get_client(self) -> Minio:
         return Minio(
             endpoint=f"{self.host}:{self.port}",
             access_key=self.access_key,
@@ -174,10 +174,10 @@ class S3(FileConnection):
             region=self.region,
         )
 
-    def _is_client_closed(self) -> bool:
-        return True
+    def _is_client_closed(self, client: Minio):
+        return False
 
-    def _close_client(self) -> None:
+    def _close_client(self, client: Minio) -> None:  # NOSONAR
         pass
 
     @staticmethod

--- a/onetl/connection/file_connection/sftp.py
+++ b/onetl/connection/file_connection/sftp.py
@@ -158,11 +158,11 @@ class SFTP(FileConnection, RenameDirMixin):
 
         return client.open_sftp()
 
-    def _is_client_closed(self) -> bool:
-        return not self._client.sock or self._client.sock.closed
+    def _is_client_closed(self, client: SFTPClient) -> bool:
+        return not client.sock or client.sock.closed
 
-    def _close_client(self) -> None:
-        self._client.close()
+    def _close_client(self, client: SFTPClient) -> None:
+        client.close()
 
     def _parse_user_ssh_config(self) -> tuple[str | None, str | None]:
         host_proxy = None

--- a/onetl/connection/file_connection/webdav.py
+++ b/onetl/connection/file_connection/webdav.py
@@ -21,7 +21,7 @@ import stat
 import textwrap
 from logging import getLogger
 from ssl import SSLContext
-from typing import Any, Optional, Union
+from typing import Optional, Union
 
 from etl_entities.instance import Host
 from pydantic import DirectoryPath, FilePath, SecretStr, root_validator
@@ -141,7 +141,7 @@ class WebDAV(FileConnection, RenameDirMixin):
     def path_exists(self, path: os.PathLike | str) -> bool:
         return self.client.check(os.fspath(path))
 
-    def _get_client(self) -> Any:
+    def _get_client(self) -> Client:
         options = {
             "webdav_hostname": f"{self.protocol}://{self.host}:{self.port}",
             "webdav_login": self.user,
@@ -153,10 +153,10 @@ class WebDAV(FileConnection, RenameDirMixin):
 
         return client
 
-    def _is_client_closed(self) -> bool:
-        pass
+    def _is_client_closed(self, client: Client):
+        return False
 
-    def _close_client(self) -> None:
+    def _close_client(self, client: Client) -> None:  # NOSONAR
         pass
 
     def _download_file(self, remote_file_path: RemotePath, local_file_path: LocalPath) -> None:

--- a/onetl/file/file_mover/file_mover.py
+++ b/onetl/file/file_mover/file_mover.py
@@ -16,13 +16,16 @@ from __future__ import annotations
 
 import logging
 import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from enum import Enum
 from typing import Iterable, List, Optional, Tuple
 
 from ordered_set import OrderedSet
 from pydantic import Field, validator
 
 from onetl.base import BaseFileConnection, BaseFileFilter, BaseFileLimit
-from onetl.base.path_protocol import PathProtocol
+from onetl.base.path_protocol import PathProtocol, PathWithStatsProtocol
+from onetl.base.pure_path_protocol import PurePathProtocol
 from onetl.file.file_mover.move_result import MoveResult
 from onetl.file.file_set import FileSet
 from onetl.hooks import slot, support_hooks
@@ -47,6 +50,13 @@ log = logging.getLogger(__name__)
 
 # source, target
 MOVE_ITEMS_TYPE = OrderedSet[Tuple[RemotePath, RemotePath]]
+
+
+class FileMoveStatus(Enum):
+    SUCCESSFUL = 0
+    FAILED = 1
+    SKIPPED = 2
+    MISSING = -1
 
 
 @support_hooks
@@ -154,6 +164,16 @@ class FileMover(FrozenModel):
             * ``ignore`` - do nothing, mark file as ignored
             * ``overwrite`` - replace existing file with a new one
             * ``delete_all`` - delete directory content before moving files
+        """
+
+        workers: int = Field(default=1, ge=1)
+        """
+        Number of workers to create for parallel file moving.
+
+        1 (default) means files will me moved sequentially.
+        2 or more means files will be moved in parallel workers.
+
+        Recommended value is ``min(32, os.cpu_count() + 4)``, e.g. ``5``.
         """
 
     connection: BaseFileConnection
@@ -426,7 +446,7 @@ class FileMover(FrozenModel):
                     # Wrong path (not relative path and source path not in the path to the file)
                     raise ValueError(f"File path '{old_file}' does not match source_path '{self.source_path}'")
 
-            if self.connection.path_exists(old_file):
+            if not isinstance(old_file, PathProtocol) and self.connection.path_exists(old_file):
                 old_file = self.connection.resolve_file(old_file)
 
             result.add((old_file, new_file))
@@ -451,25 +471,61 @@ class FileMover(FrozenModel):
         self,
         to_move: MOVE_ITEMS_TYPE,
     ) -> MoveResult:
-        total_files = len(to_move)
         files = FileSet(item[0] for item in to_move)
-
         log.info("|%s| Files to be moved:", self.__class__.__name__)
         log_lines(str(files))
         log_with_indent("")
         log.info("|%s| Starting the move process", self.__class__.__name__)
 
-        result = MoveResult()
-        for i, (source_file, target_file) in enumerate(to_move):
-            log.info("|%s| Moving file %d of %d", self.__class__.__name__, i + 1, total_files)
-            log_with_indent("from = '%s'", source_file)
-            log_with_indent("to = '%s'", target_file)
+        self._create_dirs(to_move)
 
-            self._move_file(
-                source_file,
-                target_file,
-                result,
-            )
+        result = MoveResult()
+        for status, file in self._bulk_move(to_move):
+            if status == FileMoveStatus.SUCCESSFUL:
+                result.successful.add(file)
+            elif status == FileMoveStatus.FAILED:
+                result.failed.add(file)
+            elif status == FileMoveStatus.SKIPPED:
+                result.skipped.add(file)
+            elif status == FileMoveStatus.MISSING:
+                result.missing.add(file)
+
+        return result
+
+    def _create_dirs(
+        self,
+        to_move: MOVE_ITEMS_TYPE,
+    ) -> None:
+        """
+        Create all parent paths before moving files
+        This is required to avoid errors then multiple threads create the same dir
+        """
+        parent_paths = OrderedSet(target_file.parent for _, target_file in to_move)
+        for parent_path in parent_paths:
+            self.connection.create_dir(parent_path)
+
+    def _bulk_move(
+        self,
+        to_move: MOVE_ITEMS_TYPE,
+    ) -> list[tuple[FileMoveStatus, PurePathProtocol | PathWithStatsProtocol]]:
+        workers = self.options.workers
+        result = []
+
+        if workers > 1:
+            with ThreadPoolExecutor(max_workers=workers, thread_name_prefix=self.__class__.__name__) as executor:
+                futures = [
+                    executor.submit(self._move_file, source_file, target_file) for source_file, target_file in to_move
+                ]
+                for future in as_completed(futures):
+                    result.append(future.result())
+        else:
+            for source_file, target_file in to_move:
+                result.append(
+                    self._move_file(
+                        source_file,
+                        target_file,
+                    ),
+                )
 
         return result
 
@@ -477,12 +533,12 @@ class FileMover(FrozenModel):
         self,
         source_file: RemotePath,
         target_file: RemotePath,
-        result: MoveResult,
-    ) -> None:
+    ) -> tuple[FileMoveStatus, PurePathProtocol | PathWithStatsProtocol]:
+        log.info("|%s| Moving file '%s' to '%s'", self.__class__.__name__, source_file, target_file)
+
         if not self.connection.path_exists(source_file):
             log.warning("|%s| Missing file '%s', skipping", self.__class__.__name__, source_file)
-            result.missing.add(source_file)
-            return
+            return FileMoveStatus.MISSING, source_file
 
         try:
             replace = False
@@ -498,13 +554,12 @@ class FileMover(FrozenModel):
                         self.connection.__class__.__name__,
                         path_repr(new_file),
                     )
-                    result.skipped.add(source_file)
-                    return
+                    return FileMoveStatus.SKIPPED, source_file
 
                 replace = True
 
             new_file = self.connection.rename_file(source_file, target_file, replace=replace)
-            result.successful.add(new_file)
+            return FileMoveStatus.SUCCESSFUL, new_file
 
         except Exception as e:
             if log.isEnabledFor(logging.DEBUG):
@@ -520,7 +575,7 @@ class FileMover(FrozenModel):
                     e,
                     exc_info=False,
                 )
-            result.failed.add(FailedRemoteFile(path=source_file.path, stats=source_file.stats, exception=e))
+            return FileMoveStatus.FAILED, FailedRemoteFile(path=source_file.path, stats=source_file.stats, exception=e)
 
     def _log_result(self, result: MoveResult) -> None:
         log_with_indent("")

--- a/onetl/file/file_uploader/file_uploader.py
+++ b/onetl/file/file_uploader/file_uploader.py
@@ -16,13 +16,17 @@ from __future__ import annotations
 
 import logging
 import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from enum import Enum
 from typing import Iterable, Optional, Tuple
 
 from ordered_set import OrderedSet
-from pydantic import validator
+from pydantic import Field, validator
 
 from onetl._internal import generate_temp_path  # noqa: WPS436
 from onetl.base import BaseFileConnection
+from onetl.base.path_protocol import PathWithStatsProtocol
+from onetl.base.pure_path_protocol import PurePathProtocol
 from onetl.exception import DirectoryNotFoundError, NotAFileError
 from onetl.file.file_set import FileSet
 from onetl.file.file_uploader.upload_result import UploadResult
@@ -42,6 +46,13 @@ log = logging.getLogger(__name__)
 
 # source, target, temp
 UPLOAD_ITEMS_TYPE = OrderedSet[Tuple[LocalPath, RemotePath, Optional[RemotePath]]]
+
+
+class FileUploadStatus(Enum):
+    SUCCESSFUL = 0
+    FAILED = 1
+    SKIPPED = 2
+    MISSING = -1
 
 
 @support_hooks
@@ -149,6 +160,16 @@ class FileUploader(FrozenModel):
         If ``True``, remove local file after successful download.
 
         If download failed, file will left intact.
+        """
+
+        workers: int = Field(default=1, ge=1)
+        """
+        Number of workers to create for parallel file upload.
+
+        1 (default) means files will me uploaded sequentially.
+        2 or more means files will be uploaded in parallel workers.
+
+        Recommended value is ``min(32, os.cpu_count() + 4)``, e.g. ``5``.
         """
 
     connection: BaseFileConnection
@@ -465,23 +486,68 @@ class FileUploader(FrozenModel):
             raise NotADirectoryError(f"{path_repr(self.local_path)} is not a directory")
 
     def _upload_files(self, to_upload: UPLOAD_ITEMS_TYPE) -> UploadResult:
-        total_files = len(to_upload)
         files = FileSet(item[0] for item in to_upload)
-
         log.info("|%s| Files to be uploaded:", self.__class__.__name__)
         log_lines(str(files))
         log_with_indent("")
         log.info("|%s| Starting the upload process", self.__class__.__name__)
 
-        result = UploadResult()
-        for i, (local_file, target_file, tmp_file) in enumerate(to_upload):
-            log.info("|%s| Uploading file %d of %d", self.__class__.__name__, i + 1, total_files)
-            log_with_indent("from = '%s'", local_file)
-            if tmp_file:
-                log_with_indent("temp = '%s'", tmp_file)
-            log_with_indent("to = '%s'", target_file)
+        self._create_dirs(to_upload)
 
-            self._upload_file(local_file, target_file, tmp_file, result)
+        result = UploadResult()
+        for status, file in self._bulk_upload(to_upload):
+            if status == FileUploadStatus.SUCCESSFUL:
+                result.successful.add(file)
+            elif status == FileUploadStatus.FAILED:
+                result.failed.add(file)
+            elif status == FileUploadStatus.SKIPPED:
+                result.skipped.add(file)
+            elif status == FileUploadStatus.MISSING:
+                result.missing.add(file)
+
+        return result
+
+    def _create_dirs(
+        self,
+        to_upload: UPLOAD_ITEMS_TYPE,
+    ) -> None:
+        """
+        Create all parent paths before uploading files
+        This is required to avoid errors then multiple threads create the same dir
+        """
+        parent_paths = OrderedSet()
+        for _, target_file, tmp_file in to_upload:
+            parent_paths.add(target_file.parent)
+            if tmp_file:
+                parent_paths.add(tmp_file.parent)
+
+        for parent_path in parent_paths:
+            self.connection.create_dir(parent_path)
+
+    def _bulk_upload(
+        self,
+        to_upload: UPLOAD_ITEMS_TYPE,
+    ) -> list[tuple[FileUploadStatus, PurePathProtocol | PathWithStatsProtocol]]:
+        workers = self.options.workers
+        result = []
+
+        if workers > 1:
+            with ThreadPoolExecutor(max_workers=workers, thread_name_prefix=self.__class__.__name__) as executor:
+                futures = [
+                    executor.submit(self._upload_file, local_file, target_file, tmp_file)
+                    for local_file, target_file, tmp_file in to_upload
+                ]
+                for future in as_completed(futures):
+                    result.append(future.result())
+        else:
+            for local_file, target_file, tmp_file in to_upload:
+                result.append(
+                    self._upload_file(
+                        local_file,
+                        target_file,
+                        tmp_file,
+                    ),
+                )
 
         return result
 
@@ -490,12 +556,21 @@ class FileUploader(FrozenModel):
         local_file: LocalPath,
         target_file: RemotePath,
         tmp_file: RemotePath | None,
-        result: UploadResult,
-    ) -> None:
+    ) -> tuple[FileUploadStatus, PurePathProtocol | PathWithStatsProtocol]:
+        if tmp_file:
+            log.info(
+                "|%s| Uploading file '%s' to '%s' (via tmp '%s')",
+                self.__class__.__name__,
+                local_file,
+                target_file,
+                tmp_file,
+            )
+        else:
+            log.info("|%s| Uploading file '%s' to '%s'", self.__class__.__name__, local_file, target_file)
+
         if not local_file.exists():
             log.warning("|%s| Missing file '%s', skipping", self.__class__.__name__, local_file)
-            result.missing.add(local_file)
-            return
+            return FileUploadStatus.MISSING, local_file
 
         try:
             replace = False
@@ -506,8 +581,7 @@ class FileUploader(FrozenModel):
 
                 if self.options.mode == FileWriteMode.IGNORE:
                     log.warning("|%s| File %s already exists, skipping", self.__class__.__name__, path_repr(file))
-                    result.skipped.add(local_file)
-                    return
+                    return FileUploadStatus.SKIPPED, local_file
 
                 replace = True
 
@@ -525,7 +599,7 @@ class FileUploader(FrozenModel):
                 local_file.unlink()
                 log.warning("|Local FS| Successfully removed file %s", local_file)
 
-            result.successful.add(uploaded_file)
+            return FileUploadStatus.SUCCESSFUL, uploaded_file
 
         except Exception as e:
             if log.isEnabledFor(logging.DEBUG):
@@ -533,7 +607,7 @@ class FileUploader(FrozenModel):
             else:
                 log.exception("|%s| Couldn't upload file to target dir: %s", self.__class__.__name__, e, exc_info=False)
 
-            result.failed.add(FailedLocalFile(path=local_file, exception=e))
+            return FileUploadStatus.FAILED, FailedLocalFile(path=local_file, exception=e)
 
     def _remove_temp_dir(self, temp_dir: RemotePath) -> None:
         try:

--- a/onetl/log.py
+++ b/onetl/log.py
@@ -33,7 +33,7 @@ root_log = logging.getLogger()
 
 HALF_SCREEN_SIZE = 45
 BASE_LOG_INDENT = 8
-LOG_FORMAT = "%(asctime)s [%(levelname)-8s] %(message)s"
+LOG_FORMAT = "%(asctime)s [%(levelname)-8s] %(threadName)s: %(message)s"
 CLIENT_MODULES = {"hdfs", "paramiko", "ftputil", "smbclient"}
 
 DISABLED = 9999  # CRITICAL is 50, we need even higher to disable all logs

--- a/tests/tests_integration/tests_core_integration/test_file_downloader_integration.py
+++ b/tests/tests_integration/tests_core_integration/test_file_downloader_integration.py
@@ -53,6 +53,7 @@ def test_downloader_view_file(file_all_connections, source_path, upload_test_fil
     [str, Path],
     ids=["run_path_type str", "run_path_type Path"],
 )
+@pytest.mark.parametrize("workers", [1, 3])
 def test_downloader_run(
     file_all_connections,
     source_path,
@@ -60,6 +61,7 @@ def test_downloader_run(
     path_type,
     run_path_type,
     tmp_path_factory,
+    workers,
 ):
     local_path = tmp_path_factory.mktemp("local_path")
 
@@ -67,6 +69,9 @@ def test_downloader_run(
         connection=file_all_connections,
         source_path=path_type(source_path),
         local_path=run_path_type(local_path),
+        options=FileDownloader.Options(
+            workers=workers,
+        ),
     )
 
     download_result = downloader.run()

--- a/tests/tests_integration/tests_core_integration/test_file_mover_integration.py
+++ b/tests/tests_integration/tests_core_integration/test_file_mover_integration.py
@@ -35,12 +35,14 @@ def test_mover_view_file(file_all_connections, source_path, upload_test_files):
 
 
 @pytest.mark.parametrize("path_type", [str, PurePosixPath], ids=["path_type str", "path_type PurePosixPath"])
+@pytest.mark.parametrize("workers", [1, 3])
 def test_mover_run(
     request,
     file_all_connections,
     source_path,
     upload_test_files,
     path_type,
+    workers,
 ):
     target_path = f"/tmp/test_upload_{secrets.token_hex(5)}"
 
@@ -53,6 +55,9 @@ def test_mover_run(
         connection=file_all_connections,
         source_path=path_type(source_path),
         target_path=path_type(target_path),
+        options=FileMover.Options(
+            workers=workers,
+        ),
     )
 
     # record files content and size before move

--- a/tests/tests_integration/tests_core_integration/test_file_uploader_integration.py
+++ b/tests/tests_integration/tests_core_integration/test_file_uploader_integration.py
@@ -40,7 +40,8 @@ def test_uploader_view_files(file_all_connections, resource_path):
     [str, Path],
     ids=["run_path_type str", "run_path_type Path"],
 )
-def test_uploader_run_with_files(request, file_all_connections, test_files, run_path_type, path_type):
+@pytest.mark.parametrize("workers", [1, 3])
+def test_uploader_run_with_files(request, file_all_connections, test_files, run_path_type, path_type, workers):
     target_path = path_type(f"/tmp/test_upload_{secrets.token_hex(5)}")
 
     def finalizer():
@@ -52,6 +53,9 @@ def test_uploader_run_with_files(request, file_all_connections, test_files, run_
     uploader = FileUploader(
         connection=file_all_connections,
         target_path=target_path,
+        options=FileUploader.Options(
+            workers=workers,
+        ),
     )
 
     upload_result = uploader.run(run_path_type(file) for file in test_files)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

<!-- Please give a short summary of the changes. -->

Uploading/downloading/moving files one by one maybe OK for small number of files, but definitely not for many. For example, uploading 1k files to HDFS takes about 13 minutes - namenode ensures that file blocks are replicated to proper number of data nodes, and responses to client only after that, and the rest of files are waiting for that.

All these operations are IO-bound tasks, so Python releases GIL, and we can use threads to run them in parallel.

That was changed:
* Internal implementation of `FileMover`/`FileDownloader`/`FileUploader` was enhanced to use `ThreadPoolExecutor` for parallel file operations.
* `FileMover`.`Options` / `FileDownloader`.`Options` / `FileUploader`.`Options` classes got new option `workers: int` which can be set by user to switch between plain old `for` loop and `ThreadPoolExecutor` with specific number of workers.
* Internal implementation of `FileConnection.client` and related `_get_client`/`_is_client_closed`/`_close_client` was updated to create and cache a separated client for each thread, avoiding issues with using non-thread safe client implementations (most of them are not safe).
* Skipped duplicated check for `source_file`/`local_file` existance - it was performed both before and during file handling process.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [X] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
