### PR TITLE
[DOP-8132] FileDFWriter.target_path cannot be None

### DIFF
--- a/onetl/file/file_df_writer/file_df_writer.py
+++ b/onetl/file/file_df_writer/file_df_writer.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from pydantic import validator
 
@@ -96,7 +96,7 @@ class FileDFWriter(FrozenModel):
 
     connection: BaseFileDFConnection
     format: BaseWritableFileFormat
-    target_path: Optional[PurePathProtocol] = None
+    target_path: PurePathProtocol
     options: FileDFWriterOptions = FileDFWriterOptions()
 
     @slot
@@ -152,8 +152,6 @@ class FileDFWriter(FrozenModel):
     @validator("target_path", pre=True)
     def _validate_target_path(cls, target_path, values):
         connection: BaseFileDFConnection = values["connection"]
-        if target_path is None:
-            return None
         return connection.path_from_string(target_path)
 
     @validator("format")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

<!-- Please give a short summary of the changes. -->

`target_path` cannot be `None`, this does not make any sense.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [X] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
