### PR TITLE
[DOP-7104] Fix S3.list_dir('/') returns empty list on latest Minio version

### DIFF
--- a/.github/workflows/data/s3/matrix.yml
+++ b/.github/workflows/data/s3/matrix.yml
@@ -8,13 +8,13 @@ max: &max
 
 matrix:
   small:
-  - minio-version: 2023.4.28
+  - minio-version: 2023.6.23
     <<: *max
   full:
   # prior image versions returns empty content of bucket root, some kind of bug
   - minio-version: 2021.3.17
     <<: *min
-  - minio-version: 2023.4.28
+  - minio-version: 2023.6.23
     <<: *max
   nightly:
   - minio-version: 2021.3.17

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -253,7 +253,7 @@ jobs:
       os: ${{ matrix.os }}
 
   tests-webdav:
-    name: Run WebDAV tests (server=${{ matrix.openwebdavssh-version }}, python=${{ matrix.python-version }}, os=${{ matrix.os }})
+    name: Run WebDAV tests (server=${{ matrix.webdav-version }}, python=${{ matrix.python-version }}, os=${{ matrix.os }})
     needs: [get-matrix]
     strategy:
       fail-fast: false

--- a/docs/changelog/next_release/58.bugfix.rst
+++ b/docs/changelog/next_release/58.bugfix.rst
@@ -1,0 +1,1 @@
+Fix S3.list_dir('/') returns empty list on latest Minio version.

--- a/onetl/connection/file_connection/s3.py
+++ b/onetl/connection/file_connection/s3.py
@@ -237,7 +237,7 @@ class S3(FileConnection):
 
     def _scan_entries(self, path: RemotePath) -> list[Object]:
         if self._is_root(path):
-            self.client.list_objects(self.bucket)
+            return self.client.list_objects(self.bucket)
 
         path_str = self._delete_absolute_path_slash(path)
         return self.client.list_objects(self.bucket, prefix=path_str + "/")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Fix S3.list_dir('/') returned empty list on latest Minio version. Fixed.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [X] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
