### PR TITLE
[DOP-7895] Fix building documentation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,20 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 python:
-  version: '3.8'
   install:
-  - requirements: requirements/core.txt
-  - method: pip
-    path: .[ftp, ftps, hdfs, s3, sftp, webdav, spark]
   - requirements: requirements/docs.txt
+  - method: pip
+    path: .
+    extra_requirements:
+    - ftp
+    - ftps
+    - hdfs
+    - s3
+    - sftp
+    - webdav
+    - spark

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,4 +1,4 @@
-autodoc_pydantic
+autodoc-pydantic<2.0.0
 furo
 importlib-resources<6
 numpydoc
@@ -11,6 +11,4 @@ sphinx-toolbox
 sphinx_substitution_extensions
 sphinxcontrib-towncrier
 towncrier
-# ReadTheDocs uses old OpenSSL version
-# https://github.com/urllib3/urllib3/issues/2168
-urllib3<2.0
+urllib3


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

<!-- Please give a short summary of the changes. -->

`autodoc-pydantic` 2.0.0 [released](https://github.com/mansenfranzen/autodoc_pydantic/blob/main/changelog.rst) few days ago, causing generating [empty documentation](https://onetl.readthedocs.io/en/latest/connection/file_df_connection/spark_local_fs.html) on pydantic models (almost all classes in onETL):
![изображение](https://github.com/MobileTeleSystems/onetl/assets/4661021/0aaa9804-f2a9-40aa-8f5e-a3a3ef7a65a3)

[Fixed](https://onetl--99.org.readthedocs.build/en/99/connection/file_df_connection/spark_local_fs.html)
![изображение](https://github.com/MobileTeleSystems/onetl/assets/4661021/b0ea59d1-4822-4ac1-b1c5-d9e018a31e39)

Also updated ReadTheDocs config to use latest Ubuntu and Python versions, removing restrictions from `urllib` version.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
