### PR TITLE
[DOP-8112] Log real module, file and line number

### DIFF
--- a/onetl/connection/db_connection/db_connection.py
+++ b/onetl/connection/db_connection/db_connection.py
@@ -153,7 +153,7 @@ class DBConnection(BaseDBConnection, FrozenModel):
 
     def _log_parameters(self):
         log.info("|Spark| Using connection parameters:")
-        log_with_indent("type = %s", self.__class__.__name__)
+        log_with_indent(log, "type = %s", self.__class__.__name__)
         parameters = self.dict(exclude_none=True, exclude={"spark"})
         for attr, value in sorted(parameters.items()):
-            log_with_indent("%s = %r", attr, value)
+            log_with_indent(log, "%s = %r", attr, value)

--- a/onetl/connection/db_connection/greenplum.py
+++ b/onetl/connection/db_connection/greenplum.py
@@ -604,7 +604,7 @@ class Greenplum(JDBCMixin, DBConnection):
         log.info("|%s| Executing SQL query (on executor):", self.__class__.__name__)
         where = self.Dialect._condition_assembler(condition=where, start_from=start_from, end_at=end_at)
         query = get_sql_query(table=source, columns=columns, where=where)
-        log_lines(query)
+        log_lines(log, query)
 
         df = self.spark.read.format("greenplum").options(**self._connector_params(source), **read_options).load()
         self._check_expected_jobs_number(df, action="read")
@@ -652,7 +652,7 @@ class Greenplum(JDBCMixin, DBConnection):
         jdbc_options = self.JDBCOptions.parse(options).copy(update={"fetchsize": 0})
 
         log.debug("|%s| Executing SQL query (on driver):", self.__class__.__name__)
-        log_lines(query, level=logging.DEBUG)
+        log_lines(log, query, level=logging.DEBUG)
 
         df = self._query_on_driver(query, jdbc_options)
         log.info("|%s| Schema fetched", self.__class__.__name__)
@@ -689,7 +689,7 @@ class Greenplum(JDBCMixin, DBConnection):
         )
 
         log.info("|%s| Executing SQL query (on driver):", self.__class__.__name__)
-        log_lines(query)
+        log_lines(log, query)
 
         df = self._query_on_driver(query, jdbc_options)
         row = df.collect()[0]
@@ -697,8 +697,8 @@ class Greenplum(JDBCMixin, DBConnection):
         max_value = row["max"]
 
         log.info("|Spark| Received values:")
-        log_with_indent("MIN(%r) = %r", column, min_value)
-        log_with_indent("MAX(%r) = %r", column, max_value)
+        log_with_indent(log, "MIN(%r) = %r", column, min_value)
+        log_with_indent(log, "MAX(%r) = %r", column, max_value)
 
         return min_value, max_value
 
@@ -754,7 +754,7 @@ class Greenplum(JDBCMixin, DBConnection):
                 WHERE  name = '{name}'
                 """
         log.debug("|%s| Executing SQL query (on driver):")
-        log_lines(query, level=logging.DEBUG)
+        log_lines(log, query, level=logging.DEBUG)
 
         df = self._query_on_driver(query, self.JDBCOptions())
         result = df.collect()
@@ -775,7 +775,7 @@ class Greenplum(JDBCMixin, DBConnection):
                 FROM pg_stat_database
                 """
         log.debug("|%s| Executing SQL query (on driver):")
-        log_lines(query, level=logging.DEBUG)
+        log_lines(log, query, level=logging.DEBUG)
 
         df = self._query_on_driver(query, self.JDBCOptions())
         result = df.collect()
@@ -858,8 +858,8 @@ class Greenplum(JDBCMixin, DBConnection):
         if max_jobs >= self.CONNECTIONS_EXCEPTION_LIMIT:
             raise TooManyParallelJobsError(message)
 
-        log_lines(message, level=logging.WARNING)
+        log_lines(log, message, level=logging.WARNING)
 
     def _log_parameters(self):
         super()._log_parameters()
-        log_with_indent("jdbc_url = %r", self.jdbc_url)
+        log_with_indent(log, "jdbc_url = %r", self.jdbc_url)

--- a/onetl/connection/db_connection/hive.py
+++ b/onetl/connection/db_connection/hive.py
@@ -647,7 +647,7 @@ class Hive(DBConnection):
         self._log_parameters()
 
         log.debug("|%s| Executing SQL query:", self.__class__.__name__)
-        log_lines(self._CHECK_QUERY, level=logging.DEBUG)
+        log_lines(log, self._CHECK_QUERY, level=logging.DEBUG)
 
         try:
             self._execute_sql(self._CHECK_QUERY)
@@ -699,7 +699,7 @@ class Hive(DBConnection):
         query = clear_statement(query)
 
         log.info("|%s| Executing SQL query:", self.__class__.__name__)
-        log_lines(query)
+        log_lines(log, query)
 
         df = self._execute_sql(query)
         log.info("|Spark| DataFrame successfully created from SQL statement")
@@ -759,7 +759,7 @@ class Hive(DBConnection):
         statement = clear_statement(statement)
 
         log.info("|%s| Executing statement:", self.__class__.__name__)
-        log_lines(statement)
+        log_lines(log, statement)
 
         self._execute_sql(statement).collect()
         log.info("|%s| Call succeeded", self.__class__.__name__)
@@ -822,7 +822,7 @@ class Hive(DBConnection):
         query = get_sql_query(source, columns=columns, where="1=0", compact=True)
 
         log.debug("|%s| Executing SQL query:", self.__class__.__name__)
-        log_lines(query, level=logging.DEBUG)
+        log_lines(log, query, level=logging.DEBUG)
 
         df = self._execute_sql(query)
         log.info("|%s| Schema fetched", self.__class__.__name__)
@@ -856,7 +856,7 @@ class Hive(DBConnection):
         )
 
         log.debug("|%s| Executing SQL query:", self.__class__.__name__)
-        log_lines(sql_text, level=logging.DEBUG)
+        log_lines(log, sql_text, level=logging.DEBUG)
 
         df = self._execute_sql(sql_text)
         row = df.collect()[0]
@@ -864,8 +864,8 @@ class Hive(DBConnection):
         max_value = row["max"]
 
         log.info("|Spark| Received values:")
-        log_with_indent("MIN(%s) = %r", column, min_value)
-        log_with_indent("MAX(%s) = %r", column, max_value)
+        log_with_indent(log, "MIN(%s) = %r", column, min_value)
+        log_with_indent(log, "MAX(%s) = %r", column, max_value)
 
         return min_value, max_value
 

--- a/onetl/connection/db_connection/jdbc_connection.py
+++ b/onetl/connection/db_connection/jdbc_connection.py
@@ -661,7 +661,7 @@ class JDBCConnection(SupportDfSchemaNone, JDBCMixin, DBConnection):
         query = clear_statement(query)
 
         log.info("|%s| Executing SQL query (on executor):", self.__class__.__name__)
-        log_lines(query)
+        log_lines(log, query)
 
         df = self._query_on_executor(query, self.ReadOptions.parse(options))
 
@@ -744,7 +744,7 @@ class JDBCConnection(SupportDfSchemaNone, JDBCMixin, DBConnection):
         read_options = self._exclude_partition_options(options, fetchsize=0)
 
         log.debug("|%s| Executing SQL query (on driver):", self.__class__.__name__)
-        log_lines(query, level=logging.DEBUG)
+        log_lines(log, query, level=logging.DEBUG)
 
         df = self._query_on_driver(query, read_options)
         log.info("|%s| Schema fetched", self.__class__.__name__)
@@ -815,7 +815,7 @@ class JDBCConnection(SupportDfSchemaNone, JDBCMixin, DBConnection):
         )
 
         log.info("|%s| Executing SQL query (on driver):", self.__class__.__name__)
-        log_lines(query)
+        log_lines(log, query)
 
         df = self._query_on_driver(query, read_options)
         row = df.collect()[0]
@@ -823,8 +823,8 @@ class JDBCConnection(SupportDfSchemaNone, JDBCMixin, DBConnection):
         max_value = row["max"]
 
         log.info("|Spark| Received values:")
-        log_with_indent("MIN(%s) = %r", column, min_value)
-        log_with_indent("MAX(%s) = %r", column, max_value)
+        log_with_indent(log, "MIN(%s) = %r", column, min_value)
+        log_with_indent(log, "MAX(%s) = %r", column, max_value)
 
         return min_value, max_value
 
@@ -903,4 +903,4 @@ class JDBCConnection(SupportDfSchemaNone, JDBCMixin, DBConnection):
 
     def _log_parameters(self):
         super()._log_parameters()
-        log_with_indent("jdbc_url = %r", self.jdbc_url)
+        log_with_indent(log, "jdbc_url = %r", self.jdbc_url)

--- a/onetl/connection/db_connection/jdbc_mixin.py
+++ b/onetl/connection/db_connection/jdbc_mixin.py
@@ -157,7 +157,7 @@ class JDBCMixin(FrozenModel):
         self._log_parameters()  # type: ignore
 
         log.debug("|%s| Executing SQL query (on driver):", self.__class__.__name__)
-        log_lines(self._CHECK_QUERY, level=logging.DEBUG)
+        log_lines(log, self._CHECK_QUERY, level=logging.DEBUG)
 
         try:
             self._query_optional_on_driver(self._CHECK_QUERY, self.JDBCOptions(fetchsize=1))  # type: ignore
@@ -255,7 +255,7 @@ class JDBCMixin(FrozenModel):
         query = clear_statement(query)
 
         log.info("|%s| Executing SQL query (on driver):", self.__class__.__name__)
-        log_lines(query)
+        log_lines(log, query)
 
         df = self._query_on_driver(query, self.JDBCOptions.parse(options))
 
@@ -369,7 +369,7 @@ class JDBCMixin(FrozenModel):
         statement = clear_statement(statement)
 
         log.info("|%s| Executing statement (on driver):", self.__class__.__name__)
-        log_lines(statement)
+        log_lines(log, statement)
 
         call_options = self.JDBCOptions.parse(options)
         df = self._call_on_driver(statement, call_options)

--- a/onetl/connection/db_connection/kafka/connection.py
+++ b/onetl/connection/db_connection/kafka/connection.py
@@ -46,7 +46,7 @@ from onetl.connection.db_connection.kafka.slots import KafkaSlots
 from onetl.exception import MISSING_JVM_CLASS_MSG, TargetAlreadyExistsError
 from onetl.hooks import slot, support_hooks
 from onetl.hwm import Statement
-from onetl.log import log_with_indent
+from onetl.log import log_collection, log_with_indent
 
 if TYPE_CHECKING:
     from pyspark.sql import DataFrame
@@ -532,9 +532,9 @@ class Kafka(DBConnection):
 
     def _log_parameters(self):
         log.info("|Spark| Using connection parameters:")
-        log_with_indent("type = %s", self.__class__.__name__)
-        log_with_indent("addresses = %r", self.addresses)
-        log_with_indent("cluster = %r", self.cluster)
-        log_with_indent("protocol = %r", self.protocol)
-        log_with_indent("auth = %r", self.auth)
-        log_with_indent("extra = %r", self.extra.dict(by_alias=True, exclude_none=True))
+        log_with_indent(log, "type = %s", self.__class__.__name__)
+        log_with_indent(log, "cluster = %r", self.cluster)
+        log_collection(log, "addresses", self.addresses, max_items=10)
+        log_with_indent(log, "protocol = %r", self.protocol)
+        log_with_indent(log, "auth = %r", self.auth)
+        log_with_indent(log, "extra = %r", self.extra.dict(by_alias=True, exclude_none=True))

--- a/onetl/connection/db_connection/mongodb.py
+++ b/onetl/connection/db_connection/mongodb.py
@@ -759,14 +759,14 @@ class MongoDB(DBConnection):
 
         read_options = self.PipelineOptions.parse(options).dict(by_alias=True, exclude_none=True)
         pipeline = self.Dialect.prepare_pipeline(pipeline)
-        log_with_indent("collection = %r", collection)
-        log_json(pipeline, name="pipeline")
+        log_with_indent(log, "collection = %r", collection)
+        log_json(log, pipeline, name="pipeline")
 
         if df_schema:
             empty_df = self.spark.createDataFrame([], df_schema)
-            log_dataframe_schema(empty_df)
+            log_dataframe_schema(log, empty_df)
 
-        log_options(read_options)
+        log_options(log, read_options)
 
         read_options["collection"] = collection
         read_options["aggregation.pipeline"] = self.Dialect.convert_to_str(pipeline)
@@ -827,9 +827,9 @@ class MongoDB(DBConnection):
             read_options["hint"] = self.Dialect.convert_to_str(hint)
 
         log.info("|%s| Executing aggregation pipeline:", self.__class__.__name__)
-        log_with_indent("collection = %r", source)
-        log_json(pipeline, "pipeline")
-        log_json(hint, "hint")
+        log_with_indent(log, "collection = %r", source)
+        log_json(log, pipeline, "pipeline")
+        log_json(log, hint, "hint")
 
         df = self.spark.read.format("mongodb").options(**read_options).load()
         row = df.collect()[0]
@@ -837,8 +837,8 @@ class MongoDB(DBConnection):
         max_value = row["max"]
 
         log.info("|Spark| Received values:")
-        log_with_indent("MIN(%s) = %r", column, min_value)
-        log_with_indent("MAX(%s) = %r", column, max_value)
+        log_with_indent(log, "MIN(%s) = %r", column, min_value)
+        log_with_indent(log, "MAX(%s) = %r", column, max_value)
 
         return min_value, max_value
 
@@ -872,9 +872,9 @@ class MongoDB(DBConnection):
         read_options["collection"] = source
 
         log.info("|%s| Executing aggregation pipeline:", self.__class__.__name__)
-        log_with_indent("collection = %r", source)
-        log_json(pipeline, "pipeline")
-        log_json(hint, "hint")
+        log_with_indent(log, "collection = %r", source)
+        log_json(log, pipeline, "pipeline")
+        log_json(log, hint, "hint")
         spark_reader = self.spark.read.format("mongodb").options(**read_options)
 
         if df_schema:

--- a/onetl/connection/db_connection/oracle.py
+++ b/onetl/connection/db_connection/oracle.py
@@ -277,7 +277,7 @@ class Oracle(JDBCConnection):
         statement = clear_statement(statement)
 
         log.info("|%s| Executing statement (on driver):", self.__class__.__name__)
-        log_lines(statement)
+        log_lines(log, statement)
 
         call_options = self.JDBCOptions.parse(options)
         df = self._call_on_driver(statement, call_options)
@@ -420,7 +420,7 @@ class Oracle(JDBCConnection):
         fail = any(error.level == logging.ERROR for error in aggregated_errors)
 
         message = self._build_error_message(aggregated_errors)
-        log_lines(message, level=logging.ERROR if fail else logging.WARNING)
+        log_lines(log, message, level=logging.ERROR if fail else logging.WARNING)
 
         if fail:
             raise ValueError(message)

--- a/onetl/connection/file_connection/file_connection.py
+++ b/onetl/connection/file_connection/file_connection.py
@@ -716,13 +716,13 @@ class FileConnection(BaseFileConnection, FrozenModel):
 
     def _log_parameters(self):
         log.info("|onETL| Using connection parameters:")
-        log_with_indent("type = %s", self.__class__.__name__)
+        log_with_indent(log, "type = %s", self.__class__.__name__)
         parameters = self.dict(exclude_none=True)
         for attr, value in sorted(parameters.items()):
             if isinstance(value, os.PathLike):
-                log_with_indent("%s = %s", attr, path_repr(value))
+                log_with_indent(log, "%s = %s", attr, path_repr(value))
             else:
-                log_with_indent("%s = %r", attr, value)
+                log_with_indent(log, "%s = %r", attr, value)
 
     @abstractmethod
     def _get_client(self) -> Any:

--- a/onetl/connection/file_df_connection/spark_file_df_connection.py
+++ b/onetl/connection/file_df_connection/spark_file_df_connection.py
@@ -184,7 +184,7 @@ class SparkFileDFConnection(BaseFileDFConnection, FrozenModel):
 
     def _log_parameters(self):
         log.info("|Spark| Using connection parameters:")
-        log_with_indent("type = %s", self.__class__.__name__)
+        log_with_indent(log, "type = %s", self.__class__.__name__)
         parameters = self.dict(exclude_none=True, exclude={"spark"})
         for attr, value in sorted(parameters.items()):
-            log_with_indent("%s = %r", attr, value)
+            log_with_indent(log, "%s = %r", attr, value)

--- a/onetl/connection/file_df_connection/spark_s3/connection.py
+++ b/onetl/connection/file_df_connection/spark_s3/connection.py
@@ -407,8 +407,8 @@ class SparkS3(SparkFileDFConnection):
                     self.__class__.__name__,
                 )
                 if log.isEnabledFor(logging.DEBUG):
-                    log_options(expected_values, "expected", level=logging.DEBUG)
-                    log_options(real_values, "real", level=logging.DEBUG)
+                    log_options(log, expected_values, "expected", level=logging.DEBUG)
+                    log_options(log, real_values, "real", level=logging.DEBUG)
 
             log.debug("Reset FileSystem cache")
             # Reset FileSystem cache to apply new config

--- a/onetl/core/file_filter/file_filter.py
+++ b/onetl/core/file_filter/file_filter.py
@@ -25,7 +25,6 @@ from pydantic import Field, root_validator, validator
 
 from onetl.base import BaseFileFilter, PathProtocol
 from onetl.impl import FrozenModel, RemotePath
-from onetl.log import log_with_indent
 
 
 class FileFilter(BaseFileFilter, FrozenModel):
@@ -208,7 +207,3 @@ class FileFilter(BaseFileFilter, FrozenModel):
             return self.regexp.search(os.fspath(path)) is not None
 
         return True
-
-    def log_options(self, indent: int = 0):
-        for key, value in self.dict(exclude_none=True, by_alias=True).items():  # noqa: WPS528
-            log_with_indent("%s = %r", key, value, indent=indent)

--- a/onetl/core/file_limit/file_limit.py
+++ b/onetl/core/file_limit/file_limit.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import logging
 import textwrap
 import warnings
 
@@ -22,9 +21,6 @@ from pydantic import validator
 
 from onetl.base import BaseFileLimit, PathProtocol
 from onetl.impl import FrozenModel
-from onetl.log import log_with_indent
-
-log = logging.getLogger(__name__)
 
 
 class FileLimit(BaseFileLimit, FrozenModel):
@@ -79,12 +75,8 @@ class FileLimit(BaseFileLimit, FrozenModel):
     def is_reached(self) -> bool:
         return self._counter >= self.count_limit
 
-    def log_options(self, indent: int = 0):
-        for key, value in self.dict(by_alias=True).items():  # noqa: WPS528
-            log_with_indent("%s = %r", key, value, indent=indent)
-
     @validator("count_limit")
-    def log_deprecated(cls, value):
+    def _deprecated(cls, value):
         message = f"""
             Using FileLimit is deprecated since v0.8.0 and will be removed in v1.0.0.
 

--- a/onetl/db/db_reader/db_reader.py
+++ b/onetl/db/db_reader/db_reader.py
@@ -539,10 +539,9 @@ class DBReader(FrozenModel):
             StrategyHelper,
         )
 
-        entity_boundary_log(msg="DBReader starts")
+        entity_boundary_log(log, msg="DBReader starts")
 
         self._log_parameters()
-        self._log_options()
         self.connection.check()
 
         helper: StrategyHelper
@@ -565,36 +564,35 @@ class DBReader(FrozenModel):
         )
 
         df = helper.save(df)
-        entity_boundary_log(msg="DBReader ends", char="-")
+        entity_boundary_log(log, msg="DBReader ends", char="-")
 
         return df
 
     def _log_parameters(self) -> None:
         log.info("|%s| -> |Spark| Reading DataFrame from source using parameters:", self.connection.__class__.__name__)
-        log_with_indent("source = '%s'", self.source)
+        log_with_indent(log, "source = '%s'", self.source)
 
         if self.hint:
-            log_json(self.hint, "hint")
+            log_json(log, self.hint, "hint")
 
         if self.columns:
-            log_collection("columns", self.columns)
+            log_collection(log, "columns", self.columns)
 
         if self.where:
-            log_json(self.where, "where")
+            log_json(log, self.where, "where")
 
         if self.hwm_column:
-            log_with_indent("hwm_column = '%s'", self.hwm_column)
+            log_with_indent(log, "hwm_column = '%s'", self.hwm_column)
 
         if self.hwm_expression:
-            log_json(self.hwm_expression, "hwm_expression")
+            log_json(log, self.hwm_expression, "hwm_expression")
 
         if self.df_schema:
             empty_df = self.connection.spark.createDataFrame([], self.df_schema)  # type: ignore
-            log_dataframe_schema(empty_df)
+            log_dataframe_schema(log, empty_df)
 
-    def _log_options(self) -> None:
         options = self.options.dict(by_alias=True, exclude_none=True) if self.options else None
-        log_options(options)
+        log_options(log, options)
 
     def _resolve_all_columns(self) -> list[str] | None:
         """

--- a/onetl/db/db_writer/db_writer.py
+++ b/onetl/db/db_writer/db_writer.py
@@ -202,10 +202,10 @@ class DBWriter(FrozenModel):
         if df.isStreaming:
             raise ValueError(f"DataFrame is streaming. {self.__class__.__name__} supports only batch DataFrames.")
 
-        entity_boundary_log(msg="DBWriter starts")
+        entity_boundary_log(log, msg="DBWriter starts")
 
         self._log_parameters()
-        log_dataframe_schema(df)
+        log_dataframe_schema(log, df)
         self.connection.check()
         self.connection.write_df_to_target(
             df=df,
@@ -213,14 +213,14 @@ class DBWriter(FrozenModel):
             **self._get_write_kwargs(),
         )
 
-        entity_boundary_log(msg="DBWriter ends", char="-")
+        entity_boundary_log(log, msg="DBWriter ends", char="-")
 
     def _log_parameters(self) -> None:
         log.info("|Spark| -> |%s| Writing DataFrame to target using parameters:", self.connection.__class__.__name__)
-        log_with_indent("target = '%s'", self.target)
+        log_with_indent(log, "target = '%s'", self.target)
 
         options = self.options.dict(by_alias=True, exclude_none=True) if self.options else None
-        log_options(options)
+        log_options(log, options)
 
     def _get_write_kwargs(self) -> dict:
         if self.options:

--- a/onetl/file/file_df_reader/file_df_reader.py
+++ b/onetl/file/file_df_reader/file_df_reader.py
@@ -217,14 +217,14 @@ class FileDFReader(FrozenModel):
             paths = FileSet([self.source_path])
 
         self.connection.check()
-        log_with_indent("")
+        log_with_indent(log, "")
 
         return self._read_files(paths)
 
     def _read_files(self, paths: FileSet[PurePathProtocol]) -> DataFrame:
         log.info("|%s| Paths to be read:", self.__class__.__name__)
-        log_lines(str(paths))
-        log_with_indent("")
+        log_lines(log, str(paths))
+        log_with_indent(log, "")
 
         return self.connection.read_files_as_df(
             root=self.source_path,
@@ -234,20 +234,19 @@ class FileDFReader(FrozenModel):
             options=self.options,
         )
 
-    def _log_parameters(self, files: Iterable[str | os.PathLike] | None = None) -> None:  # noqa: WPS213
-        entity_boundary_log(msg=f"{self.__class__.__name__} starts")
+    def _log_parameters(self, files: Iterable[str | os.PathLike] | None = None) -> None:
+        entity_boundary_log(log, msg=f"{self.__class__.__name__} starts")
 
         log.info("|%s| -> |Spark| Reading files using parameters:", self.connection.__class__.__name__)
-        log_with_indent("source_path = %s", f"'{self.source_path}'" if self.source_path else "None")
-        log_with_indent("format = %r", self.format)
+        log_with_indent(log, "source_path = %s", f"'{self.source_path}'" if self.source_path else "None")
+        log_with_indent(log, "format = %r", self.format)
 
         if self.df_schema:
             empty_df = self.connection.spark.createDataFrame([], self.df_schema)  # type: ignore[attr-defined]
-            log_dataframe_schema(empty_df)
+            log_dataframe_schema(log, empty_df)
 
         options_dict = self.options.dict(exclude_none=True)
-        if options_dict:
-            log_options(options_dict)
+        log_options(log, options_dict)
 
         if files is not None and self.source_path:
             log.warning(

--- a/onetl/file/file_df_writer/file_df_writer.py
+++ b/onetl/file/file_df_writer/file_df_writer.py
@@ -125,7 +125,7 @@ class FileDFWriter(FrozenModel):
         if df.isStreaming:
             raise ValueError(f"DataFrame is streaming. {self.__class__.__name__} supports only batch DataFrames.")
 
-        entity_boundary_log(f"{self.__class__.__name__} starts")
+        entity_boundary_log(log, f"{self.__class__.__name__} starts")
 
         self._log_parameters(df)
         self.connection.check()
@@ -136,18 +136,16 @@ class FileDFWriter(FrozenModel):
             options=self.options,
         )
 
-        entity_boundary_log(f"{self.__class__.__name__} ends", char="-")
+        entity_boundary_log(log, f"{self.__class__.__name__} ends", char="-")
 
-    def _log_parameters(self, df: DataFrame) -> None:  # noqa: WPS213
+    def _log_parameters(self, df: DataFrame) -> None:
         log.info("|Spark| -> |%s| Writing dataframe using parameters:", self.connection.__class__.__name__)
-        log_with_indent("target_path = '%s'", self.target_path)
-        log_with_indent("format = %r", self.format)
+        log_with_indent(log, "target_path = '%s'", self.target_path)
+        log_with_indent(log, "format = %r", self.format)
 
         options_dict = self.options.dict(exclude_none=True)
-        if options_dict:
-            log_options(options_dict)
-
-        log_dataframe_schema(df)
+        log_options(log, options_dict)
+        log_dataframe_schema(log, df)
 
     @validator("target_path", pre=True)
     def _validate_target_path(cls, target_path, values):

--- a/onetl/hwm/store/base_hwm_store.py
+++ b/onetl/hwm/store/base_hwm_store.py
@@ -117,6 +117,6 @@ class BaseHWMStore(BaseModel, ABC):
             log.info("|%s| Using options:", self.__class__.__name__)
             for option, value in options.items():
                 if isinstance(value, os.PathLike):
-                    log_with_indent("%s = %s", option, path_repr(value))
+                    log_with_indent(log, "%s = %s", option, path_repr(value))
                 else:
-                    log_with_indent("%s = %r", option, value)
+                    log_with_indent(log, "%s = %r", option, value)

--- a/onetl/plugins/import_plugins.py
+++ b/onetl/plugins/import_plugins.py
@@ -20,7 +20,7 @@ import textwrap
 
 from importlib_metadata import EntryPoint, entry_points
 
-from onetl.log import log_with_indent
+from onetl.log import log_collection, log_with_indent
 from onetl.version import __version__
 
 log = logging.getLogger(__name__)
@@ -64,7 +64,7 @@ def import_plugin(entrypoint: EntryPoint):
     try:
         loaded = entrypoint.load()
         log.debug("|onETL| Successfully loaded plugin %r", entrypoint.name)
-        log_with_indent("source: %r", inspect.getfile(loaded), level=logging.DEBUG)
+        log_with_indent(log, "source = %r", inspect.getfile(loaded), level=logging.DEBUG)
     except Exception as e:
         error_msg = _prepare_error_msg(
             plugin_name=entrypoint.name,
@@ -75,7 +75,7 @@ def import_plugin(entrypoint: EntryPoint):
         raise ImportError(error_msg) from e
 
 
-def import_plugins(group: str, whitelist: list[str] | None = None, blacklist: list[str] | None = None):
+def import_plugins(group: str, whitelist: list[str] | None = None, blacklist: list[str] | None = None):  # noqa: WPS213
     """
     Import all plugins registered for onETL
     """
@@ -89,8 +89,9 @@ def import_plugins(group: str, whitelist: list[str] | None = None, blacklist: li
         return
 
     log.debug("|Plugins| Found %d plugins", plugins_count)
-    log.debug("|Plugins| Plugins whitelist: %r", whitelist or [])
-    log.debug("|Plugins| Plugins blacklist: %r", blacklist or [])
+    log.debug("|Plugins| Plugin load options:")
+    log_collection(log, "whitelist", whitelist or [], level=logging.DEBUG)
+    log_collection(log, "blacklist", blacklist or [], level=logging.DEBUG)
 
     for i, entrypoint in enumerate(entrypoints):
         if whitelist and entrypoint.name not in whitelist:
@@ -102,11 +103,11 @@ def import_plugins(group: str, whitelist: list[str] | None = None, blacklist: li
             continue
 
         if log.isEnabledFor(logging.DEBUG):
-            log.info("|onETL| Loading plugin (%d of %d):", i + 1, plugins_count)
-            log_with_indent("name: %r", entrypoint.name, level=logging.DEBUG)
-            log_with_indent("package: %r", entrypoint.dist.name, level=logging.DEBUG)
-            log_with_indent("version: %r", entrypoint.dist.version, level=logging.DEBUG)
-            log_with_indent("importing: %r", entrypoint.value, level=logging.DEBUG)
+            log.debug("|onETL| Loading plugin (%d of %d):", i + 1, plugins_count)
+            log_with_indent(log, "name = %r", entrypoint.name, level=logging.DEBUG)
+            log_with_indent(log, "package = %r", entrypoint.dist.name, level=logging.DEBUG)
+            log_with_indent(log, "version = %r", entrypoint.dist.version, level=logging.DEBUG)
+            log_with_indent(log, "importing = %r", entrypoint.value, level=logging.DEBUG)
         else:
             log.info("|onETL| Loading plugin %r", entrypoint.name)
 

--- a/onetl/strategy/base_strategy.py
+++ b/onetl/strategy/base_strategy.py
@@ -68,7 +68,7 @@ class BaseStrategy(BaseModel):
         log.info("|onETL| Using %s as a strategy", self.__class__.__name__)
         parameters = self.dict(by_alias=True, exclude_none=True, exclude=self._log_exclude_fields())
         for attr, value in sorted(parameters.items()):
-            log_with_indent("%s = %r", attr, value)
+            log_with_indent(log, "%s = %r", attr, value)
 
     @classmethod
     def _log_exclude_fields(cls) -> set[str]:

--- a/onetl/strategy/hwm_strategy.py
+++ b/onetl/strategy/hwm_strategy.py
@@ -62,7 +62,7 @@ class HWMStrategy(BaseStrategy):
             hwm_store = HWMStoreManager.get_current()
 
             log.info("|%s| Loading HWM from %s:", class_name, hwm_store.__class__.__name__)
-            log_with_indent("qualified_name = %r", self.hwm.qualified_name)
+            log_with_indent(log, "qualified_name = %r", self.hwm.qualified_name)
 
             result = hwm_store.get(self.hwm.qualified_name)
 
@@ -92,30 +92,26 @@ class HWMStrategy(BaseStrategy):
 
             log.info("|%s| Saving HWM to %r:", class_name, hwm_store.__class__.__name__)
             self._log_hwm(self.hwm)
-            log_with_indent("qualified_name = %r", self.hwm.qualified_name)
+            log_with_indent(log, "qualified_name = %r", self.hwm.qualified_name)
 
             location = hwm_store.save(self.hwm)
             log.info("|%s| HWM has been saved", class_name)
 
             if location:
                 if isinstance(location, os.PathLike):
-                    log_with_indent("location = '%s'", os.fspath(location))
+                    log_with_indent(log, "location = '%s'", os.fspath(location))
                 else:
-                    log_with_indent("location = %r", location)
+                    log_with_indent(log, "location = %r", location)
         else:
             log.debug("|%s| HWM value is not set, do not save", class_name)
 
     def _log_hwm(self, hwm: HWM) -> None:
-        log_with_indent("type = %s", hwm.__class__.__name__)
+        log_with_indent(log, "type = %s", hwm.__class__.__name__)
 
         if isinstance(hwm.value, Collection):
-            if log.isEnabledFor(logging.DEBUG):
-                # file list can be very large, dont' show it unless user asked for
-                log_collection("value", hwm.value, level=logging.DEBUG)
-            else:
-                log_with_indent("value = %r<%d items>", hwm.value.__class__.__name__, len(hwm.value))
+            log_collection(log, "value", hwm.value, max_items=10)
         else:
-            log_with_indent("value = %r", hwm.value)
+            log_with_indent(log, "value = %r", hwm.value)
 
     @classmethod
     def _log_exclude_fields(cls) -> set[str]:

--- a/tests/.coveragerc
+++ b/tests/.coveragerc
@@ -18,3 +18,4 @@ exclude_lines =
     @(abc\.)?abstractmethod
     if pyspark_version
     spark = SparkSession._instantiatedSession
+    if log.isEnabledFor(logging.DEBUG):

--- a/tests/tests_integration/tests_db_connection_integration/test_kafka_integration.py
+++ b/tests/tests_integration/tests_db_connection_integration/test_kafka_integration.py
@@ -4,7 +4,7 @@ import pytest
 
 from onetl.connection import Kafka
 
-pytestmark = [pytest.mark.kafka, pytest.mark.df_connection, pytest.mark.connection]
+pytestmark = [pytest.mark.kafka, pytest.mark.db_connection, pytest.mark.connection]
 
 
 def test_kafka_check_plaintext_anonymous(spark, caplog):
@@ -21,7 +21,8 @@ def test_kafka_check_plaintext_anonymous(spark, caplog):
         assert kafka.check() == kafka
 
     assert "type = Kafka" in caplog.text
-    assert f"addresses = ['{kafka_processing.host}:{kafka_processing.port}']" in caplog.text
+    assert "addresses = [" in caplog.text
+    assert f"'{kafka_processing.host}:{kafka_processing.port}'" in caplog.text
     assert "cluster = 'cluster'" in caplog.text
     assert "protocol = KafkaPlaintextProtocol()" in caplog.text
     assert "auth = None" in caplog.text
@@ -48,7 +49,8 @@ def test_kafka_check_plaintext_basic_auth(spark, caplog):
         assert kafka.check() == kafka
 
     assert "type = Kafka" in caplog.text
-    assert f"addresses = ['{kafka_processing.host}:{kafka_processing.sasl_port}']" in caplog.text
+    assert "addresses = [" in caplog.text
+    assert f"'{kafka_processing.host}:{kafka_processing.sasl_port}'" in caplog.text
     assert "cluster = 'cluster'" in caplog.text
     assert "protocol = KafkaPlaintextProtocol()" in caplog.text
     assert f"auth = KafkaBasicAuth(user='{kafka_processing.user}', password=SecretStr('**********'))" in caplog.text
@@ -77,7 +79,8 @@ def test_kafka_check_plaintext_scram_auth(digest, spark, caplog):
         assert kafka.check() == kafka
 
     assert "type = Kafka" in caplog.text
-    assert f"addresses = ['{kafka_processing.host}:{kafka_processing.sasl_port}']" in caplog.text
+    assert "addresses = [" in caplog.text
+    assert f"'{kafka_processing.host}:{kafka_processing.sasl_port}'" in caplog.text
     assert "cluster = 'cluster'" in caplog.text
     assert "protocol = KafkaPlaintextProtocol()" in caplog.text
     assert (

--- a/tests/tests_integration/tests_strategy_integration/tests_incremental_batch_strategy_integration/test_strategy_incremental_batch_kafka.py
+++ b/tests/tests_integration/tests_strategy_integration/tests_incremental_batch_strategy_integration/test_strategy_incremental_batch_kafka.py
@@ -4,7 +4,7 @@ from onetl.connection import Kafka
 from onetl.db import DBReader
 from onetl.strategy import IncrementalBatchStrategy, SnapshotBatchStrategy
 
-pytestmark = [pytest.mark.kafka, pytest.mark.df_connection, pytest.mark.connection]
+pytestmark = [pytest.mark.kafka, pytest.mark.db_connection, pytest.mark.connection]
 
 
 @pytest.mark.parametrize(

--- a/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_clickhouse.py
+++ b/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_clickhouse.py
@@ -103,10 +103,14 @@ def test_clickhouse_strategy_incremental(
         processing.assert_subset_df(df=second_df, other_frame=second_span)
 
 
-# Fail if HWM is Numeric, or Decimal with fractional part, or string
+@pytest.mark.flaky(
+    # sometimes test fails with vague error on Spark side, e.g. `An error occurred while calling o58.version`
+    only_rerun="py4j.protocol.Py4JError",
+)
 @pytest.mark.parametrize(
     "hwm_column",
     [
+        # Fail if HWM is Numeric, or Decimal with fractional part, or string
         "float_value",
         "text_string",
     ],


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

<!-- Please give a short summary of the changes. -->

* Added argument `logger` to all logging functions. It is required to pass actual module name to log context.
* Added `stacklevel` argument to all logging functions. It is required to properly detect file name and line of function caller. Each function passes original stacklevel plus 1 to exclude itself from logging.
* Improved `log_collection` - added option `max_items` which allows to hide too many elements from an input, showing only N first ones and a remainder. This previously was implemented in HWMStrategy to show current HWM value, now it is also used in Kafka connector to show bootstrap servers list (it can be huge).

Before:
```
INFO     onetl.hwm.store.base_hwm_store:base_hwm_store.py:113 |onETL| Using YAMLHWMStore as HWM Store
INFO     onetl.hwm.store.base_hwm_store:base_hwm_store.py:117 |YAMLHWMStore| Using options:
INFO     onetl.log:log.py:174         path = '/tmp/pytest-of-maxim/pytest-32/hwmstore0' (kind='directory', mode='rwx------', mtime='2023-08-14T15:07:28.663466', uid=1000, gid=1000)
INFO     onetl.log:log.py:174         encoding = 'utf-8'
INFO     onetl.strategy.base_strategy:base_strategy.py:68 |onETL| Using IncrementalStrategy as a strategy
INFO     onetl.file.file_downloader.file_downloader:file_downloader.py:472 |S3| Getting files list from path '/data'
INFO     onetl.strategy.hwm_strategy:hwm_strategy.py:64 |IncrementalStrategy| Loading HWM from YAMLHWMStore:
INFO     onetl.log:log.py:174         qualified_name = 'file_list#/data@s3://localhost:9010#pytest@msmartynov'
WARNING  onetl.strategy.hwm_strategy:hwm_strategy.py:74 |IncrementalStrategy| HWM does not exist in 'YAMLHWMStore'. ALL ROWS/FILES WILL BE READ!
INFO     onetl.log:log.py:297 =================================== FileDownloader starts ===================================
INFO     onetl.file.file_downloader.file_downloader:file_downloader.py:596 |S3| -> |Local FS| Downloading files using parameters:
INFO     onetl.log:log.py:174         source_path = '/data'
INFO     onetl.log:log.py:174         local_path = '/tmp/pytest-of-maxim/pytest-32/local_path0'
INFO     onetl.log:log.py:174         temp_path = 'None'
INFO     onetl.log:log.py:174         filters = []
INFO     onetl.log:log.py:174         limits = []
INFO     onetl.log:log.py:174         options = {
INFO     onetl.log:log.py:174             'mode': 'error',
INFO     onetl.log:log.py:174             'delete_source': False,
INFO     onetl.log:log.py:174             'workers': 1,
INFO     onetl.log:log.py:174         }
INFO     onetl.connection.file_connection.file_connection:file_connection.py:123 |S3| Checking connection availability...
INFO     onetl.connection.file_connection.file_connection:file_connection.py:718 |onETL| Using connection parameters:
INFO     onetl.log:log.py:174         type = S3
INFO     onetl.log:log.py:174         access_key = 'onetl'
INFO     onetl.log:log.py:174         bucket = 'onetl'
INFO     onetl.log:log.py:174         host = 'localhost'
INFO     onetl.log:log.py:174         port = 9010
INFO     onetl.log:log.py:174         protocol = 'http'
INFO     onetl.log:log.py:174         secret_key = SecretStr('**********')
INFO     onetl.connection.file_connection.file_connection:file_connection.py:128 |S3| Connection is available
INFO     onetl.log:log.py:174         
INFO     onetl.file.file_downloader.file_downloader:file_downloader.py:395 |FileDownloader| File list is not passed to `run` method
INFO     onetl.file.file_downloader.file_downloader:file_downloader.py:472 |S3| Getting files list from path '/data'
INFO     onetl.strategy.hwm_strategy:hwm_strategy.py:64 |IncrementalStrategy| Loading HWM from YAMLHWMStore:
INFO     onetl.log:log.py:174         qualified_name = 'file_list#/data@s3://localhost:9010#pytest@msmartynov'
WARNING  onetl.strategy.hwm_strategy:hwm_strategy.py:74 |IncrementalStrategy| HWM does not exist in 'YAMLHWMStore'. ALL ROWS/FILES WILL BE READ!
sINFO     onetl.strategy.hwm_strategy:hwm_strategy.py:64 |IncrementalStrategy| Loading HWM from YAMLHWMStore:
INFO     onetl.log:log.py:174         qualified_name = 'file_list#/data@s3://localhost:9010#pytest@msmartynov'
WARNING  onetl.strategy.hwm_strategy:hwm_strategy.py:74 |IncrementalStrategy| HWM does not exist in 'YAMLHWMStore'. ALL ROWS/FILES WILL BE READ!
INFO     onetl.file.file_downloader.file_downloader:file_downloader.py:685 |FileDownloader| Files to be downloaded:
INFO     onetl.log:log.py:208         6 files (size='103 Bytes'):
INFO     onetl.log:log.py:208             '/data/exclude_dir/nested/excluded2.txt' (size='0 Bytes')
INFO     onetl.log:log.py:208             '/data/exclude_dir/excluded1.txt' (size='0 Bytes')
INFO     onetl.log:log.py:208             '/data/nested/exclude_dir/excluded3.txt' (size='0 Bytes')
INFO     onetl.log:log.py:208             '/data/ascii.txt' (size='23 Bytes')
INFO     onetl.log:log.py:208             '/data/some.csv' (size='20 Bytes')
INFO     onetl.log:log.py:208             '/data/utf-8.txt' (size='60 Bytes')
INFO     onetl.log:log.py:174         
INFO     onetl.file.file_downloader.file_downloader:file_downloader.py:688 |FileDownloader| Starting the download process
INFO     onetl.file.file_downloader.file_downloader:file_downloader.py:764 |FileDownloader| Downloading file '/data/exclude_dir/nested/excluded2.txt' to '/tmp/pytest-of-maxim/pytest-32/local_path0/exclude_dir/nested/excluded2.txt'
INFO     onetl.connection.file_connection.file_connection:file_connection.py:299 |Local FS| Successfully downloaded file '/tmp/pytest-of-maxim/pytest-32/local_path0/exclude_dir/nested/excluded2.txt'
INFO     onetl.strategy.hwm_strategy:hwm_strategy.py:93 |IncrementalStrategy| Saving HWM to 'YAMLHWMStore':
INFO     onetl.log:log.py:174         type = FileListHWM
INFO     onetl.log:log.py:174         value = 'frozenset'<1 items>
INFO     onetl.log:log.py:174         qualified_name = 'file_list#/data@s3://localhost:9010#pytest@msmartynov'
INFO     onetl.strategy.hwm_strategy:hwm_strategy.py:98 |IncrementalStrategy| HWM has been saved
INFO     onetl.log:log.py:174         location = '/tmp/pytest-of-maxim/pytest-32/hwmstore0/file_list__data__s3_localhost_9010__pytest__msmartynov.yml'
```

After:
```
INFO     onetl.hwm.store.base_hwm_store:base_hwm_store.py:113 |onETL| Using YAMLHWMStore as HWM Store
INFO     onetl.hwm.store.base_hwm_store:base_hwm_store.py:117 |YAMLHWMStore| Using options:
INFO     onetl.hwm.store.base_hwm_store:base_hwm_store.py:120         path = '/tmp/pytest-of-maxim/pytest-35/hwmstore0' (kind='directory', mode='rwx------', mtime='2023-08-14T15:09:20.727429', uid=1000, gid=1000)
INFO     onetl.hwm.store.base_hwm_store:base_hwm_store.py:122         encoding = 'utf-8'
INFO     onetl.strategy.base_strategy:base_strategy.py:68 |onETL| Using IncrementalStrategy as a strategy
INFO     onetl.strategy.hwm_strategy:hwm_strategy.py:64 |IncrementalStrategy| Loading HWM from YAMLHWMStore:
INFO     onetl.strategy.hwm_strategy:hwm_strategy.py:65         qualified_name = 'file_list#/data@s3://localhost:9010#pytest@msmartynov'
WARNING  onetl.strategy.hwm_strategy:hwm_strategy.py:74 |IncrementalStrategy| HWM does not exist in 'YAMLHWMStore'. ALL ROWS/FILES WILL BE READ!
INFO     onetl.file.file_downloader.file_downloader:file_downloader.py:594 =================================== FileDownloader starts ===================================
INFO     onetl.file.file_downloader.file_downloader:file_downloader.py:596 |S3| -> |Local FS| Downloading files using parameters:
INFO     onetl.file.file_downloader.file_downloader:file_downloader.py:597         source_path = '/data'
INFO     onetl.file.file_downloader.file_downloader:file_downloader.py:598         local_path = '/tmp/pytest-of-maxim/pytest-35/local_path0'
INFO     onetl.file.file_downloader.file_downloader:file_downloader.py:599         temp_path = None
INFO     onetl.file.file_downloader.file_downloader:file_downloader.py:600         filters = []
INFO     onetl.file.file_downloader.file_downloader:file_downloader.py:601         limits = []
INFO     onetl.file.file_downloader.file_downloader:file_downloader.py:602         options = {
INFO     onetl.file.file_downloader.file_downloader:file_downloader.py:602             'mode': 'error',
INFO     onetl.file.file_downloader.file_downloader:file_downloader.py:602             'delete_source': False,
INFO     onetl.file.file_downloader.file_downloader:file_downloader.py:602             'workers': 1,
INFO     onetl.file.file_downloader.file_downloader:file_downloader.py:602         }
INFO     onetl.connection.file_connection.file_connection:file_connection.py:123 |S3| Checking connection availability...
INFO     onetl.connection.file_connection.file_connection:file_connection.py:718 |onETL| Using connection parameters:
INFO     onetl.connection.file_connection.file_connection:file_connection.py:719         type = S3
INFO     onetl.connection.file_connection.file_connection:file_connection.py:725         access_key = 'onetl'
INFO     onetl.connection.file_connection.file_connection:file_connection.py:725         bucket = 'onetl'
INFO     onetl.connection.file_connection.file_connection:file_connection.py:725         host = 'localhost'
INFO     onetl.connection.file_connection.file_connection:file_connection.py:725         port = 9010
INFO     onetl.connection.file_connection.file_connection:file_connection.py:725         protocol = 'http'
INFO     onetl.connection.file_connection.file_connection:file_connection.py:725         secret_key = SecretStr('**********')
INFO     onetl.connection.file_connection.file_connection:file_connection.py:128 |S3| Connection is available
INFO     onetl.file.file_downloader.file_downloader:file_downloader.py:389         
INFO     onetl.file.file_downloader.file_downloader:file_downloader.py:395 |FileDownloader| File list is not passed to `run` method
INFO     onetl.strategy.hwm_strategy:hwm_strategy.py:64 |IncrementalStrategy| Loading HWM from YAMLHWMStore:
INFO     onetl.strategy.hwm_strategy:hwm_strategy.py:65         qualified_name = 'file_list#/data@s3://localhost:9010#pytest@msmartynov'
WARNING  onetl.strategy.hwm_strategy:hwm_strategy.py:74 |IncrementalStrategy| HWM does not exist in 'YAMLHWMStore'. ALL ROWS/FILES WILL BE READ!
INFO     onetl.strategy.hwm_strategy:hwm_strategy.py:64 |IncrementalStrategy| Loading HWM from YAMLHWMStore:
INFO     onetl.strategy.hwm_strategy:hwm_strategy.py:65         qualified_name = 'file_list#/data@s3://localhost:9010#pytest@msmartynov'
WARNING  onetl.strategy.hwm_strategy:hwm_strategy.py:74 |IncrementalStrategy| HWM does not exist in 'YAMLHWMStore'. ALL ROWS/FILES WILL BE READ!
INFO     onetl.file.file_downloader.file_downloader:file_downloader.py:676 |FileDownloader| Files to be downloaded:
INFO     onetl.file.file_downloader.file_downloader:file_downloader.py:677         6 files (size='103 Bytes'):
INFO     onetl.file.file_downloader.file_downloader:file_downloader.py:677             '/data/exclude_dir/nested/excluded2.txt' (size='0 Bytes')
INFO     onetl.file.file_downloader.file_downloader:file_downloader.py:677             '/data/exclude_dir/excluded1.txt' (size='0 Bytes')
INFO     onetl.file.file_downloader.file_downloader:file_downloader.py:677             '/data/nested/exclude_dir/excluded3.txt' (size='0 Bytes')
INFO     onetl.file.file_downloader.file_downloader:file_downloader.py:677             '/data/ascii.txt' (size='23 Bytes')
INFO     onetl.file.file_downloader.file_downloader:file_downloader.py:677             '/data/some.csv' (size='20 Bytes')
INFO     onetl.file.file_downloader.file_downloader:file_downloader.py:677             '/data/utf-8.txt' (size='60 Bytes')
INFO     onetl.file.file_downloader.file_downloader:file_downloader.py:678         
INFO     onetl.file.file_downloader.file_downloader:file_downloader.py:679 |FileDownloader| Starting the download process ...
INFO     onetl.file.file_downloader.file_downloader:file_downloader.py:758 |FileDownloader| Downloading file '/data/exclude_dir/nested/excluded2.txt' to '/tmp/pytest-of-maxim/pytest-35/local_path0/exclude_dir/nested/excluded2.txt'
INFO     onetl.connection.file_connection.file_connection:file_connection.py:299 |Local FS| Successfully downloaded file '/tmp/pytest-of-maxim/pytest-35/local_path0/exclude_dir/nested/excluded2.txt'
INFO     onetl.strategy.hwm_strategy:hwm_strategy.py:93 |IncrementalStrategy| Saving HWM to 'YAMLHWMStore':
INFO     onetl.strategy.hwm_strategy:hwm_strategy.py:109         type = FileListHWM
INFO     onetl.strategy.hwm_strategy:hwm_strategy.py:112         value = [
INFO     onetl.strategy.hwm_strategy:hwm_strategy.py:112             RelativePath('exclude_dir/nested/excluded2.txt'),
INFO     onetl.strategy.hwm_strategy:hwm_strategy.py:112         ]
INFO     onetl.strategy.hwm_strategy:hwm_strategy.py:95         qualified_name = 'file_list#/data@s3://localhost:9010#pytest@msmartynov'
INFO     onetl.strategy.hwm_strategy:hwm_strategy.py:98 |IncrementalStrategy| HWM has been saved
INFO     onetl.strategy.hwm_strategy:hwm_strategy.py:102         location = '/tmp/pytest-of-maxim/pytest-35/hwmstore0/file_list__data__s3_localhost_9010__pytest__msmartynov.yml'
```

Users will not see any changes because default log format set by `onetl.log.setup_logging` does not include module name and file. But it is useful for applications logging.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [X] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
