### PR TITLE
[DOP-9653] Test onETL compatibility with Spark 3.5.0

### DIFF
--- a/.github/workflows/data/clickhouse/matrix.yml
+++ b/.github/workflows/data/clickhouse/matrix.yml
@@ -5,7 +5,7 @@ min: &min
   os: ubuntu-latest
 
 max: &max
-  spark-version: 3.4.1
+  spark-version: 3.5.0
   python-version: '3.11'
   java-version: 20
   os: ubuntu-latest

--- a/.github/workflows/data/core/matrix.yml
+++ b/.github/workflows/data/core/matrix.yml
@@ -5,7 +5,7 @@ min: &min
   os: ubuntu-latest
 
 max: &max
-  spark-version: 3.4.1
+  spark-version: 3.5.0
   python-version: '3.11'
   java-version: 20
   os: ubuntu-latest

--- a/.github/workflows/data/hdfs/matrix.yml
+++ b/.github/workflows/data/hdfs/matrix.yml
@@ -7,7 +7,7 @@ min: &min
 
 max: &max
   hadoop-version: hadoop3-hdfs
-  spark-version: 3.4.1
+  spark-version: 3.5.0
   python-version: '3.11'
   java-version: 20
   os: ubuntu-latest

--- a/.github/workflows/data/hive/matrix.yml
+++ b/.github/workflows/data/hive/matrix.yml
@@ -5,7 +5,7 @@ min: &min
   os: ubuntu-latest
 
 max: &max
-  spark-version: 3.4.1
+  spark-version: 3.5.0
   python-version: '3.11'
   java-version: 20
   os: ubuntu-latest

--- a/.github/workflows/data/kafka/matrix.yml
+++ b/.github/workflows/data/kafka/matrix.yml
@@ -8,7 +8,7 @@ min: &min
 
 max: &max
   kafka-version: 3.5.1
-  spark-version: 3.4.1
+  spark-version: 3.5.0
   python-version: '3.11'
   java-version: 20
   os: ubuntu-latest

--- a/.github/workflows/data/mssql/matrix.yml
+++ b/.github/workflows/data/mssql/matrix.yml
@@ -5,7 +5,7 @@ min: &min
   os: ubuntu-latest
 
 max: &max
-  spark-version: 3.4.1
+  spark-version: 3.5.0
   python-version: '3.11'
   java-version: 20
   os: ubuntu-latest

--- a/.github/workflows/data/mysql/matrix.yml
+++ b/.github/workflows/data/mysql/matrix.yml
@@ -5,7 +5,7 @@ min: &min
   os: ubuntu-latest
 
 max: &max
-  spark-version: 3.4.1
+  spark-version: 3.5.0
   python-version: '3.11'
   java-version: 20
   os: ubuntu-latest

--- a/.github/workflows/data/oracle/matrix.yml
+++ b/.github/workflows/data/oracle/matrix.yml
@@ -5,7 +5,7 @@ min: &min
   os: ubuntu-latest
 
 max: &max
-  spark-version: 3.4.1
+  spark-version: 3.5.0
   python-version: '3.11'
   java-version: 20
   os: ubuntu-latest

--- a/.github/workflows/data/postgres/matrix.yml
+++ b/.github/workflows/data/postgres/matrix.yml
@@ -5,7 +5,7 @@ min: &min
   os: ubuntu-latest
 
 max: &max
-  spark-version: 3.4.1
+  spark-version: 3.5.0
   python-version: '3.11'
   java-version: 20
   os: ubuntu-latest

--- a/.github/workflows/data/s3/matrix.yml
+++ b/.github/workflows/data/s3/matrix.yml
@@ -9,7 +9,7 @@ min: &min
 
 max: &max
   minio-version: 2023.7.18
-  spark-version: 3.4.1
+  spark-version: 3.5.0
   python-version: '3.11'
   java-version: 20
   os: ubuntu-latest

--- a/.github/workflows/data/teradata/matrix.yml
+++ b/.github/workflows/data/teradata/matrix.yml
@@ -1,5 +1,5 @@
 max: &max
-  spark-version: 3.4.1
+  spark-version: 3.5.0
   python-version: '3.11'
   java-version: 20
   os: ubuntu-latest

--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ Non-goals
 Requirements
 ------------
 * **Python 3.7 - 3.11**
-* PySpark 2.3.x - 3.4.x (depends on used connector)
+* PySpark 2.3.x - 3.5.x (depends on used connector)
 * Java 8+ (required by Spark, see below)
 * Kerberos libs & GCC (required by ``Hive``, ``HDFS`` and ``SparkHDFS`` connectors)
 
@@ -96,7 +96,7 @@ Supported storages
 +                    +--------------+----------------------------------------------------------------------------------------------------------------------+
 |                    | Samba        | `pysmb library <https://pypi.org/project/pysmb/>`_                                                                   |
 +--------------------+--------------+----------------------------------------------------------------------------------------------------------------------+
-| Files as DataFrame | SparkLocalFS | Apache Spark `File Data Source <https://spark.apache.org/docs/3.4.1/sql-data-sources-generic-options.html>`_         |
+| Files as DataFrame | SparkLocalFS | Apache Spark `File Data Source <https://spark.apache.org/docs/latest/sql-data-sources-generic-options.html>`_        |
 |                    +--------------+                                                                                                                      +
 |                    | SparkHDFS    |                                                                                                                      |
 |                    +--------------+----------------------------------------------------------------------------------------------------------------------+
@@ -179,6 +179,8 @@ Compatibility matrix
 +--------------------------------------------------------------+-------------+-------------+-------+
 | `3.4.x <https://spark.apache.org/docs/3.4.1/#downloading>`_  | 3.7 - 3.11  | 8u362 - 20  | 2.12  |
 +--------------------------------------------------------------+-------------+-------------+-------+
+| `3.5.x <https://spark.apache.org/docs/3.5.0/#downloading>`_  | 3.8 - 3.11  | 8u371 - 20  | 2.12  |
++--------------------------------------------------------------+-------------+-------------+-------+
 
 .. _pyspark-install:
 
@@ -192,7 +194,7 @@ or install PySpark explicitly:
 
 .. code:: bash
 
-    pip install onetl pyspark==3.4.1  # install a specific PySpark version
+    pip install onetl pyspark==3.5.0  # install a specific PySpark version
 
 or inject PySpark to ``sys.path`` in some other way BEFORE creating a class instance.
 **Otherwise connection object cannot be created.**
@@ -530,7 +532,7 @@ Read files directly from S3 path, convert them to dataframe, transform it and th
     setup_logging()
 
     # Initialize new SparkSession with Hadoop AWS libraries and Postgres driver loaded
-    maven_packages = SparkS3.get_packages(spark_version="3.4.1") + Postgres.get_packages()
+    maven_packages = SparkS3.get_packages(spark_version="3.5.0") + Postgres.get_packages()
     spark = (
         SparkSession.builder.appName("spark_app_onetl_demo")
         .config("spark.jars.packages", ",".join(maven_packages))

--- a/docs/changelog/next_release/159.feature.rst
+++ b/docs/changelog/next_release/159.feature.rst
@@ -1,0 +1,1 @@
+Tested compatibility with Spark 3.5.0. ``MongoDB`` and ``Excel`` are not supported yet, but other packages do.

--- a/onetl/connection/db_connection/clickhouse/connection.py
+++ b/onetl/connection/db_connection/clickhouse/connection.py
@@ -46,7 +46,7 @@ class Clickhouse(JDBCConnection):
     .. dropdown:: Version compatibility
 
         * Clickhouse server versions: 20.7 or higher
-        * Spark versions: 2.3.x - 3.4.x
+        * Spark versions: 2.3.x - 3.5.x
         * Java versions: 8 - 20
 
         See `official documentation <https://clickhouse.com/docs/en/integrations/java#jdbc-driver>`_.
@@ -63,7 +63,7 @@ class Clickhouse(JDBCConnection):
             pip install onetl[spark]  # latest PySpark version
 
             # or
-            pip install onetl pyspark=3.4.1  # pass specific PySpark version
+            pip install onetl pyspark=3.5.0  # pass specific PySpark version
 
         See :ref:`install-spark` installation instruction for more details.
 

--- a/onetl/connection/db_connection/hive/connection.py
+++ b/onetl/connection/db_connection/hive/connection.py
@@ -52,7 +52,7 @@ class Hive(DBConnection):
     .. dropdown:: Version compatibility
 
         * Hive metastore version: 0.12 - 3.1.2 (may require to add proper .jar file explicitly)
-        * Spark versions: 2.3.x - 3.4.x
+        * Spark versions: 2.3.x - 3.5.x
         * Java versions: 8 - 20
 
     .. warning::
@@ -67,7 +67,7 @@ class Hive(DBConnection):
             pip install onetl[spark]  # latest PySpark version
 
             # or
-            pip install onetl pyspark=3.4.1  # pass specific PySpark version
+            pip install onetl pyspark=3.5.0  # pass specific PySpark version
 
         See :ref:`install-spark` installation instruction for more details.
 

--- a/onetl/connection/db_connection/kafka/connection.py
+++ b/onetl/connection/db_connection/kafka/connection.py
@@ -71,7 +71,7 @@ class Kafka(DBConnection):
     .. dropdown:: Version compatibility
 
         * Apache Kafka versions: 0.10 or higher
-        * Spark versions: 2.4.x - 3.4.x
+        * Spark versions: 2.4.x - 3.5.x
         * Scala versions: 2.11 - 2.13
 
     Parameters
@@ -317,7 +317,7 @@ class Kafka(DBConnection):
         write_options.update(options.dict(by_alias=True, exclude_none=True, exclude={"if_exists"}))
         write_options["topic"] = target
 
-        # As of Apache Spark version 3.4.1, the mode 'error' is not functioning as expected.
+        # As of Apache Spark version 3.5.0, the mode 'error' is not functioning as expected.
         # This issue has been reported and can be tracked at:
         # https://issues.apache.org/jira/browse/SPARK-44774
         mode = options.if_exists

--- a/onetl/connection/db_connection/mssql/connection.py
+++ b/onetl/connection/db_connection/mssql/connection.py
@@ -44,7 +44,7 @@ class MSSQL(JDBCConnection):
     .. dropdown:: Version compatibility
 
         * SQL Server versions: 2014 - 2022
-        * Spark versions: 2.3.x - 3.4.x
+        * Spark versions: 2.3.x - 3.5.x
         * Java versions: 8 - 20
 
         See `official documentation <https://learn.microsoft.com/en-us/sql/connect/jdbc/system-requirements-for-the-jdbc-driver>`_
@@ -62,7 +62,7 @@ class MSSQL(JDBCConnection):
             pip install onetl[spark]  # latest PySpark version
 
             # or
-            pip install onetl pyspark=3.4.1  # pass specific PySpark version
+            pip install onetl pyspark=3.5.0  # pass specific PySpark version
 
         See :ref:`install-spark` installation instruction for more details.
 

--- a/onetl/connection/db_connection/mysql/connection.py
+++ b/onetl/connection/db_connection/mysql/connection.py
@@ -44,7 +44,7 @@ class MySQL(JDBCConnection):
     .. dropdown:: Version compatibility
 
         * MySQL server versions: 5.7, 8.0
-        * Spark versions: 2.3.x - 3.4.x
+        * Spark versions: 2.3.x - 3.5.x
         * Java versions: 8 - 20
 
         See `official documentation <https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-versions.html>`_.
@@ -61,7 +61,7 @@ class MySQL(JDBCConnection):
             pip install onetl[spark]  # latest PySpark version
 
             # or
-            pip install onetl pyspark=3.4.1  # pass specific PySpark version
+            pip install onetl pyspark=3.5.0  # pass specific PySpark version
 
         See :ref:`install-spark` installation instruction for more details.
 

--- a/onetl/connection/db_connection/oracle/connection.py
+++ b/onetl/connection/db_connection/oracle/connection.py
@@ -84,7 +84,7 @@ class Oracle(JDBCConnection):
     .. dropdown:: Version compatibility
 
         * Oracle Server versions: 23c, 21c, 19c, 18c, 12.2 and probably 11.2 (tested, but that's not official).
-        * Spark versions: 2.3.x - 3.4.x
+        * Spark versions: 2.3.x - 3.5.x
         * Java versions: 8 - 20
 
         See `official documentation <https://www.oracle.com/cis/database/technologies/appdev/jdbc-downloads.html>`_.
@@ -101,7 +101,7 @@ class Oracle(JDBCConnection):
             pip install onetl[spark]  # latest PySpark version
 
             # or
-            pip install onetl pyspark=3.4.1  # pass specific PySpark version
+            pip install onetl pyspark=3.5.0  # pass specific PySpark version
 
         See :ref:`install-spark` installation instruction for more details.
 

--- a/onetl/connection/db_connection/postgres/connection.py
+++ b/onetl/connection/db_connection/postgres/connection.py
@@ -42,7 +42,7 @@ class Postgres(JDBCConnection):
     .. dropdown:: Version compatibility
 
         * PostgreSQL server versions: 8.2 or higher
-        * Spark versions: 2.3.x - 3.4.x
+        * Spark versions: 2.3.x - 3.5.x
         * Java versions: 8 - 20
 
         See `official documentation <https://jdbc.postgresql.org/download/>`_.
@@ -59,7 +59,7 @@ class Postgres(JDBCConnection):
             pip install onetl[spark]  # latest PySpark version
 
             # or
-            pip install onetl pyspark=3.4.1  # pass specific PySpark version
+            pip install onetl pyspark=3.5.0  # pass specific PySpark version
 
         See :ref:`install-spark` installation instruction for more details.
 

--- a/onetl/connection/db_connection/teradata/connection.py
+++ b/onetl/connection/db_connection/teradata/connection.py
@@ -47,7 +47,7 @@ class Teradata(JDBCConnection):
     .. dropdown:: Version compatibility
 
         * Teradata server versions: 16.10 - 20.0
-        * Spark versions: 2.3.x - 3.4.x
+        * Spark versions: 2.3.x - 3.5.x
         * Java versions: 8 - 20
 
         See `official documentation <https://teradata-docs.s3.amazonaws.com/doc/connectivity/jdbc/reference/current/platformMatrix.html>`_.
@@ -64,7 +64,7 @@ class Teradata(JDBCConnection):
             pip install onetl[spark]  # latest PySpark version
 
             # or
-            pip install onetl pyspark=3.4.1  # pass specific PySpark version
+            pip install onetl pyspark=3.5.0  # pass specific PySpark version
 
         See :ref:`install-spark` installation instruction for more details.
 

--- a/onetl/connection/file_df_connection/spark_hdfs/connection.py
+++ b/onetl/connection/file_df_connection/spark_hdfs/connection.py
@@ -57,7 +57,7 @@ class SparkHDFS(SparkFileDFConnection):
             pip install onetl[spark]  # latest PySpark version
 
             # or
-            pip install onetl pyspark=3.4.1  # pass specific PySpark version
+            pip install onetl pyspark=3.5.0  # pass specific PySpark version
 
         See :ref:`install-spark` installation instruction for more details.
 

--- a/onetl/connection/file_df_connection/spark_local_fs.py
+++ b/onetl/connection/file_df_connection/spark_local_fs.py
@@ -47,7 +47,7 @@ class SparkLocalFS(SparkFileDFConnection):
             pip install onetl[spark]  # latest PySpark version
 
             # or
-            pip install onetl pyspark=3.4.1  # pass specific PySpark version
+            pip install onetl pyspark=3.5.0  # pass specific PySpark version
 
         See :ref:`install-spark` installation instruction for more details.
 

--- a/onetl/connection/file_df_connection/spark_s3/connection.py
+++ b/onetl/connection/file_df_connection/spark_s3/connection.py
@@ -62,7 +62,7 @@ class SparkS3(SparkFileDFConnection):
 
     .. dropdown:: Version compatibility
 
-        * Spark versions: 3.2.x - 3.4.x (only with Hadoop 3.x libraries)
+        * Spark versions: 3.2.x - 3.5.x (only with Hadoop 3.x libraries)
         * Java versions: 8 - 20
         * Scala versions: 2.11 - 2.13
 
@@ -82,7 +82,7 @@ class SparkS3(SparkFileDFConnection):
             pip install onetl[spark]  # latest PySpark version
 
             # or
-            pip install onetl pyspark=3.4.1  # pass specific PySpark version
+            pip install onetl pyspark=3.5.0  # pass specific PySpark version
 
         See :ref:`install-spark` installation instruction for more details.
 
@@ -161,7 +161,7 @@ class SparkS3(SparkFileDFConnection):
         from pyspark.sql import SparkSession
 
         # Create Spark session with Hadoop AWS libraries loaded
-        maven_packages = SparkS3.get_packages(spark_version="3.4.1")
+        maven_packages = SparkS3.get_packages(spark_version="3.5.0")
         # Some dependencies are not used, but downloading takes a lot of time. Skipping them.
         excluded_packages = [
             "com.google.cloud.bigdataoss:gcs-connector",
@@ -262,8 +262,8 @@ class SparkS3(SparkFileDFConnection):
 
             from onetl.connection import SparkS3
 
-            SparkS3.get_packages(spark_version="3.4.1")
-            SparkS3.get_packages(spark_version="3.4.1", scala_version="2.12")
+            SparkS3.get_packages(spark_version="3.5.0")
+            SparkS3.get_packages(spark_version="3.5.0", scala_version="2.12")
 
         """
 

--- a/onetl/file/format/avro.py
+++ b/onetl/file/format/avro.py
@@ -71,7 +71,7 @@ class Avro(ReadWriteFileFormat):
 
     .. dropdown:: Version compatibility
 
-        * Spark versions: 2.4.x - 3.4.x
+        * Spark versions: 2.4.x - 3.5.x
         * Java versions: 8 - 20
         * Scala versions: 2.11 - 2.13
 
@@ -95,7 +95,7 @@ class Avro(ReadWriteFileFormat):
         from pyspark.sql import SparkSession
 
         # Create Spark session with Avro package loaded
-        maven_packages = Avro.get_packages(spark_version="3.4.1")
+        maven_packages = Avro.get_packages(spark_version="3.5.0")
         spark = (
             SparkSession.builder.appName("spark-app-name")
             .config("spark.jars.packages", ",".join(maven_packages))

--- a/requirements/tests/spark-3.5.0.txt
+++ b/requirements/tests/spark-3.5.0.txt
@@ -1,0 +1,5 @@
+numpy>=1.16
+pandas>=1.0
+pyarrow>=1.0
+pyspark==3.5.0
+sqlalchemy

--- a/tests/tests_unit/test_file/test_format_unit/test_avro_unit.py
+++ b/tests/tests_unit/test_file/test_format_unit/test_avro_unit.py
@@ -27,12 +27,12 @@ def test_avro_get_packages_scala_version_not_supported():
     [
         # Detect Scala version by Spark version
         ("2.4.0", None, "org.apache.spark:spark-avro_2.11:2.4.0"),
-        ("3.4.0", None, "org.apache.spark:spark-avro_2.12:3.4.0"),
+        ("3.5.0", None, "org.apache.spark:spark-avro_2.12:3.5.0"),
         # Override Scala version
         ("2.4.0", "2.11", "org.apache.spark:spark-avro_2.11:2.4.0"),
         ("2.4.0", "2.12", "org.apache.spark:spark-avro_2.12:2.4.0"),
-        ("3.4.0", "2.12", "org.apache.spark:spark-avro_2.12:3.4.0"),
-        ("3.4.0", "2.13", "org.apache.spark:spark-avro_2.13:3.4.0"),
+        ("3.5.0", "2.12", "org.apache.spark:spark-avro_2.12:3.5.0"),
+        ("3.5.0", "2.13", "org.apache.spark:spark-avro_2.13:3.5.0"),
     ],
 )
 def test_avro_get_packages(spark_version, scala_version, package):

--- a/tests/tests_unit/tests_db_connection_unit/test_greenplum_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_greenplum_unit.py
@@ -31,6 +31,7 @@ def test_greenplum_get_packages_no_input():
         "2.2",
         "3.3",
         "3.4",
+        "3.5",
     ],
 )
 def test_greenplum_get_packages_spark_version_not_supported(spark_version):

--- a/tests/tests_unit/tests_file_df_connection_unit/test_spark_s3_unit.py
+++ b/tests/tests_unit/tests_file_df_connection_unit/test_spark_s3_unit.py
@@ -10,9 +10,9 @@ pytestmark = [pytest.mark.s3, pytest.mark.file_df_connection, pytest.mark.connec
 @pytest.mark.parametrize(
     "spark_version, scala_version, package",
     [
-        ("3.4.1", None, "org.apache.spark:spark-hadoop-cloud_2.12:3.4.1"),
-        ("3.4.1", "2.12", "org.apache.spark:spark-hadoop-cloud_2.12:3.4.1"),
-        ("3.4.1", "2.13", "org.apache.spark:spark-hadoop-cloud_2.13:3.4.1"),
+        ("3.5.0", None, "org.apache.spark:spark-hadoop-cloud_2.12:3.5.0"),
+        ("3.5.0", "2.12", "org.apache.spark:spark-hadoop-cloud_2.12:3.5.0"),
+        ("3.5.0", "2.13", "org.apache.spark:spark-hadoop-cloud_2.13:3.5.0"),
     ],
 )
 def test_spark_s3_get_packages(spark_version, scala_version, package):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

<!-- Please give a short summary of the changes. -->

Nightly tests with latest pyspark version shown that some classes do not yet support Spark 3.5.0:
https://github.com/MobileTeleSystems/onetl/actions/runs/6336863272/job/17210825113

* MongoDB fails with sone internal error. This could be caused by used package version (10.1 then latest is 10.2).
* Excel [does not have package](https://github.com/crealytics/spark-excel/issues/787) for 3.5.0 yet: https://mvnrepository.com/artifact/com.crealytics/spark-excel

Other connection and file formats do support 3.5.0, so updated documentation of connectors & Readme.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [X] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
