### PR TITLE
[DOP-7866] Move Java class availability check to validator

### DIFF
--- a/docs/changelog/next_release/97.feature.rst
+++ b/docs/changelog/next_release/97.feature.rst
@@ -1,0 +1,1 @@
+Check of Java class availability moved from ``.check()`` method to connection constructor.

--- a/onetl/base/base_file_format.py
+++ b/onetl/base/base_file_format.py
@@ -26,9 +26,8 @@ class BaseReadableFileFormat(ABC):
     Representation of readable file format.
     """
 
-    @classmethod
     @abstractmethod
-    def check_if_supported(cls, spark: SparkSession) -> None:
+    def check_if_supported(self, spark: SparkSession) -> None:
         """
         Check if Spark session does support this file format. |support_hooks|
 
@@ -59,9 +58,8 @@ class BaseWritableFileFormat(ABC):
     Representation of writable file format.
     """
 
-    @classmethod
     @abstractmethod
-    def check_if_supported(cls, spark: SparkSession) -> None:
+    def check_if_supported(self, spark: SparkSession) -> None:
         """
         Check if Spark session does support this file format. |support_hooks|
 

--- a/onetl/connection/db_connection/clickhouse.py
+++ b/onetl/connection/db_connection/clickhouse.py
@@ -126,7 +126,7 @@ class Clickhouse(JDBCConnection):
     port: int = 8123
     database: Optional[str] = None
 
-    driver: ClassVar[str] = "ru.yandex.clickhouse.ClickHouseDriver"
+    DRIVER: ClassVar[str] = "ru.yandex.clickhouse.ClickHouseDriver"
 
     @slot
     @classmethod

--- a/onetl/connection/db_connection/db_connection.py
+++ b/onetl/connection/db_connection/db_connection.py
@@ -36,8 +36,6 @@ log = getLogger(__name__)
 class DBConnection(BaseDBConnection, FrozenModel):
     spark: SparkSession = Field(repr=False)
 
-    _check_query: ClassVar[str] = "SELECT 1"
-
     class Dialect(BaseDBConnection.Dialect):
         @classmethod
         def _expression_with_alias(cls, expression: str, alias: str) -> str:

--- a/onetl/connection/db_connection/hive.py
+++ b/onetl/connection/db_connection/hive.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import logging
 from enum import Enum
 from textwrap import dedent
-from typing import TYPE_CHECKING, Any, Iterable, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, ClassVar, Iterable, List, Optional, Tuple, Union
 
 from deprecated import deprecated
 from etl_entities.instance import Cluster
@@ -514,6 +514,7 @@ class Hive(DBConnection):
         pass
 
     cluster: Cluster
+    _CHECK_QUERY: ClassVar[str] = "SELECT 1"
 
     @validator("cluster")
     def validate_cluster_name(cls, cluster):
@@ -586,10 +587,10 @@ class Hive(DBConnection):
         self._log_parameters()
 
         log.debug("|%s| Executing SQL query:", self.__class__.__name__)
-        log_lines(self._check_query, level=logging.DEBUG)
+        log_lines(self._CHECK_QUERY, level=logging.DEBUG)
 
         try:
-            self._execute_sql(self._check_query)
+            self._execute_sql(self._CHECK_QUERY)
             log.info("|%s| Connection is available.", self.__class__.__name__)
         except Exception as e:
             log.exception("|%s| Connection is unavailable", self.__class__.__name__)

--- a/onetl/connection/db_connection/mssql.py
+++ b/onetl/connection/db_connection/mssql.py
@@ -169,8 +169,8 @@ class MSSQL(JDBCConnection):
     port: int = 1433
     extra: Extra = Extra()
 
-    driver: ClassVar[str] = "com.microsoft.sqlserver.jdbc.SQLServerDriver"
-    _check_query: ClassVar[str] = "SELECT 1 AS field"
+    DRIVER: ClassVar[str] = "com.microsoft.sqlserver.jdbc.SQLServerDriver"
+    _CHECK_QUERY: ClassVar[str] = "SELECT 1 AS field"
 
     @slot
     @classmethod

--- a/onetl/connection/db_connection/mysql.py
+++ b/onetl/connection/db_connection/mysql.py
@@ -124,7 +124,7 @@ class MySQL(JDBCConnection):
     database: Optional[str] = None
     extra: Extra = Extra()
 
-    driver: ClassVar[str] = "com.mysql.cj.jdbc.Driver"
+    DRIVER: ClassVar[str] = "com.mysql.cj.jdbc.Driver"
 
     @slot
     @classmethod

--- a/onetl/connection/db_connection/oracle.py
+++ b/onetl/connection/db_connection/oracle.py
@@ -174,9 +174,8 @@ class Oracle(JDBCConnection):
     sid: Optional[str] = None
     service_name: Optional[str] = None
 
-    driver: ClassVar[str] = "oracle.jdbc.driver.OracleDriver"
-
-    _check_query: ClassVar[str] = "SELECT 1 FROM dual"
+    DRIVER: ClassVar[str] = "oracle.jdbc.driver.OracleDriver"
+    _CHECK_QUERY: ClassVar[str] = "SELECT 1 FROM dual"
 
     @slot
     @classmethod

--- a/onetl/connection/db_connection/postgres.py
+++ b/onetl/connection/db_connection/postgres.py
@@ -131,7 +131,7 @@ class Postgres(JDBCConnection):
     database: str
     port: int = 5432
 
-    driver: ClassVar[str] = "org.postgresql.Driver"
+    DRIVER: ClassVar[str] = "org.postgresql.Driver"
 
     @slot
     @classmethod

--- a/onetl/connection/db_connection/teradata.py
+++ b/onetl/connection/db_connection/teradata.py
@@ -145,9 +145,8 @@ class Teradata(JDBCConnection):
     database: Optional[str] = None
     extra: Extra = Extra()
 
-    driver: ClassVar[str] = "com.teradata.jdbc.TeraDriver"
-
-    _check_query: ClassVar[str] = "SELECT 1 AS check_result"
+    DRIVER: ClassVar[str] = "com.teradata.jdbc.TeraDriver"
+    _CHECK_QUERY: ClassVar[str] = "SELECT 1 AS check_result"
 
     @slot
     @classmethod

--- a/onetl/exception.py
+++ b/onetl/exception.py
@@ -18,7 +18,7 @@ from evacuator import NeedEvacuation
 
 MISSING_JVM_CLASS_MSG = textwrap.dedent(
     """
-    |Spark| Cannot import Java class {java_class!r}.
+    Cannot import Java class {java_class!r}.
 
         It looks like you've created Spark session without this option:
             maven_packages = {package_source}.get_packages({args})

--- a/onetl/file/format/json.py
+++ b/onetl/file/format/json.py
@@ -112,7 +112,6 @@ class JSON(ReadOnlyFileFormat):
         extra = "allow"
 
     @slot
-    @classmethod
-    def check_if_supported(cls, spark: SparkSession) -> None:
+    def check_if_supported(self, spark: SparkSession) -> None:
         # always available
         pass

--- a/onetl/file/format/jsonline.py
+++ b/onetl/file/format/jsonline.py
@@ -106,7 +106,6 @@ class JSONLine(ReadWriteFileFormat):
         extra = "allow"
 
     @slot
-    @classmethod
-    def check_if_supported(cls, spark: SparkSession) -> None:
+    def check_if_supported(self, spark: SparkSession) -> None:
         # always available
         pass

--- a/onetl/file/format/orc.py
+++ b/onetl/file/format/orc.py
@@ -76,7 +76,6 @@ class ORC(ReadWriteFileFormat):
         extra = "allow"
 
     @slot
-    @classmethod
-    def check_if_supported(cls, spark: SparkSession) -> None:
+    def check_if_supported(self, spark: SparkSession) -> None:
         # always available
         pass

--- a/onetl/file/format/parquet.py
+++ b/onetl/file/format/parquet.py
@@ -80,7 +80,6 @@ class Parquet(ReadWriteFileFormat):
         extra = "allow"
 
     @slot
-    @classmethod
-    def check_if_supported(cls, spark: SparkSession) -> None:
+    def check_if_supported(self, spark: SparkSession) -> None:
         # always available
         pass

--- a/onetl/impl/base_model.py
+++ b/onetl/impl/base_model.py
@@ -43,7 +43,7 @@ class BaseModel(PydanticBaseModel):
     def _forward_refs(cls) -> dict[str, type]:
         refs: dict[str, type] = {}
         for item in dir(cls):
-            if "_" in item:
+            if item.startswith("_") or item.startswith("package"):
                 continue
 
             value = getattr(cls, item)

--- a/tests/tests_unit/test_file/test_format_unit/test_avro_unit.py
+++ b/tests/tests_unit/test_file/test_format_unit/test_avro_unit.py
@@ -107,8 +107,9 @@ def test_avro_options_prohibited(option):
         Avro.parse({option: "value"})
 
 
+@pytest.mark.local_fs
 def test_avro_missing_package(spark_no_packages):
     msg = "Cannot import Java class 'org.apache.spark.sql.avro.AvroFileFormat'"
     with pytest.raises(ValueError, match=msg):
         with patch.object(spark_no_packages, "version", new="2.4.0"):
-            Avro.check_if_supported(spark_no_packages)
+            Avro().check_if_supported(spark_no_packages)

--- a/tests/tests_unit/tests_db_connection_unit/test_clickhouse_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_clickhouse_unit.py
@@ -8,7 +8,7 @@ pytestmark = [pytest.mark.clickhouse, pytest.mark.db_connection, pytest.mark.con
 
 
 def test_clickhouse_driver():
-    assert Clickhouse.driver == "ru.yandex.clickhouse.ClickHouseDriver"
+    assert Clickhouse.DRIVER == "ru.yandex.clickhouse.ClickHouseDriver"
 
 
 def test_clickhouse_package():
@@ -19,6 +19,18 @@ def test_clickhouse_package():
 
 def test_clickhouse_get_packages():
     assert Clickhouse.get_packages() == ["ru.yandex.clickhouse:clickhouse-jdbc:0.3.2"]
+
+
+def test_clickhouse_missing_package(spark_no_packages):
+    msg = "Cannot import Java class 'ru.yandex.clickhouse.ClickHouseDriver'"
+    with pytest.raises(ValueError, match=msg):
+        Clickhouse(
+            host="some_host",
+            user="user",
+            database="database",
+            password="passwd",
+            spark=spark_no_packages,
+        )
 
 
 def test_clickhouse(spark_mock):

--- a/tests/tests_unit/tests_db_connection_unit/test_greenplum_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_greenplum_unit.py
@@ -1,4 +1,5 @@
 import re
+from unittest.mock import patch
 
 import pytest
 
@@ -9,7 +10,7 @@ pytestmark = [pytest.mark.greenplum, pytest.mark.db_connection, pytest.mark.conn
 
 
 def test_greenplum_driver():
-    assert Greenplum.driver == "org.postgresql.Driver"
+    assert Greenplum.DRIVER == "org.postgresql.Driver"
 
 
 def test_greenplum_package():
@@ -68,6 +69,19 @@ def test_greenplum_get_packages_scala_version_not_supported(scala_version):
 )
 def test_greenplum_get_packages(spark_version, scala_version, package):
     assert Greenplum.get_packages(spark_version=spark_version, scala_version=scala_version) == [package]
+
+
+def test_greenplum_missing_package(spark_no_packages):
+    msg = "Cannot import Java class 'io.pivotal.greenplum.spark.GreenplumRelationProvider'"
+    with pytest.raises(ValueError, match=msg):
+        with patch.object(spark_no_packages, "version", new="3.2.0"):
+            Greenplum(
+                host="some_host",
+                user="user",
+                database="database",
+                password="passwd",
+                spark=spark_no_packages,
+            )
 
 
 def test_greenplum(spark_mock):

--- a/tests/tests_unit/tests_db_connection_unit/test_kafka_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_kafka_unit.py
@@ -2,6 +2,7 @@ import os
 import re
 from pathlib import Path
 from textwrap import dedent
+from unittest.mock import patch
 
 import pytest
 from pydantic import ValidationError
@@ -25,6 +26,17 @@ pytestmark = [pytest.mark.kafka, pytest.mark.db_connection, pytest.mark.connecti
 )
 def test_kafka_get_packages(spark_version, scala_version, package):
     assert Kafka.get_packages(spark_version=spark_version, scala_version=scala_version) == [package]
+
+
+def test_kafka_missing_package(spark_no_packages):
+    msg = "Cannot import Java class 'org.apache.spark.sql.kafka010.KafkaSourceProvider'"
+    with pytest.raises(ValueError, match=msg):
+        with patch.object(spark_no_packages, "version", new="2.4.0"):
+            Kafka(
+                cluster="some_cluster",
+                addresses=["192.168.1.1"],
+                spark=spark_no_packages,
+            )
 
 
 @pytest.mark.parametrize(

--- a/tests/tests_unit/tests_db_connection_unit/test_mongodb_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_mongodb_unit.py
@@ -1,5 +1,6 @@
 import re
 from datetime import datetime
+from unittest.mock import patch
 
 import pytest
 
@@ -64,6 +65,19 @@ def test_mongodb_get_packages_scala_version_not_supported(scala_version):
 )
 def test_mongodb_get_packages(spark_version, scala_version, package):
     assert MongoDB.get_packages(spark_version=spark_version, scala_version=scala_version) == [package]
+
+
+def test_mongodb_missing_package(spark_no_packages):
+    msg = "Cannot import Java class 'com.mongodb.spark.sql.connector.MongoTableProvider'"
+    with pytest.raises(ValueError, match=msg):
+        with patch.object(spark_no_packages, "version", new="3.2.0"):
+            MongoDB(
+                host="host",
+                user="user",
+                password="password",
+                database="database",
+                spark=spark_no_packages,
+            )
 
 
 def test_mongodb(spark_mock):

--- a/tests/tests_unit/tests_db_connection_unit/test_mssql_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_mssql_unit.py
@@ -8,7 +8,7 @@ pytestmark = [pytest.mark.mssql, pytest.mark.db_connection, pytest.mark.connecti
 
 
 def test_mssql_class_attributes():
-    assert MSSQL.driver == "com.microsoft.sqlserver.jdbc.SQLServerDriver"
+    assert MSSQL.DRIVER == "com.microsoft.sqlserver.jdbc.SQLServerDriver"
 
 
 def test_mssql_package():
@@ -39,6 +39,18 @@ def test_mssql_get_packages_java_version_not_supported(java_version):
 )
 def test_mssql_get_packages(java_version, package):
     assert MSSQL.get_packages(java_version=java_version) == [package]
+
+
+def test_mssql_missing_package(spark_no_packages):
+    msg = "Cannot import Java class 'com.microsoft.sqlserver.jdbc.SQLServerDriver'"
+    with pytest.raises(ValueError, match=msg):
+        MSSQL(
+            host="some_host",
+            user="user",
+            database="database",
+            password="passwd",
+            spark=spark_no_packages,
+        )
 
 
 def test_mssql(spark_mock):

--- a/tests/tests_unit/tests_db_connection_unit/test_mysql_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_mysql_unit.py
@@ -8,7 +8,7 @@ pytestmark = [pytest.mark.mysql, pytest.mark.db_connection, pytest.mark.connecti
 
 
 def test_mysql_class_attributes():
-    assert MySQL.driver == "com.mysql.cj.jdbc.Driver"
+    assert MySQL.DRIVER == "com.mysql.cj.jdbc.Driver"
 
 
 def test_mysql_package():
@@ -19,6 +19,18 @@ def test_mysql_package():
 
 def test_mysql_get_packages():
     assert MySQL.get_packages() == ["com.mysql:mysql-connector-j:8.0.33"]
+
+
+def test_mysql_missing_package(spark_no_packages):
+    msg = "Cannot import Java class 'com.mysql.cj.jdbc.Driver'"
+    with pytest.raises(ValueError, match=msg):
+        MySQL(
+            host="some_host",
+            user="user",
+            database="database",
+            password="passwd",
+            spark=spark_no_packages,
+        )
 
 
 def test_mysql(spark_mock):

--- a/tests/tests_unit/tests_db_connection_unit/test_oracle_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_oracle_unit.py
@@ -8,7 +8,7 @@ pytestmark = [pytest.mark.oracle, pytest.mark.db_connection, pytest.mark.connect
 
 
 def test_oracle_class_attributes():
-    assert Oracle.driver == "oracle.jdbc.driver.OracleDriver"
+    assert Oracle.DRIVER == "oracle.jdbc.driver.OracleDriver"
 
 
 def test_oracle_package():
@@ -39,6 +39,18 @@ def test_oracle_get_packages_java_version_not_supported(java_version):
 )
 def test_oracle_get_packages(java_version, package):
     assert Oracle.get_packages(java_version=java_version) == [package]
+
+
+def test_oracle_missing_package(spark_no_packages):
+    msg = "Cannot import Java class 'oracle.jdbc.driver.OracleDriver'"
+    with pytest.raises(ValueError, match=msg):
+        Oracle(
+            host="some_host",
+            user="user",
+            sid="sid",
+            password="passwd",
+            spark=spark_no_packages,
+        )
 
 
 def test_oracle(spark_mock):

--- a/tests/tests_unit/tests_db_connection_unit/test_postgres_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_postgres_unit.py
@@ -8,7 +8,7 @@ pytestmark = [pytest.mark.postgres, pytest.mark.db_connection, pytest.mark.conne
 
 
 def test_postgres_class_attributes():
-    assert Postgres.driver == "org.postgresql.Driver"
+    assert Postgres.DRIVER == "org.postgresql.Driver"
 
 
 def test_postgres_package():
@@ -19,6 +19,18 @@ def test_postgres_package():
 
 def test_postgres_get_packages():
     assert Postgres.get_packages() == ["org.postgresql:postgresql:42.6.0"]
+
+
+def test_oracle_missing_package(spark_no_packages):
+    msg = "Cannot import Java class 'org.postgresql.Driver'"
+    with pytest.raises(ValueError, match=msg):
+        Postgres(
+            host="some_host",
+            user="user",
+            database="database",
+            password="passwd",
+            spark=spark_no_packages,
+        )
 
 
 def test_postgres(spark_mock):

--- a/tests/tests_unit/tests_db_connection_unit/test_teradata_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_teradata_unit.py
@@ -8,7 +8,7 @@ pytestmark = [pytest.mark.teradata, pytest.mark.db_connection, pytest.mark.conne
 
 
 def test_teradata_class_attributes():
-    assert Teradata.driver == "com.teradata.jdbc.TeraDriver"
+    assert Teradata.DRIVER == "com.teradata.jdbc.TeraDriver"
 
 
 def test_teradata_package():
@@ -19,6 +19,18 @@ def test_teradata_package():
 
 def test_teradata_get_packages():
     assert Teradata.get_packages() == ["com.teradata.jdbc:terajdbc:17.20.00.15"]
+
+
+def test_teradata_missing_package(spark_no_packages):
+    msg = "Cannot import Java class 'com.teradata.jdbc.TeraDriver'"
+    with pytest.raises(ValueError, match=msg):
+        Teradata(
+            host="some_host",
+            user="user",
+            database="database",
+            password="passwd",
+            spark=spark_no_packages,
+        )
 
 
 def test_teradata(spark_mock):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

<!-- Please give a short summary of the changes. -->

* Made all methods like `_check_if_driver_imported` a pydantic validators. They are executed on every constructor call, so there is no need to run them explicitly in `.check()`. Added unit tests.
* Renamed class variables like `driver` to `DRIVER`, they are constants.
* Made `FileFormat.check_if_available` regular method instead of classmethod. This allows to access format object to check if some properties are applicable to specific Spark versions.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [ ] My PR is ready to review.
