### PR TITLE
[DOP-9653] Add Python 3.12 compatibility

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -7,7 +7,7 @@ on:
     - master
 
 env:
-  DEFAULT_PYTHON: '3.11'
+  DEFAULT_PYTHON: '3.12'
 
 permissions:
   contents: read

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,6 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  # flake8-commas and bandit's ssh_no_host_key_verification are failing on Python 3.12
   DEFAULT_PYTHON: '3.11'
 
 jobs:

--- a/.github/workflows/data/clickhouse/matrix.yml
+++ b/.github/workflows/data/clickhouse/matrix.yml
@@ -6,13 +6,13 @@ min: &min
 
 max: &max
   spark-version: 3.5.0
-  python-version: '3.11'
+  python-version: '3.12'
   java-version: 20
   os: ubuntu-latest
 
 latest: &latest
   spark-version: latest
-  python-version: '3.11'
+  python-version: '3.12'
   java-version: 20
   os: ubuntu-latest
 

--- a/.github/workflows/data/core/matrix.yml
+++ b/.github/workflows/data/core/matrix.yml
@@ -6,13 +6,13 @@ min: &min
 
 max: &max
   spark-version: 3.5.0
-  python-version: '3.11'
+  python-version: '3.12'
   java-version: 20
   os: ubuntu-latest
 
 latest: &latest
   spark-version: latest
-  python-version: '3.11'
+  python-version: '3.12'
   java-version: 20
   os: ubuntu-latest
 

--- a/.github/workflows/data/ftp/matrix.yml
+++ b/.github/workflows/data/ftp/matrix.yml
@@ -3,7 +3,7 @@ min: &min
   os: ubuntu-latest
 
 max: &max
-  python-version: '3.11'
+  python-version: '3.12'
   os: ubuntu-latest
 
 matrix:

--- a/.github/workflows/data/ftps/matrix.yml
+++ b/.github/workflows/data/ftps/matrix.yml
@@ -3,7 +3,7 @@ min: &min
   os: ubuntu-latest
 
 max: &max
-  python-version: '3.11'
+  python-version: '3.12'
   os: ubuntu-latest
 
 matrix:

--- a/.github/workflows/data/hdfs/matrix.yml
+++ b/.github/workflows/data/hdfs/matrix.yml
@@ -8,14 +8,14 @@ min: &min
 max: &max
   hadoop-version: hadoop3-hdfs
   spark-version: 3.5.0
-  python-version: '3.11'
+  python-version: '3.12'
   java-version: 20
   os: ubuntu-latest
 
 latest: &latest
   hadoop-version: hadoop3-hdfs
   spark-version: latest
-  python-version: '3.11'
+  python-version: '3.12'
   java-version: 20
   os: ubuntu-latest
 

--- a/.github/workflows/data/hive/matrix.yml
+++ b/.github/workflows/data/hive/matrix.yml
@@ -6,13 +6,13 @@ min: &min
 
 max: &max
   spark-version: 3.5.0
-  python-version: '3.11'
+  python-version: '3.12'
   java-version: 20
   os: ubuntu-latest
 
 latest: &latest
   spark-version: latest
-  python-version: '3.11'
+  python-version: '3.12'
   java-version: 20
   os: ubuntu-latest
 

--- a/.github/workflows/data/kafka/matrix.yml
+++ b/.github/workflows/data/kafka/matrix.yml
@@ -9,14 +9,14 @@ min: &min
 max: &max
   kafka-version: 3.5.1
   spark-version: 3.5.0
-  python-version: '3.11'
+  python-version: '3.12'
   java-version: 20
   os: ubuntu-latest
 
 latest: &latest
   kafka-version: latest
   spark-version: latest
-  python-version: '3.11'
+  python-version: '3.12'
   java-version: 20
   os: ubuntu-latest
 

--- a/.github/workflows/data/local-fs/matrix.yml
+++ b/.github/workflows/data/local-fs/matrix.yml
@@ -18,13 +18,13 @@ min_excel: &min_excel
 
 max: &max
   spark-version: 3.5.0
-  python-version: '3.11'
+  python-version: '3.12'
   java-version: 20
   os: ubuntu-latest
 
 latest: &latest
   spark-version: latest
-  python-version: '3.11'
+  python-version: '3.12'
   java-version: 20
   os: ubuntu-latest
 

--- a/.github/workflows/data/mongodb/matrix.yml
+++ b/.github/workflows/data/mongodb/matrix.yml
@@ -7,13 +7,13 @@ min: &min
 
 max: &max
   spark-version: 3.4.1
-  python-version: '3.11'
+  python-version: '3.12'
   java-version: 20
   os: ubuntu-latest
 
 latest: &latest
   spark-version: latest
-  python-version: '3.11'
+  python-version: '3.12'
   java-version: 20
   os: ubuntu-latest
 

--- a/.github/workflows/data/mssql/matrix.yml
+++ b/.github/workflows/data/mssql/matrix.yml
@@ -6,13 +6,13 @@ min: &min
 
 max: &max
   spark-version: 3.5.0
-  python-version: '3.11'
+  python-version: '3.12'
   java-version: 20
   os: ubuntu-latest
 
 latest: &latest
   spark-version: latest
-  python-version: '3.11'
+  python-version: '3.12'
   java-version: 20
   os: ubuntu-latest
 

--- a/.github/workflows/data/mysql/matrix.yml
+++ b/.github/workflows/data/mysql/matrix.yml
@@ -6,13 +6,13 @@ min: &min
 
 max: &max
   spark-version: 3.5.0
-  python-version: '3.11'
+  python-version: '3.12'
   java-version: 20
   os: ubuntu-latest
 
 latest: &latest
   spark-version: latest
-  python-version: '3.11'
+  python-version: '3.12'
   java-version: 20
   os: ubuntu-latest
 

--- a/.github/workflows/data/oracle/matrix.yml
+++ b/.github/workflows/data/oracle/matrix.yml
@@ -6,13 +6,13 @@ min: &min
 
 max: &max
   spark-version: 3.5.0
-  python-version: '3.11'
+  python-version: '3.12'
   java-version: 20
   os: ubuntu-latest
 
 latest: &latest
   spark-version: latest
-  python-version: '3.11'
+  python-version: '3.12'
   java-version: 20
   os: ubuntu-latest
 

--- a/.github/workflows/data/postgres/matrix.yml
+++ b/.github/workflows/data/postgres/matrix.yml
@@ -6,13 +6,13 @@ min: &min
 
 max: &max
   spark-version: 3.5.0
-  python-version: '3.11'
+  python-version: '3.12'
   java-version: 20
   os: ubuntu-latest
 
 latest: &latest
   spark-version: latest
-  python-version: '3.11'
+  python-version: '3.12'
   java-version: 20
   os: ubuntu-latest
 

--- a/.github/workflows/data/s3/matrix.yml
+++ b/.github/workflows/data/s3/matrix.yml
@@ -10,14 +10,14 @@ min: &min
 max: &max
   minio-version: 2023.7.18
   spark-version: 3.5.0
-  python-version: '3.11'
+  python-version: '3.12'
   java-version: 20
   os: ubuntu-latest
 
 latest: &latest
   minio-version: latest
   spark-version: latest
-  python-version: '3.11'
+  python-version: '3.12'
   java-version: 20
   os: ubuntu-latest
 

--- a/.github/workflows/data/samba/matrix.yml
+++ b/.github/workflows/data/samba/matrix.yml
@@ -3,7 +3,7 @@ min: &min
   os: ubuntu-latest
 
 max: &max
-  python-version: '3.11'
+  python-version: '3.12'
   os: ubuntu-latest
 
 matrix:

--- a/.github/workflows/data/sftp/matrix.yml
+++ b/.github/workflows/data/sftp/matrix.yml
@@ -3,7 +3,7 @@ min: &min
   os: ubuntu-latest
 
 max: &max
-  python-version: '3.11'
+  python-version: '3.12'
   os: ubuntu-latest
 
 matrix:

--- a/.github/workflows/data/teradata/matrix.yml
+++ b/.github/workflows/data/teradata/matrix.yml
@@ -1,12 +1,12 @@
 max: &max
   spark-version: 3.5.0
-  python-version: '3.11'
+  python-version: '3.12'
   java-version: 20
   os: ubuntu-latest
 
 latest: &latest
   spark-version: latest
-  python-version: '3.11'
+  python-version: '3.12'
   java-version: 20
   os: ubuntu-latest
 

--- a/.github/workflows/data/webdav/matrix.yml
+++ b/.github/workflows/data/webdav/matrix.yml
@@ -3,7 +3,7 @@ min: &min
   os: ubuntu-latest
 
 max: &max
-  python-version: '3.11'
+  python-version: '3.12'
   os: ubuntu-latest
 
 matrix:

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 env:
-  DEFAULT_PYTHON: '3.11'
+  DEFAULT_PYTHON: '3.12'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/get-matrix.yml
+++ b/.github/workflows/get-matrix.yml
@@ -47,7 +47,7 @@ on:
         value: ${{ jobs.get-matrix.outputs.matrix-webdav }}
 
 env:
-  DEFAULT_PYTHON: '3.11'
+  DEFAULT_PYTHON: '3.12'
 
 jobs:
   get-matrix:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DEFAULT_PYTHON: '3.11'
+  DEFAULT_PYTHON: '3.12'
 
 jobs:
   get-matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
     - '[0-9]+.[0-9]+.[0-9]+'
 
 env:
-  DEFAULT_PYTHON: '3.11'
+  DEFAULT_PYTHON: '3.12'
 
 jobs:
   release:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DEFAULT_PYTHON: '3.11'
+  DEFAULT_PYTHON: '3.12'
 
 jobs:
   get-matrix:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.12"
 
 python:
   install:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -70,7 +70,7 @@ Create virtualenv and install dependencies:
         -r requirements/tests/mysql.txt \
         -r requirements/tests/postgres.txt \
         -r requirements/tests/oracle.txt \
-        -r requirements/tests/spark-3.4.1.txt
+        -r requirements/tests/spark-3.5.0.txt
 
 Enable pre-commit hooks
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ Non-goals
 
 Requirements
 ------------
-* **Python 3.7 - 3.11**
+* **Python 3.7 - 3.12**
 * PySpark 2.3.x - 3.5.x (depends on used connector)
 * Java 8+ (required by Spark, see below)
 * Kerberos libs & GCC (required by ``Hive``, ``HDFS`` and ``SparkHDFS`` connectors)
@@ -177,9 +177,9 @@ Compatibility matrix
 +--------------------------------------------------------------+-------------+-------------+-------+
 | `3.3.x <https://spark.apache.org/docs/3.3.3/#downloading>`_  | 3.7 - 3.10  | 8u201 - 17  | 2.12  |
 +--------------------------------------------------------------+-------------+-------------+-------+
-| `3.4.x <https://spark.apache.org/docs/3.4.1/#downloading>`_  | 3.7 - 3.11  | 8u362 - 20  | 2.12  |
+| `3.4.x <https://spark.apache.org/docs/3.4.1/#downloading>`_  | 3.7 - 3.12  | 8u362 - 20  | 2.12  |
 +--------------------------------------------------------------+-------------+-------------+-------+
-| `3.5.x <https://spark.apache.org/docs/3.5.0/#downloading>`_  | 3.8 - 3.11  | 8u371 - 20  | 2.12  |
+| `3.5.x <https://spark.apache.org/docs/3.5.0/#downloading>`_  | 3.8 - 3.12  | 8u371 - 20  | 2.12  |
 +--------------------------------------------------------------+-------------+-------------+-------+
 
 .. _pyspark-install:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       context: .
       target: base
       args:
-        SPARK_VERSION: 3.4.1
+        SPARK_VERSION: 3.5.0
     env_file: .env.docker
     volumes:
     - ./:/app/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim as base
+FROM python:3.12-slim as base
 LABEL maintainer="DataOps.ETL"
 
 ARG ONETL_USER_HOME=/usr/local/onetl
@@ -45,7 +45,7 @@ COPY --chown=onetl:onetl ./run_tests.sh ./pytest_runner.sh ./combine_coverage.sh
 COPY --chown=onetl:onetl ./docker/wait-for-it.sh /app/docker/wait-for-it.sh
 RUN chmod +x /app/run_tests.sh /app/pytest_runner.sh /app/combine_coverage.sh /app/docker/wait-for-it.sh
 
-ARG SPARK_VERSION=3.4.1
+ARG SPARK_VERSION=3.5.0
 # Spark is heavy, and version change is quite rare
 COPY --chown=onetl:onetl ./requirements/tests/spark-${SPARK_VERSION}.txt /app/requirements/tests/
 RUN pip install -r /app/requirements/tests/spark-${SPARK_VERSION}.txt

--- a/docs/changelog/next_release/167.feature.rst
+++ b/docs/changelog/next_release/167.feature.rst
@@ -1,0 +1,1 @@
+Add Python 3.12 compatibility.

--- a/onetl/impl/local_path.py
+++ b/onetl/impl/local_path.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 import os
+import sys
 from pathlib import Path, PurePosixPath, PureWindowsPath
 
 
@@ -20,8 +21,10 @@ class LocalPath(Path):
     def __new__(cls, *args, **kwargs):
         if cls is LocalPath:
             cls = LocalWindowsPath if os.name == "nt" else LocalPosixPath
-        self = cls._from_parts(args)
-        return self  # noqa: WPS331
+        if sys.version_info < (3, 12):
+            return cls._from_parts(args)
+        else:
+            return object.__new__(cls)  # noqa: WPS503
 
 
 class LocalPosixPath(LocalPath, PurePosixPath):

--- a/requirements/tests/mssql.txt
+++ b/requirements/tests/mssql.txt
@@ -1,2 +1,1 @@
-# https://github.com/pymssql/pymssql/issues/832
-pymssql<2.2.8
+pymssql

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Software Development :: Libraries",
         "Topic :: Software Development :: Libraries :: Java Libraries",
         "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

<!-- Please give a short summary of the changes. -->

Add Python 3.12 to CI matrix, README and setup.py.

Related issues:
* [X] PyArrow does not have wheels for Python 3.12: https://github.com/apache/arrow/issues/37880
* [X] Clickhouse-driver is not yet compatible with Python 3.12: https://github.com/mymarilyn/clickhouse-driver/issues/394
* [X] etl-entities does not support Python 3.12 yet: https://github.com/MobileTeleSystems/etl-entities/pull/62

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [X] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
