### PR TITLE
[DOP-8208] Fix validation ot includeHeaders

### DIFF
--- a/docs/changelog/next_release/131.bugfix.rst
+++ b/docs/changelog/next_release/131.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed validation of ``headers`` column is written to Kafka with default ``Kafka.WriteOptions()`` - default value was ``False``,
+but instead of raising an exception, column value was just ignored.

--- a/docs/changelog/next_release/131.improvement.rst
+++ b/docs/changelog/next_release/131.improvement.rst
@@ -1,0 +1,1 @@
+Improve validation messages while writing dataframe to Kafka.

--- a/onetl/connection/db_connection/kafka/options.py
+++ b/onetl/connection/db_connection/kafka/options.py
@@ -12,6 +12,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from __future__ import annotations
+
 from enum import Enum
 
 from pydantic import Field, root_validator
@@ -31,14 +33,6 @@ PROHIBITED_OPTIONS = frozenset(
         "subscribe",
         "subscribePattern",
         "topic",
-    ),
-)
-
-KNOWN_READ_WRITE_OPTIONS = frozenset(
-    (
-        # not adding this to class itself because headers support was added to Spark only in 3.0
-        # https://issues.apache.org/jira/browse/SPARK-23539
-        "includeHeaders",
     ),
 )
 
@@ -100,14 +94,21 @@ class KafkaReadOptions(GenericOptions):
     .. code:: python
 
         options = Kafka.ReadOptions(
+            include_headers=False,
             minPartitions=50,
-            includeHeaders=True,
         )
+    """
+
+    include_headers: bool = Field(default=False, alias="includeHeaders")
+    """
+    If ``True``, add ``headers`` column to output DataFrame.
+
+    If ``False``, column will not be added.
     """
 
     class Config:
         prohibited_options = PROHIBITED_OPTIONS
-        known_options = KNOWN_READ_OPTIONS | KNOWN_READ_WRITE_OPTIONS
+        known_options = KNOWN_READ_OPTIONS
         extra = "allow"
 
 
@@ -140,7 +141,7 @@ class KafkaWriteOptions(GenericOptions):
 
         options = Kafka.WriteOptions(
             if_exists="append",
-            includeHeaders=False,
+            include_headers=True,
         )
     """
 
@@ -154,9 +155,16 @@ class KafkaWriteOptions(GenericOptions):
         * ``error`` - Raises an error if topic already exists.
     """
 
+    include_headers: bool = Field(default=False, alias="includeHeaders")
+    """
+    If ``True``, ``headers`` column from dataframe can be written to Kafka (requires Kafka 2.0+).
+
+    If ``False`` and dataframe contains ``headers`` column, an exception will be raised.
+    """
+
     class Config:
         prohibited_options = PROHIBITED_OPTIONS | KNOWN_READ_OPTIONS
-        known_options = KNOWN_READ_WRITE_OPTIONS
+        known_options: frozenset[str] = frozenset()
         extra = "allow"
 
     @root_validator(pre=True)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

<!-- Please give a short summary of the changes. -->

* Fixed validation of `headers` column is written to Kafka with default `Kafka.WriteOptions()` - `includeHeaders` had no default value, so instead of raising an exception, column value was just ignored. Now default value is explicitly set to `False`.
* Add check for Spark version to `Kafka.write_df_to_target`, raise exception if user passed `include_headers=True` on Spark 2.4, there this option does not exist.
* Reviewed list of columns user can pass to `DBWriter.run` for Kafka - `timestamp` and `timestampType` are not supported by Spark, `offset` is not supported by Kafka.
* Add more unit tests for Kafka options

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [X] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
