### PR TITLE
[DOP-8019] Improve Kafka.KerberosAuth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 /reports/
+/*.keytab
 
 # Translations
 *.mo

--- a/onetl/_util/file.py
+++ b/onetl/_util/file.py
@@ -1,0 +1,55 @@
+#  Copyright 2023 MTS (Mobile Telesystems)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from __future__ import annotations
+
+import hashlib
+import io
+import os
+from pathlib import Path
+
+from onetl.exception import NotAFileError
+from onetl.impl import path_repr
+
+
+def get_file_hash(
+    path: os.PathLike | str,
+    algorithm: str,
+    chunk_size: int = io.DEFAULT_BUFFER_SIZE,
+) -> hashlib._Hash:
+    """Get file hash by path and algorithm"""
+    digest = hashlib.new(algorithm)
+    with open(path, "rb") as file:
+        chunk = file.read(chunk_size)
+        while chunk:
+            digest.update(chunk)
+            chunk = file.read(chunk_size)
+
+    return digest
+
+
+def is_file_readable(path: str | os.PathLike) -> Path:
+    """Check if specified path is a file and is readable"""
+    path = Path(os.path.expandvars(path)).expanduser().resolve()
+
+    if not path.exists():
+        raise FileNotFoundError(f"File '{path}' does not exist")
+
+    if not path.is_file():
+        raise NotAFileError(f"{path_repr(path)} is not a file")
+
+    if not os.access(path, os.R_OK):
+        raise OSError(f"No read access to file {path_repr(path)}")
+
+    return path

--- a/onetl/connection/db_connection/kafka/connection.py
+++ b/onetl/connection/db_connection/kafka/connection.py
@@ -350,6 +350,38 @@ class Kafka(DBConnection):
             f"org.apache.spark:spark-sql-kafka-0-10_{scala_ver.digits(2)}:{spark_ver.digits(3)}",
         ]
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    @slot
+    def close(self):
+        """
+        Close all connections created to Kafka. |support_hooks|
+
+        Examples
+        --------
+
+        Close connection automatically:
+
+        .. code:: python
+
+            with connection:
+                ...
+
+        Close connection manually:
+
+        .. code:: python
+
+            connection.close()
+
+        """
+        self.protocol.cleanup(self)
+        if self.auth:
+            self.auth.cleanup(self)
+
     @property
     def instance_url(self):
         return "kafka://" + self.cluster
@@ -394,7 +426,7 @@ class Kafka(DBConnection):
             log.debug("|%s| Got %r", cls.__name__, validated_addresses)
 
         cluster_addresses = set(cls.Slots.get_cluster_addresses(cluster) or [])
-        unknown_addresses = {address for address in validated_addresses if address not in cluster_addresses}
+        unknown_addresses = set(validated_addresses) - cluster_addresses
         if cluster_addresses and unknown_addresses:
             raise ValueError(f"Cluster {cluster!r} does not contain addresses {unknown_addresses!r}")
 

--- a/onetl/connection/db_connection/kafka/extra.py
+++ b/onetl/connection/db_connection/kafka/extra.py
@@ -17,12 +17,19 @@ from onetl.impl import GenericOptions
 
 PROHIBITED_OPTIONS = frozenset(
     (
+        # filled by onETL classes
         "bootstrap.servers",
         "security.protocol",
         "sasl.*",
         "ssl.*",
-        "key.*",
-        "value.*",
+        # Not supported by Spark
+        "auto.offset.reset",
+        "enable.auto.commit",
+        "interceptor.classes",
+        "key.deserializer",
+        "key.serializer",
+        "value.deserializer",
+        "value.serializer",
     ),
 )
 

--- a/onetl/connection/db_connection/kafka/kafka_auth.py
+++ b/onetl/connection/db_connection/kafka/kafka_auth.py
@@ -27,4 +27,14 @@ class KafkaAuth(ABC):
 
     @abstractmethod
     def get_options(self, kafka: Kafka) -> dict:
+        """
+        Get options for Kafka connection
+        """
+        ...
+
+    @abstractmethod
+    def cleanup(self, kafka: Kafka) -> None:
+        """
+        This method is called while closing Kafka connection
+        """
         ...

--- a/onetl/connection/db_connection/kafka/kafka_plaintext_protocol.py
+++ b/onetl/connection/db_connection/kafka/kafka_plaintext_protocol.py
@@ -29,3 +29,7 @@ class KafkaPlaintextProtocol(KafkaProtocol, FrozenModel):
         if kafka.auth:
             return {"security.protocol": "SASL_PLAINTEXT"}
         return {"security.protocol": "PLAINTEXT"}
+
+    def cleanup(self, kafka: Kafka) -> None:
+        # nothing to cleanup
+        pass

--- a/onetl/connection/db_connection/kafka/kafka_protocol.py
+++ b/onetl/connection/db_connection/kafka/kafka_protocol.py
@@ -23,4 +23,14 @@ if TYPE_CHECKING:
 class KafkaProtocol(ABC):
     @abstractmethod
     def get_options(self, kafka: Kafka) -> dict:
+        """
+        Get options for Kafka connection
+        """
+        ...
+
+    @abstractmethod
+    def cleanup(self, kafka: Kafka) -> None:
+        """
+        This method is called while closing Kafka connection
+        """
         ...

--- a/onetl/connection/db_connection/kafka/options.py
+++ b/onetl/connection/db_connection/kafka/options.py
@@ -24,7 +24,6 @@ PROHIBITED_OPTIONS = frozenset(
         "kafka.*",
         "startingOffsets",
         "startingOffsetsByTimestamp",
-        "startingOffsetsByTimestampStrategy",
         "startingTimestamp",
         "subscribe",
         "subscribePattern",
@@ -74,7 +73,6 @@ class KafkaReadOptions(GenericOptions):
             * ``kafka.*``
             * ``startingOffsets``
             * ``startingOffsetsByTimestamp``
-            * ``startingOffsetsByTimestampStrategy``
             * ``startingTimestamp``
             * ``subscribe``
             * ``subscribePattern``
@@ -91,7 +89,7 @@ class KafkaReadOptions(GenericOptions):
     .. code:: python
 
         Kafka.ReadOptions(
-            maxOffsetsPerTrigger=10000,
+            minPartitions=50,
         )
     """
 
@@ -121,7 +119,6 @@ class KafkaWriteOptions(GenericOptions):
             * ``kafka.*``
             * ``startingOffsets``
             * ``startingOffsetsByTimestamp``
-            * ``startingOffsetsByTimestampStrategy``
             * ``startingTimestamp``
             * ``subscribe``
             * ``subscribePattern``

--- a/onetl/connection/kerberos_helpers.py
+++ b/onetl/connection/kerberos_helpers.py
@@ -17,31 +17,14 @@ from __future__ import annotations
 import os
 import subprocess
 from logging import getLogger
-from pathlib import Path
 
-from onetl.exception import NotAFileError
-from onetl.impl import path_repr
+from onetl._util.file import is_file_readable
 
 log = getLogger(__name__)
 
 
-def check_keytab_file(path: str | os.PathLike) -> Path:
-    path = Path(os.path.expandvars(path)).expanduser().resolve()
-
-    if not path.exists():
-        raise FileNotFoundError(f"File '{path}' does not exist")
-
-    if not path.is_file():
-        raise NotAFileError(f"{path_repr(path)} is not a file")
-
-    if not os.access(path, os.R_OK):
-        raise OSError(f"No access to keytab file {path_repr(path)}")
-
-    return path
-
-
 def kinit_keytab(user: str, keytab: str | os.PathLike) -> None:
-    path = check_keytab_file(keytab)
+    path = is_file_readable(keytab)
 
     cmd = ["kinit", user, "-k", "-t", os.fspath(path)]
     log.info("|onETL| Executing kerberos auth command: %s", " ".join(cmd))

--- a/tests/fixtures/create_keytab.py
+++ b/tests/fixtures/create_keytab.py
@@ -1,11 +1,17 @@
+import hashlib
 from pathlib import Path
 
 import pytest
 
 
-@pytest.fixture()
+@pytest.fixture
 def create_keytab(tmp_path_factory):
-    path = Path(tmp_path_factory.mktemp("data") / "keytab")
+    path = Path(tmp_path_factory.mktemp("data") / "some.keytab")
     path.write_text("content")
 
     return path
+
+
+@pytest.fixture
+def keytab_md5():
+    return hashlib.md5(b"content").hexdigest()  # noqa: S324

--- a/tests/tests_integration/test_file_format_integration/test_csv_integration.py
+++ b/tests/tests_integration/test_file_format_integration/test_csv_integration.py
@@ -76,7 +76,7 @@ def test_csv_reader_with_options(
 
     reader = FileReader(
         connection=local_fs,
-        format=CSV(**{option: value}),
+        format=CSV.parse({option: value}),
         df_schema=df.schema,
         source_path=csv_root,
     )
@@ -107,7 +107,7 @@ def test_csv_writer_with_options(
     df = file_df_dataframe
     csv_root = source_path / "csv"
 
-    csv = CSV(**{option: value})
+    csv = CSV.parse({option: value})
 
     writer = FileWriter(
         connection=file_df_connection,

--- a/tests/tests_integration/tests_db_connection_integration/test_kafka_integration.py
+++ b/tests/tests_integration/tests_db_connection_integration/test_kafka_integration.py
@@ -1,6 +1,4 @@
 import logging
-import re
-from pathlib import Path
 
 import pytest
 
@@ -67,43 +65,3 @@ def test_kafka_check_error(spark):
     )
     with pytest.raises(RuntimeError, match="Connection is unavailable"):
         kafka.check()
-
-
-def test_kafka_connection_get_jaas_conf_deploy_keytab_true(spark, create_keytab):
-    # Arrange
-    cloned_keytab = Path("./keytab")
-    # deploy_keytab=True by default
-    kafka = Kafka(
-        spark=spark,
-        addresses=["some_address"],
-        cluster="cluster",
-        auth=Kafka.KerberosAuth(
-            principal="user",
-            keytab=create_keytab,
-        ),
-    )
-
-    assert not cloned_keytab.exists()
-
-    # Act
-    kafka.auth.get_options(kafka)
-
-    # Assert
-    assert cloned_keytab.exists()
-    assert cloned_keytab.read_text() == create_keytab.read_text()
-    cloned_keytab.unlink()
-
-
-def test_kafka_connection_get_jaas_conf_deploy_keytab_true_error(spark):
-    # Assert
-    # deploy_keytab=True by default
-    with pytest.raises(ValueError, match=re.escape("File '/not/a/keytab' is missing")):
-        Kafka(
-            spark=spark,
-            addresses=["some_address"],
-            cluster="cluster",
-            auth=Kafka.KerberosAuth(
-                principal="user",
-                keytab="/not/a/keytab",
-            ),
-        )

--- a/tests/tests_unit/test_file/test_file_writer_unit.py
+++ b/tests/tests_unit/test_file/test_file_writer_unit.py
@@ -13,7 +13,7 @@ from onetl.file import FileWriter
     ],
 )
 def test_file_writer_options(option, value):
-    options = FileWriter.Options(**{option: value})
+    options = FileWriter.Options.parse({option: value})
     assert getattr(options, option) == value
 
 

--- a/tests/tests_unit/test_file/test_format_unit/test_avro_unit.py
+++ b/tests/tests_unit/test_file/test_format_unit/test_avro_unit.py
@@ -66,7 +66,7 @@ def test_avro_options_schema(value, real_value):
     ],
 )
 def test_avro_options_alias(name, real_name, value):
-    avro = Avro(**{name: value})
+    avro = Avro.parse({name: value})
     assert getattr(avro, real_name) == value
 
 
@@ -82,7 +82,7 @@ def test_avro_options_alias(name, real_name, value):
     ],
 )
 def test_avro_options_known(known_option):
-    avro = Avro(**{known_option: "value"})
+    avro = Avro.parse({known_option: "value"})
     assert getattr(avro, known_option) == "value"
 
 

--- a/tests/tests_unit/test_file/test_format_unit/test_csv_unit.py
+++ b/tests/tests_unit/test_file/test_format_unit/test_csv_unit.py
@@ -70,7 +70,7 @@ def test_csv_options_delimiter_alias():
     ],
 )
 def test_csv_options_known(known_option):
-    csv = CSV(**{known_option: "value"})
+    csv = CSV.parse({known_option: "value"})
     assert getattr(csv, known_option) == "value"
 
 

--- a/tests/tests_unit/test_file/test_format_unit/test_file_format_unit.py
+++ b/tests/tests_unit/test_file/test_format_unit/test_file_format_unit.py
@@ -23,4 +23,4 @@ from onetl.file.format import CSV
 def test_file_format_prohibited_options(prohibited_option, format_class):
     msg = rf"Options \['{prohibited_option}'\] are not allowed to use in a {format_class.__name__}"
     with pytest.raises(ValueError, match=msg):
-        format_class(**{prohibited_option: "value"})
+        format_class.parse({prohibited_option: "value"})

--- a/tests/tests_unit/test_file/test_format_unit/test_json_unit.py
+++ b/tests/tests_unit/test_file/test_format_unit/test_json_unit.py
@@ -53,7 +53,7 @@ def test_json_options_cannot_override_multiline():
     ],
 )
 def test_json_options_known(known_option):
-    json = JSON(**{known_option: "value"})
+    json = JSON.parse({known_option: "value"})
     assert getattr(json, known_option) == "value"
 
 

--- a/tests/tests_unit/test_file/test_format_unit/test_jsonline_unit.py
+++ b/tests/tests_unit/test_file/test_format_unit/test_jsonline_unit.py
@@ -53,7 +53,7 @@ def test_jsonline_options_cannot_override_multiline():
     ],
 )
 def test_jsonline_options_known(known_option):
-    jsonline = JSONLine(**{known_option: "value"})
+    jsonline = JSONLine.parse({known_option: "value"})
     assert getattr(jsonline, known_option) == "value"
 
 

--- a/tests/tests_unit/test_file/test_format_unit/test_orc_unit.py
+++ b/tests/tests_unit/test_file/test_format_unit/test_orc_unit.py
@@ -14,7 +14,7 @@ from onetl.file.format import ORC
     ],
 )
 def test_orc_options_known(known_option):
-    orc = ORC(**{known_option: "value"})
+    orc = ORC.parse({known_option: "value"})
     assert getattr(orc, known_option) == "value"
 
 

--- a/tests/tests_unit/test_file/test_format_unit/test_parquet_unit.py
+++ b/tests/tests_unit/test_file/test_format_unit/test_parquet_unit.py
@@ -16,7 +16,7 @@ from onetl.file.format import Parquet
     ],
 )
 def test_parquet_options_known(known_option):
-    parquet = Parquet(**{known_option: "value"})
+    parquet = Parquet.parse({known_option: "value"})
     assert getattr(parquet, known_option) == "value"
 
 

--- a/tests/tests_unit/tests_db_connection_unit/test_db_options_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_db_options_unit.py
@@ -30,7 +30,7 @@ pytestmark = [pytest.mark.db_connection, pytest.mark.connection]
 )
 def test_db_options_connection_parameters_cannot_be_passed(options_class, arg, value):
     with pytest.raises(ValueError, match=rf"Options \['{arg}'\] are not allowed to use in a {options_class.__name__}"):
-        options_class(**{arg: value})
+        options_class.parse({arg: value})
 
 
 @pytest.mark.parametrize(

--- a/tests/tests_unit/tests_db_connection_unit/test_greenplum_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_greenplum_unit.py
@@ -216,7 +216,7 @@ def test_greenplum_read_write_options_populated_by_connection_class():
 )
 def test_greenplum_read_write_options_prohibited(arg, value, options_class):
     with pytest.raises(ValueError, match=rf"Options \['{arg}'\] are not allowed to use in a {options_class.__name__}"):
-        options_class(**{arg: value})
+        options_class.parse({arg: value})
 
 
 @pytest.mark.parametrize(
@@ -233,7 +233,7 @@ def test_greenplum_read_write_options_prohibited(arg, value, options_class):
 def test_greenplum_write_options_cannot_be_used_in_read_options(arg, value):
     error_msg = rf"Options \['{arg}'\] are not allowed to use in a ReadOptions"
     with pytest.raises(ValueError, match=error_msg):
-        Greenplum.ReadOptions(**{arg: value})
+        Greenplum.ReadOptions.parse({arg: value})
 
 
 @pytest.mark.parametrize(
@@ -249,7 +249,7 @@ def test_greenplum_write_options_cannot_be_used_in_read_options(arg, value):
 def test_greenplum_read_options_cannot_be_used_in_write_options(arg, value):
     error_msg = rf"Options \['{arg}'\] are not allowed to use in a WriteOptions"
     with pytest.raises(ValueError, match=error_msg):
-        Greenplum.WriteOptions(**{arg: value})
+        Greenplum.WriteOptions.parse({arg: value})
 
 
 @pytest.mark.parametrize(

--- a/tests/tests_unit/tests_db_connection_unit/test_jdbc_options_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_jdbc_options_unit.py
@@ -45,14 +45,14 @@ def test_jdbc_options_default():
 def test_jdbc_read_write_options_populated_by_connection_class(arg, value):
     error_msg = rf"Options \['{arg}'\] are not allowed to use in a ReadOptions"
     with pytest.raises(ValueError, match=error_msg):
-        Postgres.ReadOptions(**{arg: value})
+        Postgres.ReadOptions.parse({arg: value})
 
     error_msg = rf"Options \['{arg}'\] are not allowed to use in a WriteOptions"
     with pytest.raises(ValueError, match=error_msg):
-        Postgres.WriteOptions(**{arg: value})
+        Postgres.WriteOptions.parse({arg: value})
 
     # JDBCOptions does not have such restriction
-    options = Postgres.JDBCOptions(**{arg: value})
+    options = Postgres.JDBCOptions.parse({arg: value})
     assert options.dict()[arg] == value
 
 
@@ -73,7 +73,7 @@ def test_jdbc_read_write_options_populated_by_connection_class(arg, value):
 def test_jdbc_write_options_cannot_be_used_in_read_options(arg, value):
     error_msg = rf"Options \['{arg}'\] are not allowed to use in a ReadOptions"
     with pytest.raises(ValueError, match=error_msg):
-        Postgres.ReadOptions(**{arg: value})
+        Postgres.ReadOptions.parse({arg: value})
 
 
 @pytest.mark.parametrize(
@@ -101,7 +101,7 @@ def test_jdbc_write_options_cannot_be_used_in_read_options(arg, value):
 def test_jdbc_read_options_cannot_be_used_in_write_options(arg, value):
     error_msg = rf"Options \['{arg}'\] are not allowed to use in a WriteOptions"
     with pytest.raises(ValueError, match=error_msg):
-        Postgres.WriteOptions(**{arg: value})
+        Postgres.WriteOptions.parse({arg: value})
 
 
 @pytest.mark.parametrize(
@@ -129,7 +129,7 @@ def test_jdbc_read_options_cannot_be_used_in_write_options(arg, value):
 def test_jdbc_old_options_allowed_but_deprecated(arg, value):
     warning_msg = "Please use 'ReadOptions' or 'WriteOptions' class instead. Will be removed in v1.0.0"
     with pytest.warns(UserWarning, match=warning_msg):
-        options = Postgres.Options(**{arg: value})
+        options = Postgres.Options.parse({arg: value})
 
     assert options.dict(by_alias=True)[to_camel(arg)] == value
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

<!-- Please give a short summary of the changes. -->

1. Added `Kafka.close()` method. It calls `kafka.protocol.cleanup()` and `kafka.auth.cleanup()` methods, allowing to delete temporary objects and files created by auth & protocol implementations.
2. Implemented `KafkaKerberosAuth.cleanup()` method - if it copies keytab file to current directory, and file still exist, it will be deleted. To prevent deleting source keytab (e.g. `Kafka.KerberosAuth(keytab="./user.keytab", deploy_keytab=True)` which already present in the source directory), keytab is copied with new name in format `${principal}_${md5(file)}.keytab`. This also prevents issues like using different keytabs different Kafka by instances which have the same file name.
3. Updated implementation of `_validate_keytab` validator - function for checking keytab availability is already there, in `kerberos_helpers` module. Moved it to `onetl._util.file`
4. Implemented passing custom `sasl.kerberos.*` options to Kafka config.
5. Allowed keytab path to be None. This allows using `Kafka.KerberosAuth(principal="me", useTicketCache=True)` on `spark.master=local`.
6. Added examples of using `KerberosAuth` and `BasicAuth`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [X] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [ ] My PR is ready to review.
