### PR TITLE
[DOP-7933] Rename HDFS.slots to HDFS.Slots

### DIFF
--- a/docs/changelog/next_release/103.breaking.rst
+++ b/docs/changelog/next_release/103.breaking.rst
@@ -1,0 +1,6 @@
+Rename classes:
+
+* ``HDFS.slots`` -> ``HDFS.Slots``
+* ``Hive.slots`` -> ``Hive.Slots``
+
+Old names are left intact, but will be removed in v1.0.0

--- a/docs/connection/db_connection/hive.rst
+++ b/docs/connection/db_connection/hive.rst
@@ -9,7 +9,7 @@ Hive connection
 
     Hive
     Hive.WriteOptions
-    Hive.slots
+    Hive.Slots
 
 .. autoclass:: Hive
     :members: get_current, check, sql, execute
@@ -21,6 +21,6 @@ Hive connection
     :members: mode, format, partition_by, bucket_by, sort_by, compression
     :member-order: bysource
 
-.. autoclass:: slots
+.. autoclass:: Slots
     :members: normalize_cluster_name, get_known_clusters, get_current_cluster
     :member-order: bysource

--- a/docs/connection/file_connection/hdfs.rst
+++ b/docs/connection/file_connection/hdfs.rst
@@ -8,13 +8,13 @@ HDFS connection
 .. autosummary::
 
     HDFS
-    HDFS.slots
+    HDFS.Slots
 
 .. autoclass:: HDFS
     :members: __init__, check, path_exists, is_file, is_dir, get_stat, resolve_dir, resolve_file, create_dir, remove_file, remove_dir, rename_dir, rename_file, list_dir, walk, download_file, upload_file
 
 .. currentmodule:: onetl.connection.file_connection.hdfs.HDFS
 
-.. autoclass:: slots
+.. autoclass:: Slots
     :members: normalize_cluster_name, normalize_namenode_name, get_known_clusters, get_cluster_namenodes, get_current_cluster, get_webhdfs_port, is_namenode_active
     :member-order: bysource

--- a/onetl/connection/file_connection/hdfs.py
+++ b/onetl/connection/file_connection/hdfs.py
@@ -203,7 +203,7 @@ class HDFS(FileConnection, RenameDirMixin):
     """
 
     @support_hooks
-    class slots:  # noqa: N801
+    class Slots:
         """Slots that could be implemented by third-party plugins"""
 
         @slot
@@ -235,7 +235,7 @@ class HDFS(FileConnection, RenameDirMixin):
                 from onetl.hooks import hook
 
 
-                @HDFS.slots.normalize_cluster_name.bind
+                @HDFS.Slots.normalize_cluster_name.bind
                 @hook
                 def normalize_cluster_name(cluster: str) -> str:
                     return cluster.lower()
@@ -273,7 +273,7 @@ class HDFS(FileConnection, RenameDirMixin):
                 from onetl.hooks import hook
 
 
-                @HDFS.slots.normalize_namenode_host.bind
+                @HDFS.Slots.normalize_namenode_host.bind
                 @hook
                 def normalize_namenode_host(host: str, cluster: str) -> str | None:
                     if cluster == "rnd-dwh":
@@ -310,7 +310,7 @@ class HDFS(FileConnection, RenameDirMixin):
                 from onetl.hooks import hook
 
 
-                @HDFS.slots.get_known_clusters.bind
+                @HDFS.Slots.get_known_clusters.bind
                 @hook
                 def get_known_clusters() -> str[str]:
                     return {"rnd-dwh", "rnd-prod"}
@@ -346,7 +346,7 @@ class HDFS(FileConnection, RenameDirMixin):
                 from onetl.hooks import hook
 
 
-                @HDFS.slots.get_cluster_namenodes.bind
+                @HDFS.Slots.get_cluster_namenodes.bind
                 @hook
                 def get_cluster_namenodes(cluster: str) -> str[str] | None:
                     if cluster == "rnd-dwh":
@@ -379,7 +379,7 @@ class HDFS(FileConnection, RenameDirMixin):
                 from onetl.hooks import hook
 
 
-                @HDFS.slots.get_current_cluster.bind
+                @HDFS.Slots.get_current_cluster.bind
                 @hook
                 def get_current_cluster() -> str:
                     # some magic here
@@ -415,7 +415,7 @@ class HDFS(FileConnection, RenameDirMixin):
                 from onetl.hooks import hook
 
 
-                @HDFS.slots.get_webhdfs_port.bind
+                @HDFS.Slots.get_webhdfs_port.bind
                 @hook
                 def get_webhdfs_port(cluster: str) -> int | None:
                     if cluster == "rnd-dwh":
@@ -463,12 +463,15 @@ class HDFS(FileConnection, RenameDirMixin):
                 from onetl.hooks import hook
 
 
-                @HDFS.slots.is_namenode_active.bind
+                @HDFS.Slots.is_namenode_active.bind
                 @hook
                 def is_namenode_active(host: str, cluster: str | None) -> bool:
                     # some magic here
                     return True
             """
+
+    # TODO: remove in v1.0.0
+    slots = Slots
 
     cluster: Optional[Cluster] = None
     host: Optional[Host] = None
@@ -516,12 +519,12 @@ class HDFS(FileConnection, RenameDirMixin):
     @validator("cluster")
     def validate_cluster_name(cls, cluster):
         log.debug("|%s| Normalizing cluster %r name ...", cls.__name__, cluster)
-        validated_cluster = cls.slots.normalize_cluster_name(cluster) or cluster
+        validated_cluster = cls.Slots.normalize_cluster_name(cluster) or cluster
         if validated_cluster != cluster:
             log.debug("|%s|   Got %r", cls.__name__, validated_cluster)
 
         log.debug("|%s| Checking if cluster %r is a known cluster ...", cls.__name__, validated_cluster)
-        known_clusters = cls.slots.get_known_clusters()
+        known_clusters = cls.Slots.get_known_clusters()
         if known_clusters and validated_cluster not in known_clusters:
             raise ValueError(
                 f"Cluster {validated_cluster!r} is not in the known clusters list: {sorted(known_clusters)!r}",
@@ -534,13 +537,13 @@ class HDFS(FileConnection, RenameDirMixin):
         cluster = values.get("cluster")
 
         log.debug("|%s| Normalizing namenode %r ...", cls.__name__, host)
-        namenode = cls.slots.normalize_namenode_host(host, cluster) or host
+        namenode = cls.Slots.normalize_namenode_host(host, cluster) or host
         if namenode != host:
             log.debug("|%s|   Got %r", cls.__name__, namenode)
 
         if cluster:
             log.debug("|%s| Checking if %r is a known namenode of cluster %r ...", cls.__name__, namenode, cluster)
-            known_namenodes = cls.slots.get_cluster_namenodes(cluster)
+            known_namenodes = cls.Slots.get_cluster_namenodes(cluster)
             if known_namenodes and namenode not in known_namenodes:
                 raise ValueError(
                     f"Namenode {namenode!r} is not in the known nodes list of cluster {cluster!r}: "
@@ -554,7 +557,7 @@ class HDFS(FileConnection, RenameDirMixin):
         cluster = values.get("cluster")
         if cluster:
             log.debug("|%s| Getting WebHDFS port of cluster %r ...", cls.__name__, cluster)
-            result = cls.slots.get_webhdfs_port(cluster) or port
+            result = cls.Slots.get_webhdfs_port(cluster) or port
             if result != port:
                 log.debug("|%s|   Got %r", cls.__name__, result)
             return result
@@ -607,11 +610,11 @@ class HDFS(FileConnection, RenameDirMixin):
         """
 
         log.info("|%s| Detecting current cluster...", cls.__name__)
-        current_cluster = cls.slots.get_current_cluster()
+        current_cluster = cls.Slots.get_current_cluster()
         if not current_cluster:
             raise RuntimeError(
                 f"{cls.__name__}.get_current() can be used only if there are "
-                f"some hooks bound to {cls.__name__}.slots.get_current_cluster",
+                f"some hooks bound to {cls.__name__}.Slots.get_current_cluster",
             )
 
         log.info("|%s|   Got %r", cls.__name__, current_cluster)
@@ -631,14 +634,14 @@ class HDFS(FileConnection, RenameDirMixin):
         class_name = self.__class__.__name__
         log.info("|%s| Detecting active namenode of cluster %r ...", class_name, self.cluster)
 
-        namenodes = self.slots.get_cluster_namenodes(self.cluster)
+        namenodes = self.Slots.get_cluster_namenodes(self.cluster)
         if not namenodes:
             raise RuntimeError(f"Cannot get list of namenodes for a cluster {self.cluster!r}")
 
         nodes_len = len(namenodes)
         for i, namenode in enumerate(namenodes):
             log.debug("|%s|   Trying namenode %r (%d of %d) ...", class_name, namenode, i, nodes_len)
-            if self.slots.is_namenode_active(namenode, self.cluster):
+            if self.Slots.is_namenode_active(namenode, self.cluster):
                 log.info("|%s|     Node %r is active!", class_name, namenode)
                 return namenode
             log.debug("|%s|     Node %r is not active, skipping", class_name, namenode)
@@ -656,7 +659,7 @@ class HDFS(FileConnection, RenameDirMixin):
         else:
             log.info("|%s| Detecting if namenode %r is active...", class_name, self.host)
 
-        is_active = self.slots.is_namenode_active(self.host, self.cluster)
+        is_active = self.Slots.is_namenode_active(self.host, self.cluster)
         if is_active:
             log.info("|%s|   Namenode %r is active!", class_name, self.host)
             return self.host

--- a/tests/tests_integration/tests_file_connection_integration/test_hdfs_file_connection_integration.py
+++ b/tests/tests_integration/tests_file_connection_integration/test_hdfs_file_connection_integration.py
@@ -94,7 +94,7 @@ def test_hdfs_file_connection_check_failed():
 def test_hdfs_file_connection_check_with_hooks(request, hdfs_server):
     from onetl.connection import HDFS
 
-    @HDFS.slots.is_namenode_active.bind
+    @HDFS.Slots.is_namenode_active.bind
     @hook
     def is_namenode_active(host: str, cluster: str | None) -> bool:
         return host == hdfs_server.host
@@ -115,7 +115,7 @@ def test_hdfs_file_connection_check_with_hooks(request, hdfs_server):
     with pytest.raises(RuntimeError, match="Cannot get list of namenodes for a cluster 'rnd-dwh'"):
         HDFS(cluster="rnd-dwh").check()
 
-    @HDFS.slots.get_cluster_namenodes.bind
+    @HDFS.Slots.get_cluster_namenodes.bind
     @hook
     def get_cluster_namenodes(cluster: str) -> set[str]:
         if cluster == "rnd-dwh":
@@ -124,7 +124,7 @@ def test_hdfs_file_connection_check_with_hooks(request, hdfs_server):
 
     request.addfinalizer(get_cluster_namenodes.disable)
 
-    @HDFS.slots.get_webhdfs_port.bind
+    @HDFS.Slots.get_webhdfs_port.bind
     @hook
     def get_webhdfs_port(cluster: str) -> int | None:
         if cluster == "rnd-dwh":
@@ -139,7 +139,7 @@ def test_hdfs_file_connection_check_with_hooks(request, hdfs_server):
     with pytest.raises(RuntimeError, match="Cannot detect active namenode for cluster 'rnd-prod'"):
         HDFS(cluster="rnd-prod").check()
 
-    @HDFS.slots.get_current_cluster.bind
+    @HDFS.Slots.get_current_cluster.bind
     @hook
     def get_current_cluster() -> str:
         return "rnd-dwh"

--- a/tests/tests_unit/tests_db_connection_unit/test_hive_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_hive_unit.py
@@ -31,7 +31,7 @@ def test_hive_get_known_clusters_hook(request, spark_mock):
     # no exception
     Hive(cluster="unknown", spark=spark_mock)
 
-    @Hive.slots.get_known_clusters.bind
+    @Hive.Slots.get_known_clusters.bind
     @hook
     def get_known_clusters() -> set[str]:
         return {"known1", "known2"}
@@ -48,7 +48,7 @@ def test_hive_get_known_clusters_hook(request, spark_mock):
 
 
 def test_hive_known_normalize_cluster_name_hook(request, spark_mock):
-    @Hive.slots.normalize_cluster_name.bind
+    @Hive.Slots.normalize_cluster_name.bind
     @hook
     def normalize_cluster_name(cluster: str) -> str:
         return cluster.lower().replace("_", "-")
@@ -67,7 +67,7 @@ def test_hive_known_get_current_cluster_hook(request, spark_mock, mocker):
     Hive(cluster="rnd-prod", spark=spark_mock).check()
     Hive(cluster="rnd-dwh", spark=spark_mock).check()
 
-    @Hive.slots.get_current_cluster.bind
+    @Hive.Slots.get_current_cluster.bind
     @hook
     def get_current_cluster() -> str:
         return "rnd-dwh"
@@ -82,14 +82,14 @@ def test_hive_known_get_current_cluster_hook(request, spark_mock, mocker):
 
 
 def test_hive_known_get_current(request, spark_mock):
-    # no hooks bound to Hive.slots.get_current_cluster
+    # no hooks bound to Hive.Slots.get_current_cluster
     error_msg = re.escape(
-        "Hive.get_current() can be used only if there are some hooks bound to Hive.slots.get_current_cluster",
+        "Hive.get_current() can be used only if there are some hooks bound to Hive.Slots.get_current_cluster",
     )
     with pytest.raises(RuntimeError, match=error_msg):
         Hive.get_current(spark=spark_mock)
 
-    @Hive.slots.get_current_cluster.bind
+    @Hive.Slots.get_current_cluster.bind
     @hook
     def get_current_cluster() -> str:
         return "rnd-dwh"

--- a/tests/tests_unit/tests_file_connection_unit/test_hdfs_unit.py
+++ b/tests/tests_unit/tests_file_connection_unit/test_hdfs_unit.py
@@ -152,7 +152,7 @@ def test_hdfs_connection_with_password_and_keytab(request, tmp_path_factory):
 def test_hdfs_get_known_clusters_hook(request):
     from onetl.connection import HDFS
 
-    @HDFS.slots.get_known_clusters.bind
+    @HDFS.Slots.get_known_clusters.bind
     @hook
     def get_known_clusters() -> set[str]:
         return {"known1", "known2"}
@@ -171,7 +171,7 @@ def test_hdfs_get_known_clusters_hook(request):
 def test_hdfs_known_normalize_cluster_name_hook(request):
     from onetl.connection import HDFS
 
-    @HDFS.slots.normalize_cluster_name.bind
+    @HDFS.Slots.normalize_cluster_name.bind
     @hook
     def normalize_cluster_name(cluster: str) -> str:
         return cluster.lower().replace("_", "-")
@@ -186,7 +186,7 @@ def test_hdfs_known_normalize_cluster_name_hook(request):
 def test_hdfs_get_cluster_namenodes_hook(request):
     from onetl.connection import HDFS
 
-    @HDFS.slots.get_cluster_namenodes.bind
+    @HDFS.Slots.get_cluster_namenodes.bind
     @hook
     def get_cluster_namenodes(cluster: str) -> set[str]:
         return {"some-node1.domain.com", "some-node2.domain.com"}
@@ -206,7 +206,7 @@ def test_hdfs_get_cluster_namenodes_hook(request):
 def test_hdfs_normalize_namenode_host_hook(request):
     from onetl.connection import HDFS
 
-    @HDFS.slots.normalize_namenode_host.bind
+    @HDFS.Slots.normalize_namenode_host.bind
     @hook
     def normalize_namenode_host(host: str, cluster: str | None) -> str:
         host = host.lower()
@@ -226,7 +226,7 @@ def test_hdfs_normalize_namenode_host_hook(request):
 def test_hdfs_get_webhdfs_port_hook(request):
     from onetl.connection import HDFS
 
-    @HDFS.slots.get_webhdfs_port.bind
+    @HDFS.Slots.get_webhdfs_port.bind
     @hook
     def get_webhdfs_port(cluster: str) -> int | None:
         if cluster == "rnd-dwh":
@@ -245,14 +245,14 @@ def test_hdfs_get_webhdfs_port_hook(request):
 def test_hdfs_known_get_current(request, mocker):
     from onetl.connection import HDFS
 
-    # no hooks bound to HDFS.slots.get_current_cluster
+    # no hooks bound to HDFS.Slots.get_current_cluster
     error_msg = re.escape(
-        "HDFS.get_current() can be used only if there are some hooks bound to HDFS.slots.get_current_cluster",
+        "HDFS.get_current() can be used only if there are some hooks bound to HDFS.Slots.get_current_cluster",
     )
     with pytest.raises(RuntimeError, match=error_msg):
         HDFS.get_current()
 
-    @HDFS.slots.get_current_cluster.bind
+    @HDFS.Slots.get_current_cluster.bind
     @hook
     def get_current_cluster() -> str:
         return "rnd-dwh"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

<!-- Please give a short summary of the changes. -->

Renamed classes according PEP-8:
* `HDFS.slots` -> `HDFS.Slots`
* `Hive.slots` -> `Hive.Slots`

Old names are left intact to keep backward compatibility.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [X] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
