### PR TITLE
[DOP-7983] - restrict streaming df in run method

### DIFF
--- a/onetl/db/db_writer/db_writer.py
+++ b/onetl/db/db_writer/db_writer.py
@@ -183,7 +183,7 @@ class DBWriter(FrozenModel):
         """
         Method for writing your df to specified target. |support_hooks|
 
-        .. note :: Method doesn't support only **streaming** DataFrames.
+        .. note :: Method does support only **batching** DataFrames.
 
         Parameters
         ----------

--- a/onetl/db/db_writer/db_writer.py
+++ b/onetl/db/db_writer/db_writer.py
@@ -183,7 +183,7 @@ class DBWriter(FrozenModel):
         """
         Method for writing your df to specified target. |support_hooks|
 
-        .. note :: Method supports only **batch** DataFrames.
+        .. note :: Method doesn't support only **streaming** DataFrames.
 
         Parameters
         ----------

--- a/onetl/db/db_writer/db_writer.py
+++ b/onetl/db/db_writer/db_writer.py
@@ -183,6 +183,8 @@ class DBWriter(FrozenModel):
         """
         Method for writing your df to specified target. |support_hooks|
 
+        .. note :: Method supports only **batch** DataFrames.
+
         Parameters
         ----------
         df : pyspark.sql.dataframe.DataFrame
@@ -197,6 +199,8 @@ class DBWriter(FrozenModel):
 
             writer.run(df)
         """
+        if df.isStreaming:
+            raise ValueError(f"DataFrame is streaming. {self.__class__.__name__} supports only batch DataFrames.")
 
         entity_boundary_log(msg="DBWriter starts")
 

--- a/onetl/file/file_writer/file_writer.py
+++ b/onetl/file/file_writer/file_writer.py
@@ -104,7 +104,7 @@ class FileWriter(FrozenModel):
         """
         Method for writing DataFrame as files. |support_hooks|
 
-        .. note :: Method doesn't support only **streaming** DataFrames.
+        .. note :: Method does support only **batching** DataFrames.
 
         Parameters
         ----------

--- a/onetl/file/file_writer/file_writer.py
+++ b/onetl/file/file_writer/file_writer.py
@@ -104,7 +104,7 @@ class FileWriter(FrozenModel):
         """
         Method for writing DataFrame as files. |support_hooks|
 
-        .. note :: Method supports only **batch** DataFrames.
+        .. note :: Method doesn't support only **streaming** DataFrames.
 
         Parameters
         ----------

--- a/onetl/file/file_writer/file_writer.py
+++ b/onetl/file/file_writer/file_writer.py
@@ -104,6 +104,8 @@ class FileWriter(FrozenModel):
         """
         Method for writing DataFrame as files. |support_hooks|
 
+        .. note :: Method supports only **batch** DataFrames.
+
         Parameters
         ----------
 
@@ -119,6 +121,9 @@ class FileWriter(FrozenModel):
 
             writer.run(df)
         """
+
+        if df.isStreaming:
+            raise ValueError(f"DataFrame is streaming. {self.__class__.__name__} supports only batch DataFrames.")
 
         entity_boundary_log(f"{self.__class__.__name__} starts")
 

--- a/tests/tests_integration/tests_core_integration/test_file_writer_integration/test_common_file_writer_integration.py
+++ b/tests/tests_integration/tests_core_integration/test_file_writer_integration/test_common_file_writer_integration.py
@@ -565,3 +565,21 @@ def test_file_writer_run_if_exists_append_to_overlapping_partitions(
     assert read_df.count()
     assert read_df.schema == file_df_schema_str_value_last
     assert_equal_df(read_df, df, order_by="id")
+
+
+def test_file_writer_with_streaming_df(
+    spark,
+    file_df_connection_with_path,
+):
+    file_df_connection, target_path = file_df_connection_with_path
+    csv_root = target_path / "csv"
+    writer = FileWriter(
+        connection=file_df_connection,
+        format=CSV(),
+        target_path=csv_root,
+    )
+
+    streaming_df = spark.readStream.format("rate").load()
+    assert streaming_df.isStreaming
+    with pytest.raises(ValueError, match="DataFrame is streaming. FileWriter supports only batch DataFrames."):
+        writer.run(streaming_df)

--- a/tests/tests_integration/tests_core_integration/tests_db_writer_integration/test_common_db_writer_integration.py
+++ b/tests/tests_integration/tests_core_integration/tests_db_writer_integration/test_common_db_writer_integration.py
@@ -1,0 +1,27 @@
+import pytest
+
+from onetl.connection import MongoDB
+from onetl.db import DBWriter
+
+pytestmark = pytest.mark.mongodb
+
+
+def test_mongodb_writer_with_streaming_df(spark, processing, prepare_schema_table):
+    mongo = MongoDB(
+        host=processing.host,
+        port=processing.port,
+        user=processing.user,
+        password=processing.password,
+        database=processing.database,
+        spark=spark,
+    )
+
+    writer = DBWriter(
+        connection=mongo,
+        table=prepare_schema_table.table,
+    )
+
+    streaming_df = spark.readStream.format("rate").load()
+    assert streaming_df.isStreaming
+    with pytest.raises(ValueError, match="DataFrame is streaming. DBWriter supports only batch DataFrames."):
+        writer.run(streaming_df)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

- restrict spark streaming dataframe in `DBWriter` and `FileWriter` `.run()` method
- add integration tests
- updated documentation

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [x] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
