### PR TITLE
[DOP-8647] - Allow modes "ignore" and "error" in Hive.WriteOptions

### DIFF
--- a/docs/changelog/next_release/143.feature.rst
+++ b/docs/changelog/next_release/143.feature.rst
@@ -1,0 +1,1 @@
+Add ``if_exists="ignore"`` and ``error`` to ``Hive.WriteOptions``

--- a/docs/connection/db_connection/kafka/read.rst
+++ b/docs/connection/db_connection/kafka/read.rst
@@ -7,7 +7,8 @@ For reading data from Kafka, use :obj:`DBReader <onetl.db.db_reader.db_reader.DB
 
 .. warning::
 
-    Currently, Kafka does not support :ref:`strategy`. You can only read the whole topic.
+    Currently, Kafka does not support :ref:`strategy`. You can only read the whole topic, or use ``group.id`` / ``groupIdPrefix`` so Kafka
+    will return only messages added to topic since last read.
 
 .. note::
 

--- a/onetl/connection/db_connection/hive/connection.py
+++ b/onetl/connection/db_connection/hive/connection.py
@@ -341,10 +341,10 @@ class Hive(DBConnection):
         # https://stackoverflow.com/a/72747050
         if table_exists and write_options.if_exists != HiveTableExistBehavior.REPLACE_ENTIRE_TABLE:
             if write_options.if_exists == HiveTableExistBehavior.ERROR:
-                raise ValueError("Operation stopped due to if_exists set to 'error'.")
+                raise ValueError("Operation stopped due to Hive.WriteOptions(if_exists=...) is set to 'error'.")
             elif write_options.if_exists == HiveTableExistBehavior.IGNORE:
                 log.info(
-                    "|%s| No further action is taken due to if_exists is set to 'ignore'",
+                    "|%s| No further action is taken due to Hive.WriteOptions(if_exists=...) is set to 'ignore'",
                     self.__class__.__name__,
                 )
                 return

--- a/onetl/connection/db_connection/hive/connection.py
+++ b/onetl/connection/db_connection/hive/connection.py
@@ -341,7 +341,7 @@ class Hive(DBConnection):
         # https://stackoverflow.com/a/72747050
         if table_exists and write_options.if_exists != HiveTableExistBehavior.REPLACE_ENTIRE_TABLE:
             if write_options.if_exists == HiveTableExistBehavior.ERROR:
-                raise ValueError("Operation stopped due to Hive.WriteOptions(if_exists=...) is set to 'error'.")
+                raise ValueError("Operation stopped due to Hive.WriteOptions(if_exists='error')")
             elif write_options.if_exists == HiveTableExistBehavior.IGNORE:
                 log.info(
                     "|%s| Skip writing to existing table because of Hive.WriteOptions(if_exists='ignore')",

--- a/onetl/connection/db_connection/hive/connection.py
+++ b/onetl/connection/db_connection/hive/connection.py
@@ -500,7 +500,6 @@ class Hive(DBConnection):
         write_options = self.WriteOptions.parse(options)
 
         if write_options.if_exists == HiveTableExistBehavior.ERROR:
-            log.error("|%s| If_exists is set to 'error'", self.__class__.__name__)
             raise ValueError("Operation stopped due to if_exists set to 'error'.")
         elif write_options.if_exists == HiveTableExistBehavior.IGNORE:
             log.info(

--- a/onetl/connection/db_connection/hive/connection.py
+++ b/onetl/connection/db_connection/hive/connection.py
@@ -344,7 +344,7 @@ class Hive(DBConnection):
                 raise ValueError("Operation stopped due to Hive.WriteOptions(if_exists=...) is set to 'error'.")
             elif write_options.if_exists == HiveTableExistBehavior.IGNORE:
                 log.info(
-                    "|%s| No further action is taken due to Hive.WriteOptions(if_exists=...) is set to 'ignore'",
+                    "|%s| Skip writing to existing table because of Hive.WriteOptions(if_exists='ignore')",
                     self.__class__.__name__,
                 )
                 return

--- a/onetl/connection/db_connection/hive/connection.py
+++ b/onetl/connection/db_connection/hive/connection.py
@@ -499,6 +499,16 @@ class Hive(DBConnection):
     ) -> None:
         write_options = self.WriteOptions.parse(options)
 
+        if write_options.if_exists == HiveTableExistBehavior.ERROR:
+            log.error("|%s| If_exists is set to 'error'", self.__class__.__name__)
+            raise ValueError("Operation stopped due to if_exists set to 'error'.")
+        elif write_options.if_exists == HiveTableExistBehavior.IGNORE:
+            log.info(
+                "|%s| No further action is taken due to if_exists is set to 'ignore'",
+                self.__class__.__name__,
+            )
+            return
+
         unsupported_options = write_options.dict(by_alias=True, exclude_unset=True, exclude={"if_exists"})
         if unsupported_options:
             log.warning(

--- a/onetl/connection/db_connection/hive/options.py
+++ b/onetl/connection/db_connection/hive/options.py
@@ -26,6 +26,8 @@ from onetl.impl import GenericOptions
 
 class HiveTableExistBehavior(str, Enum):
     APPEND = "append"
+    IGNORE = "ignore"
+    ERROR = "error"
     REPLACE_ENTIRE_TABLE = "replace_entire_table"
     REPLACE_OVERLAPPING_PARTITIONS = "replace_overlapping_partitions"
 
@@ -173,9 +175,30 @@ class HiveWriteOptions(GenericOptions):
                 Table is recreated using options provided by user (``format``, ``compression``, etc)
                 **instead of using original table options**. Be careful
 
-    .. note::
+        * ``ignore``
+            Ignores the write operation if the table/partition already exists.
 
-        ``error`` and ``ignore`` modes are not supported.
+            .. dropdown:: Behavior in details
+
+                * Table does not exist
+                    Table is created using options provided by user (``format``, ``compression``, etc).
+
+                * Table exists
+                    If the table exists, **no further action is taken**. This is true whether or not new partition
+                    values are present and whether the partitioning scheme differs or not
+
+        * ``error``
+            Raises an error if the table/partition already exists.
+
+            .. dropdown:: Behavior in details
+
+                * Table does not exist
+                    Table is created using options provided by user (``format``, ``compression``, etc).
+
+                * Table exists
+                    If the table exists, **raises an error**. This is true whether or not new partition
+                    values are present and whether the partitioning scheme differs or not
+
 
     .. note::
 

--- a/tests/tests_integration/tests_core_integration/tests_db_writer_integration/test_hive_writer_integration.py
+++ b/tests/tests_integration/tests_core_integration/tests_db_writer_integration/test_hive_writer_integration.py
@@ -401,10 +401,7 @@ def test_hive_writer_insert_into_ignore(spark, processing, get_schema_table, ori
     with caplog.at_level(logging.INFO):
         writer2.run(df1.union(df3))
 
-        assert (
-            "|Hive| No further action is taken due to Hive.WriteOptions(if_exists=...) is set to 'ignore'"
-            in caplog.text
-        )
+        assert "|Hive| Skip writing to existing table because of Hive.WriteOptions(if_exists='ignore')" in caplog.text
 
     new_ddl = hive.sql(f"SHOW CREATE TABLE {get_schema_table.full_name}").collect()[0][0]
 

--- a/tests/tests_integration/tests_core_integration/tests_db_writer_integration/test_hive_writer_integration.py
+++ b/tests/tests_integration/tests_core_integration/tests_db_writer_integration/test_hive_writer_integration.py
@@ -448,7 +448,7 @@ def test_hive_writer_insert_into_error(spark, processing, get_schema_table, orig
 
     with pytest.raises(
         ValueError,
-        match=re.escape("Operation stopped due to Hive.WriteOptions(if_exists=...) is set to 'error'."),
+        match=re.escape("Operation stopped due to Hive.WriteOptions(if_exists='error')"),
     ):
         writer2.run(df)
 

--- a/tests/tests_unit/tests_db_connection_unit/test_hive_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_hive_unit.py
@@ -153,6 +153,8 @@ def test_hive_write_options_unsupported_insert_into(insert_into):
         ({"if_exists": "append"}, HiveTableExistBehavior.APPEND),
         ({"if_exists": "replace_overlapping_partitions"}, HiveTableExistBehavior.REPLACE_OVERLAPPING_PARTITIONS),
         ({"if_exists": "replace_entire_table"}, HiveTableExistBehavior.REPLACE_ENTIRE_TABLE),
+        ({"if_exists": "error"}, HiveTableExistBehavior.ERROR),
+        ({"if_exists": "ignore"}, HiveTableExistBehavior.IGNORE),
     ],
 )
 def test_hive_write_options_if_exists(options, value):
@@ -198,6 +200,18 @@ def test_hive_write_options_if_exists(options, value):
             "Mode `overwrite_table` is deprecated since v0.9.0 and will be removed in v1.0.0. "
             "Use `replace_entire_table` instead",
         ),
+        (
+            {"mode": "error"},
+            HiveTableExistBehavior.ERROR,
+            "Option `Hive.WriteOptions(mode=...)` is deprecated since v0.9.0 and will be removed in v1.0.0. "
+            "Use `Hive.WriteOptions(if_exists=...)` instead",
+        ),
+        (
+            {"mode": "ignore"},
+            HiveTableExistBehavior.IGNORE,
+            "Option `Hive.WriteOptions(mode=...)` is deprecated since v0.9.0 and will be removed in v1.0.0. "
+            "Use `Hive.WriteOptions(if_exists=...)` instead",
+        ),
     ],
 )
 def test_hive_write_options_mode_deprecated(options, value, message):
@@ -209,10 +223,6 @@ def test_hive_write_options_mode_deprecated(options, value, message):
 @pytest.mark.parametrize(
     "options",
     [
-        # disallowed modes
-        {"mode": "error"},
-        {"mode": "ignore"},
-        # wrong mode
         {"mode": "wrong_mode"},
     ],
 )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

- add `ignore` and `error` modes `(if_exists=...)` to `Hive.WriteOptions`
- add unit and integration tests
- updated documentation

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [x] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
