### PR TITLE
[DOP-8664] - Allow modes "ignore" and "error" in MongoDB.WriteOptions

### DIFF
--- a/docs/changelog/next_release/145.feature.rst
+++ b/docs/changelog/next_release/145.feature.rst
@@ -1,0 +1,1 @@
+Add ``if_exists="ignore"`` and ``error`` to ``MongoDB.WriteOptions``

--- a/onetl/connection/db_connection/mongodb/connection.py
+++ b/onetl/connection/db_connection/mongodb/connection.py
@@ -545,7 +545,7 @@ class MongoDB(DBConnection):
         return spark
 
     def _collection_exists(self, source: str) -> bool:
-        jvm = self.spark._jvm  # type: ignore
+        jvm = self.spark._jvm
         client = jvm.com.mongodb.client.MongoClients.create(self.connection_url)  # type: ignore
         collections = set(client.getDatabase(self.database).listCollectionNames().iterator())
         if source in collections:

--- a/onetl/connection/db_connection/mongodb/connection.py
+++ b/onetl/connection/db_connection/mongodb/connection.py
@@ -509,7 +509,7 @@ class MongoDB(DBConnection):
                 raise ValueError("Operation stopped due to MongoDB.WriteOptions(if_exists=...) is set to 'error'.")
             elif write_options.if_exists == MongoDBCollectionExistBehavior.IGNORE:
                 log.info(
-                    "|%s| No further action is taken due to MongoDB.WriteOptions(if_exists=...) is set to 'ignore'",
+                    "|%s| Skip writing to existing collection because of MongoDB.WriteOptions(if_exists='ignore')",
                     self.__class__.__name__,
                 )
                 return

--- a/onetl/connection/db_connection/mongodb/connection.py
+++ b/onetl/connection/db_connection/mongodb/connection.py
@@ -506,10 +506,10 @@ class MongoDB(DBConnection):
 
         if self._collection_exists(target):
             if write_options.if_exists == MongoDBCollectionExistBehavior.ERROR:
-                raise ValueError("Operation stopped due to if_exists set to 'error'.")
+                raise ValueError("Operation stopped due to MongoDB.WriteOptions(if_exists=...) is set to 'error'.")
             elif write_options.if_exists == MongoDBCollectionExistBehavior.IGNORE:
                 log.info(
-                    "|%s| No further action is taken due to if_exists is set to 'ignore'",
+                    "|%s| No further action is taken due to MongoDB.WriteOptions(if_exists=...) is set to 'ignore'",
                     self.__class__.__name__,
                 )
                 return

--- a/onetl/connection/db_connection/mongodb/connection.py
+++ b/onetl/connection/db_connection/mongodb/connection.py
@@ -506,7 +506,7 @@ class MongoDB(DBConnection):
 
         if self._collection_exists(target):
             if write_options.if_exists == MongoDBCollectionExistBehavior.ERROR:
-                raise ValueError("Operation stopped due to MongoDB.WriteOptions(if_exists=...) is set to 'error'.")
+                raise ValueError("Operation stopped due to MongoDB.WriteOptions(if_exists='error')")
             elif write_options.if_exists == MongoDBCollectionExistBehavior.IGNORE:
                 log.info(
                     "|%s| Skip writing to existing collection because of MongoDB.WriteOptions(if_exists='ignore')",

--- a/onetl/connection/db_connection/mongodb/options.py
+++ b/onetl/connection/db_connection/mongodb/options.py
@@ -81,6 +81,8 @@ KNOWN_WRITE_OPTIONS = frozenset(
 
 class MongoDBCollectionExistBehavior(str, Enum):
     APPEND = "append"
+    IGNORE = "ignore"
+    ERROR = "error"
     REPLACE_ENTIRE_COLLECTION = "replace_entire_collection"
 
     def __str__(self) -> str:
@@ -207,33 +209,52 @@ class MongoDBWriteOptions(GenericOptions):
 
             .. dropdown:: Behavior in details
 
-            * Collection does not exist
-                Collection is created using options provided by user
-                (``shardkey`` and others).
+                * Collection does not exist
+                    Collection is created using options provided by user
+                    (``shardkey`` and others).
 
-            * Collection exists
-                Data is appended to a collection.
+                * Collection exists
+                    Data is appended to a collection.
 
-                .. warning::
+                    .. warning::
 
-                    This mode does not check whether collection already contains
-                    objects from dataframe, so duplicated objects can be created.
+                        This mode does not check whether collection already contains
+                        objects from dataframe, so duplicated objects can be created.
 
         * ``replace_entire_collection``
             **Collection is deleted and then created**.
 
             .. dropdown:: Behavior in details
 
-            * Collection does not exist
-                Collection is created using options provided by user
-                (``shardkey`` and others).
+                * Collection does not exist
+                    Collection is created using options provided by user
+                    (``shardkey`` and others).
 
-            * Collection exists
-                Collection content is replaced with dataframe content.
+                * Collection exists
+                    Collection content is replaced with dataframe content.
 
-    .. note::
+        * ``ignore``
+            Ignores the write operation if the collection already exists.
 
-        ``error`` and ``ignore`` modes are not supported.
+            .. dropdown:: Behavior in details
+
+                * Collection does not exist
+                    Collection is created using options provided by user
+
+                * Collection exists
+                    The write operation is ignored, and no data is written to the collection.
+
+        * ``error``
+            Raises an error if the collection already exists.
+
+            .. dropdown:: Behavior in details
+
+                * Collection does not exist
+                    Collection is created using options provided by user
+
+                * Collection exists
+                    An error is raised, and no data is written to the collection.
+
     """
 
     class Config:

--- a/tests/tests_integration/tests_core_integration/tests_db_writer_integration/test_greenplum_writer_integration.py
+++ b/tests/tests_integration/tests_core_integration/tests_db_writer_integration/test_greenplum_writer_integration.py
@@ -137,6 +137,14 @@ def test_greenplum_writer_if_exists_error(spark, processing, prepare_schema_tabl
     ):
         writer.run(df)
 
+    empty_df = spark.createDataFrame([], df.schema)
+
+    processing.assert_equal_df(
+        schema=prepare_schema_table.schema,
+        table=prepare_schema_table.table,
+        df=empty_df,
+    )
+
 
 def test_greenplum_writer_if_exists_ignore(spark, processing, prepare_schema_table):
     df = processing.create_spark_df(spark=spark, min_id=1, max_id=1500)

--- a/tests/tests_integration/tests_core_integration/tests_db_writer_integration/test_mongodb_writer_integration.py
+++ b/tests/tests_integration/tests_core_integration/tests_db_writer_integration/test_mongodb_writer_integration.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 
 from onetl.connection import MongoDB
@@ -6,8 +8,18 @@ from onetl.db import DBWriter
 pytestmark = pytest.mark.mongodb
 
 
+@pytest.mark.parametrize(
+    "options",
+    [
+        {},
+        {"if_exists": "append"},
+        {"if_exists": "replace_entire_collection"},
+        {"if_exists": "error"},
+        {"if_exists": "ignore"},
+    ],
+)
 @pytest.mark.flaky(reruns=2)
-def test_mongodb_writer_snapshot(spark, processing, prepare_schema_table):
+def test_mongodb_writer_snapshot(spark, processing, get_schema_table, options, caplog):
     df = processing.create_spark_df(spark=spark)
 
     mongo = MongoDB(
@@ -21,12 +33,132 @@ def test_mongodb_writer_snapshot(spark, processing, prepare_schema_table):
 
     writer = DBWriter(
         connection=mongo,
-        table=prepare_schema_table.table,
+        table=get_schema_table.table,
+        options=MongoDB.WriteOptions(**options),
+    )
+
+    with caplog.at_level(logging.INFO):
+        writer.run(df)
+
+        assert f"|MongoDB| Collection '{get_schema_table.table}' does not exist" in caplog.text
+
+    processing.assert_equal_df(
+        schema=get_schema_table.schema,
+        table=get_schema_table.table,
+        df=df,
+    )
+
+
+def test_mongodb_writer_if_exists_append(spark, processing, get_schema_table):
+    df = processing.create_spark_df(spark=spark, min_id=1, max_id=1500)
+    df1 = df[df._id < 1001]
+    df2 = df[df._id > 1000]
+
+    mongo = MongoDB(
+        host=processing.host,
+        port=processing.port,
+        user=processing.user,
+        password=processing.password,
+        database=processing.database,
+        spark=spark,
+    )
+
+    writer = DBWriter(
+        connection=mongo,
+        table=get_schema_table.table,
+        options=MongoDB.WriteOptions(if_exists="append"),
+    )
+    writer.run(df1)
+    writer.run(df2)
+
+    processing.assert_equal_df(
+        schema=get_schema_table.schema,
+        table=get_schema_table.table,
+        df=df,
+    )
+
+
+def test_mongodb_writer_if_exists_replace_entire_collection(spark, processing, get_schema_table):
+    df = processing.create_spark_df(spark=spark, min_id=1, max_id=1500)
+    df1 = df[df._id < 1001]
+    df2 = df[df._id > 1000]
+
+    mongo = MongoDB(
+        host=processing.host,
+        port=processing.port,
+        user=processing.user,
+        password=processing.password,
+        database=processing.database,
+        spark=spark,
+    )
+
+    writer = DBWriter(
+        connection=mongo,
+        table=get_schema_table.table,
+        options=MongoDB.WriteOptions(if_exists="replace_entire_collection"),
+    )
+    writer.run(df1)
+    writer.run(df2)
+
+    processing.assert_equal_df(
+        schema=get_schema_table.schema,
+        table=get_schema_table.table,
+        df=df2,
+    )
+
+
+def test_mongodb_writer_if_exists_error(spark, processing, get_schema_table, caplog):
+    df = processing.create_spark_df(spark=spark, min_id=1, max_id=1500)
+
+    mongo = MongoDB(
+        host=processing.host,
+        port=processing.port,
+        user=processing.user,
+        password=processing.password,
+        database=processing.database,
+        spark=spark,
+    )
+
+    writer = DBWriter(
+        connection=mongo,
+        table=get_schema_table.table,
+        options=MongoDB.WriteOptions(if_exists="error"),
     )
     writer.run(df)
 
+    with pytest.raises(ValueError, match="Operation stopped due to if_exists set to 'error'."):
+        writer.run(df)
+
+
+def test_mongodb_writer_if_exists_ignore(spark, processing, get_schema_table, caplog):
+    df = processing.create_spark_df(spark=spark, min_id=1, max_id=1500)
+    df1 = df[df._id < 1001]
+    df2 = df[df._id > 1000]
+
+    mongo = MongoDB(
+        host=processing.host,
+        port=processing.port,
+        user=processing.user,
+        password=processing.password,
+        database=processing.database,
+        spark=spark,
+    )
+
+    writer = DBWriter(
+        connection=mongo,
+        table=get_schema_table.table,
+        options=MongoDB.WriteOptions(if_exists="ignore"),
+    )
+    writer.run(df1)
+
+    with caplog.at_level(logging.INFO):
+        writer.run(df2)  # The write operation is ignored
+
+        assert f"|MongoDB| Collection '{get_schema_table.table}' exists" in caplog.text
+        assert "|MongoDB| No further action is taken due to if_exists is set to 'ignore'" in caplog.text
+
     processing.assert_equal_df(
-        schema=prepare_schema_table.schema,
-        table=prepare_schema_table.table,
-        df=df,
+        schema=get_schema_table.schema,
+        table=get_schema_table.table,
+        df=df1,
     )

--- a/tests/tests_integration/tests_core_integration/tests_db_writer_integration/test_mongodb_writer_integration.py
+++ b/tests/tests_integration/tests_core_integration/tests_db_writer_integration/test_mongodb_writer_integration.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 import pytest
 
@@ -126,7 +127,10 @@ def test_mongodb_writer_if_exists_error(spark, processing, get_schema_table, cap
     )
     writer.run(df)
 
-    with pytest.raises(ValueError, match="Operation stopped due to if_exists set to 'error'."):
+    with pytest.raises(
+        ValueError,
+        match=re.escape("Operation stopped due to MongoDB.WriteOptions(if_exists=...) is set to 'error'."),
+    ):
         writer.run(df)
 
     processing.assert_equal_df(
@@ -161,7 +165,10 @@ def test_mongodb_writer_if_exists_ignore(spark, processing, get_schema_table, ca
         writer.run(df2)  # The write operation is ignored
 
         assert f"|MongoDB| Collection '{get_schema_table.table}' exists" in caplog.text
-        assert "|MongoDB| No further action is taken due to if_exists is set to 'ignore'" in caplog.text
+        assert (
+            "|MongoDB| No further action is taken due to MongoDB.WriteOptions(if_exists=...) is set to 'ignore'"
+            in caplog.text
+        )
 
     processing.assert_equal_df(
         schema=get_schema_table.schema,

--- a/tests/tests_integration/tests_core_integration/tests_db_writer_integration/test_mongodb_writer_integration.py
+++ b/tests/tests_integration/tests_core_integration/tests_db_writer_integration/test_mongodb_writer_integration.py
@@ -129,7 +129,7 @@ def test_mongodb_writer_if_exists_error(spark, processing, get_schema_table, cap
 
     with pytest.raises(
         ValueError,
-        match=re.escape("Operation stopped due to MongoDB.WriteOptions(if_exists=...) is set to 'error'."),
+        match=re.escape("Operation stopped due to MongoDB.WriteOptions(if_exists='error')"),
     ):
         writer.run(df)
 

--- a/tests/tests_integration/tests_core_integration/tests_db_writer_integration/test_mongodb_writer_integration.py
+++ b/tests/tests_integration/tests_core_integration/tests_db_writer_integration/test_mongodb_writer_integration.py
@@ -166,7 +166,7 @@ def test_mongodb_writer_if_exists_ignore(spark, processing, get_schema_table, ca
 
         assert f"|MongoDB| Collection '{get_schema_table.table}' exists" in caplog.text
         assert (
-            "|MongoDB| No further action is taken due to MongoDB.WriteOptions(if_exists=...) is set to 'ignore'"
+            "|MongoDB| Skip writing to existing collection because of MongoDB.WriteOptions(if_exists='ignore')"
             in caplog.text
         )
 

--- a/tests/tests_integration/tests_core_integration/tests_db_writer_integration/test_mongodb_writer_integration.py
+++ b/tests/tests_integration/tests_core_integration/tests_db_writer_integration/test_mongodb_writer_integration.py
@@ -129,6 +129,12 @@ def test_mongodb_writer_if_exists_error(spark, processing, get_schema_table, cap
     with pytest.raises(ValueError, match="Operation stopped due to if_exists set to 'error'."):
         writer.run(df)
 
+    processing.assert_equal_df(
+        schema=get_schema_table.schema,
+        table=get_schema_table.table,
+        df=df,
+    )
+
 
 def test_mongodb_writer_if_exists_ignore(spark, processing, get_schema_table, caplog):
     df = processing.create_spark_df(spark=spark, min_id=1, max_id=1500)

--- a/tests/tests_unit/tests_db_connection_unit/test_mongodb_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_mongodb_unit.py
@@ -233,6 +233,8 @@ def test_mongodb_convert_dict_to_str():
     [
         ({}, MongoDBCollectionExistBehavior.APPEND),
         ({"if_exists": "append"}, MongoDBCollectionExistBehavior.APPEND),
+        ({"if_exists": "ignore"}, MongoDBCollectionExistBehavior.IGNORE),
+        ({"if_exists": "error"}, MongoDBCollectionExistBehavior.ERROR),
         ({"if_exists": "replace_entire_collection"}, MongoDBCollectionExistBehavior.REPLACE_ENTIRE_COLLECTION),
     ],
 )
@@ -261,6 +263,18 @@ def test_mongodb_write_options_if_exists(options, value):
             "Mode `overwrite` is deprecated since v0.9.0 and will be removed in v1.0.0. "
             "Use `replace_entire_collection` instead",
         ),
+        (
+            {"mode": "ignore"},
+            MongoDBCollectionExistBehavior.IGNORE,
+            "Option `MongoDB.WriteOptions(mode=...)` is deprecated since v0.9.0 and will be removed in v1.0.0. "
+            "Use `MongoDB.WriteOptions(if_exists=...)` instead",
+        ),
+        (
+            {"mode": "error"},
+            MongoDBCollectionExistBehavior.ERROR,
+            "Option `MongoDB.WriteOptions(mode=...)` is deprecated since v0.9.0 and will be removed in v1.0.0. "
+            "Use `MongoDB.WriteOptions(if_exists=...)` instead",
+        ),
     ],
 )
 def test_mongodb_write_options_mode_deprecated(options, value, message):
@@ -272,10 +286,6 @@ def test_mongodb_write_options_mode_deprecated(options, value, message):
 @pytest.mark.parametrize(
     "options",
     [
-        # disallowed modes
-        {"mode": "error"},
-        {"mode": "ignore"},
-        # wrong mode
         {"mode": "wrong_mode"},
     ],
 )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

- add `ignore` and `error` modes (`if_exists=...)` to `MongoDB.WriteOptions`
- add unit and integration tests
- updated documentation

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [x] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
