### PR TITLE
[DOP-7206] Allow to skip changelog CI check

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     types: [opened, synchronize, labeled, unlabeled, reopened]
     branches-ignore:
-    - dependabot/**
-    - pre-commit-ci-update-config
     - master
 
 env:
@@ -19,6 +17,7 @@ jobs:
     name: Changelog Entry Check
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    if: "!contains(github.event.pull_request.labels.*.name, 'ci:skip-changelog') && github.event.pull_request.user.login != 'pre-commit-ci[bot]' && github.event.pull_request.user.login != 'dependabot[bot]'"
     steps:
     - name: Checkout code
       uses: actions/checkout@v3

--- a/docs/changelog/README.rst
+++ b/docs/changelog/README.rst
@@ -90,3 +90,8 @@ Examples for adding changelog entries to your Pull Requests
 
 .. _Towncrier philosophy:
     https://towncrier.readthedocs.io/en/stable/#philosophy
+
+How to skip change notes check?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Just add ``ci:skip-changelog`` label to pull request.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Adding `ci:skip-changelog` disables changelog check step.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [ ] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
