### PR TITLE
[DOP-2329] Generate config for authorization in Kafka

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         wget \
         procps \
-        openjdk-11-jdk \
+        openjdk-17-jdk \
         libsasl2-modules \
         libsasl2-dev \
         libaio1 \

--- a/docs/changelog/next_release/63.feature.rst
+++ b/docs/changelog/next_release/63.feature.rst
@@ -1,0 +1,1 @@
+Generate config for authorization in Kafka.

--- a/onetl/connection/db_connection/kafka.py
+++ b/onetl/connection/db_connection/kafka.py
@@ -234,17 +234,17 @@ class Kafka(DBConnection):
         hash_object.update(value.encode("utf-8"))
         return hash_object.hexdigest()
 
-    def _get_jaas_conf(self):
+    def _get_jaas_conf(self) -> Optional[str]:
         service_name = self._calculate_hash(
             f"{self.addresses}{self.user}{self.cluster}",
         )
         if self.password is not None:
             return self._password_jaas(service_name, self.password)
 
-        if self.keytab is None:
-            raise ValueError("keytab path is None")
+        if self.keytab is not None:
+            return self._prepare_jaas_for_keytab(service_name, self.keytab)
 
-        return self._prepare_jaas_for_keytab(service_name, self.keytab)
+        return None
 
     def _prepare_jaas_for_keytab(self, service_name, keytab: LocalPath) -> str:
         if self.deploy_keytab:

--- a/setup.cfg
+++ b/setup.cfg
@@ -333,6 +333,8 @@ per-file-ignores =
 # WPS210 Found too many local variables
         WPS210,
     tests/*:
+# Found too many empty lines in `def`
+        WPS473,
 # TAE001 too few type annotations
         TAE001,
 # U100 Unused argument

--- a/tests/tests_integration/tests_db_connection_integration/test_kafka_integration.py
+++ b/tests/tests_integration/tests_db_connection_integration/test_kafka_integration.py
@@ -1,4 +1,7 @@
+import re
 from pathlib import Path
+
+import pytest
 
 from onetl.connection import Kafka
 
@@ -22,3 +25,16 @@ def test_kafka_connection_get_jaas_conf_deploy_keytab_true(spark, create_keytab)
     assert cloned_keytab.exists()
     assert cloned_keytab.read_text() == create_keytab.read_text()
     cloned_keytab.unlink()
+
+
+def test_kafka_connection_get_jaas_conf_deploy_keytab_true_error(spark):
+    # Assert
+    # deploy_keytab=True by default
+    with pytest.raises(ValueError, match=re.escape("File '/not/a/keytab' is missing")):
+        Kafka(
+            spark=spark,
+            addresses=["some_address"],
+            user="user",
+            cluster="cluster",
+            keytab="/not/a/keytab",
+        )

--- a/tests/tests_integration/tests_db_connection_integration/test_kafka_integration.py
+++ b/tests/tests_integration/tests_db_connection_integration/test_kafka_integration.py
@@ -8,6 +8,7 @@ from onetl.connection import Kafka
 
 def test_kafka_connection_get_jaas_conf_deploy_keytab_true(spark, create_keytab):
     # Arrange
+    cloned_keytab = Path("./keytab")
     # deploy_keytab=True by default
     kafka = Kafka(
         spark=spark,
@@ -17,11 +18,12 @@ def test_kafka_connection_get_jaas_conf_deploy_keytab_true(spark, create_keytab)
         keytab=create_keytab,
     )
 
+    assert not cloned_keytab.exists()
+
     # Act
     kafka._get_jaas_conf()
 
     # Assert
-    cloned_keytab = Path("./keytab")
     assert cloned_keytab.exists()
     assert cloned_keytab.read_text() == create_keytab.read_text()
     cloned_keytab.unlink()

--- a/tests/tests_integration/tests_db_connection_integration/test_kafka_integration.py
+++ b/tests/tests_integration/tests_db_connection_integration/test_kafka_integration.py
@@ -1,0 +1,25 @@
+import os
+from pathlib import Path
+
+from onetl.connection import Kafka
+
+
+def test_kafka_connection_get_jaas_conf_deploy_keytab_true(spark, create_keytab):
+    # Arrange
+    # deploy_keytab=True by default
+    kafka = Kafka(
+        spark=spark,
+        addresses=["some_address"],
+        user="user",
+        cluster="cluster",
+        keytab=create_keytab,
+    )
+
+    # Act
+    kafka._get_jaas_conf()
+
+    # Assert
+    assert os.path.exists("./keytab")
+    assert Path("./keytab").read_text() == create_keytab.read_text()
+
+    os.unlink("./keytab")

--- a/tests/tests_integration/tests_db_connection_integration/test_kafka_integration.py
+++ b/tests/tests_integration/tests_db_connection_integration/test_kafka_integration.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 from onetl.connection import Kafka
@@ -19,7 +18,7 @@ def test_kafka_connection_get_jaas_conf_deploy_keytab_true(spark, create_keytab)
     kafka._get_jaas_conf()
 
     # Assert
-    assert os.path.exists("./keytab")
-    assert Path("./keytab").read_text() == create_keytab.read_text()
-
-    os.unlink("./keytab")
+    cloned_keytab = Path("./keytab")
+    assert cloned_keytab.exists()
+    assert cloned_keytab.read_text() == create_keytab.read_text()
+    cloned_keytab.unlink()

--- a/tests/tests_unit/tests_db_connection_unit/test_kafka_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_kafka_unit.py
@@ -256,9 +256,9 @@ def test_kafka_connection_get_jaas_conf_password(spark_mock):
     # Assert
     assert conf == (
         "org.apache.kafka.common.security.plain.PlainLoginModule required\n"
-        'serviceName="a3d4d08729f94e64acfa5b5ef6caa3b1"\n'
+        'serviceName="e21047b5be0df7652cd99feb4168e887"\n'
         'username="user"\n'
-        'password="**********";'
+        'password="password";'
     )
 
 
@@ -281,7 +281,7 @@ def test_kafka_connection_get_jaas_conf_deploy_keytab_false(spark_mock, create_k
         "com.sun.security.auth.module.Krb5LoginModule required\n"
         f'keyTab="{create_keytab}"\n'
         'principal="user"\n'
-        'serviceName="3a4df6708d55e431d32237f3cf8e8a63"\n'
+        'serviceName="e21047b5be0df7652cd99feb4168e887"\n'
         "renewTicket=true\n"
         "storeKey=true\n"
         "useKeyTab=true\n"
@@ -308,7 +308,7 @@ def test_kafka_connection_get_jaas_conf_deploy_keytab_true(spark_mock, create_ke
         "com.sun.security.auth.module.Krb5LoginModule required\n"
         f'keyTab="{create_keytab.name}"\n'
         'principal="user"\n'
-        'serviceName="3a4df6708d55e431d32237f3cf8e8a63"\n'
+        'serviceName="e21047b5be0df7652cd99feb4168e887"\n'
         "renewTicket=true\n"
         "storeKey=true\n"
         "useKeyTab=true\n"

--- a/tests/tests_unit/tests_db_connection_unit/test_kafka_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_kafka_unit.py
@@ -238,3 +238,79 @@ def test_kafka_empty_cluster(spark_mock):
             user="user",
             addresses=["192.168.1.1"],
         )
+
+
+def test_kafka_connection_get_jaas_conf_password(spark_mock):
+    # Arrange
+    kafka = Kafka(
+        spark=spark_mock,
+        addresses=["some_address"],
+        cluster="cluster",
+        user="user",
+        password="password",
+    )
+
+    # Act
+    conf = kafka._get_jaas_conf()
+
+    # Assert
+    assert conf == (
+        "org.apache.kafka.common.security.plain.PlainLoginModule required\n"
+        'serviceName="a3d4d08729f94e64acfa5b5ef6caa3b1"\n'
+        'username="user"\n'
+        'password="**********";'
+    )
+
+
+def test_kafka_connection_get_jaas_conf_deploy_keytab_false(spark_mock, create_keytab):
+    # Arrange
+    kafka = Kafka(
+        spark=spark_mock,
+        addresses=["some_address"],
+        user="user",
+        cluster="cluster",
+        keytab=create_keytab,
+        deploy_keytab=False,
+    )
+
+    # Act
+    conf = kafka._get_jaas_conf()
+
+    # Assert
+    assert conf == (
+        "com.sun.security.auth.module.Krb5LoginModule required\n"
+        f'keyTab="{create_keytab}"\n'
+        'principal="user"\n'
+        'serviceName="3a4df6708d55e431d32237f3cf8e8a63"\n'
+        "renewTicket=true\n"
+        "storeKey=true\n"
+        "useKeyTab=true\n"
+        "useTicketCache=false;"
+    )
+
+
+def test_kafka_connection_get_jaas_conf_deploy_keytab_true(spark_mock, create_keytab):
+    # Arrange
+    # deploy_keytab=True by default
+    kafka = Kafka(
+        spark=spark_mock,
+        addresses=["some_address"],
+        user="user",
+        cluster="cluster",
+        keytab=create_keytab,
+    )
+
+    # Act
+    conf = kafka._get_jaas_conf()
+
+    # Assert
+    assert conf == (
+        "com.sun.security.auth.module.Krb5LoginModule required\n"
+        'keyTab="keytab"\n'
+        'principal="user"\n'
+        'serviceName="3a4df6708d55e431d32237f3cf8e8a63"\n'
+        "renewTicket=true\n"
+        "storeKey=true\n"
+        "useKeyTab=true\n"
+        "useTicketCache=false;"
+    )

--- a/tests/tests_unit/tests_db_connection_unit/test_kafka_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_kafka_unit.py
@@ -306,7 +306,7 @@ def test_kafka_connection_get_jaas_conf_deploy_keytab_true(spark_mock, create_ke
     # Assert
     assert conf == (
         "com.sun.security.auth.module.Krb5LoginModule required\n"
-        'keyTab="keytab"\n'
+        f'keyTab="{create_keytab.name}"\n'
         'principal="user"\n'
         'serviceName="3a4df6708d55e431d32237f3cf8e8a63"\n'
         "renewTicket=true\n"

--- a/tests/tests_unit/tests_db_connection_unit/test_kafka_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_kafka_unit.py
@@ -1,5 +1,6 @@
 import os
 import re
+from pathlib import Path
 
 import pytest
 
@@ -314,3 +315,5 @@ def test_kafka_connection_get_jaas_conf_deploy_keytab_true(spark_mock, create_ke
         "useKeyTab=true\n"
         "useTicketCache=false;"
     )
+
+    Path("./keytab").unlink()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary
The class must have a private method for generating a JAAS config that Kafka uses for authorization.
<!-- Please give a short summary of the changes. -->

## Related issue number
DOP-2329
<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [x] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
