### PR TITLE
[DOP-11371] Fix @slot decorator

### DIFF
--- a/docs/changelog/next_release/183.bugfix.rst
+++ b/docs/changelog/next_release/183.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``@slot`` and ``@hook`` decorators returning methods with missing arguments in signature (Pylance, VS Code).

--- a/onetl/hooks/hook.py
+++ b/onetl/hooks/hook.py
@@ -8,14 +8,13 @@ from enum import Enum
 from functools import wraps
 from typing import Callable, Generator, Generic, TypeVar
 
-from typing_extensions import ParamSpec, Protocol, runtime_checkable
+from typing_extensions import Protocol, runtime_checkable
 
 from onetl.log import NOTICE
 
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
-P = ParamSpec("P")
 
 
 class HookPriority(int, Enum):
@@ -36,7 +35,7 @@ class HookPriority(int, Enum):
 
 
 @dataclass  # noqa: WPS338
-class Hook(Generic[P, T]):  # noqa: WPS338
+class Hook(Generic[T]):  # noqa: WPS338
     """
     Hook representation.
 
@@ -70,7 +69,7 @@ class Hook(Generic[P, T]):  # noqa: WPS338
         hook = Hook(callback=some_func, enabled=True, priority=HookPriority.FIRST)
     """
 
-    callback: Callable[P, T]
+    callback: Callable[..., T]
     enabled: bool = True
     priority: HookPriority = HookPriority.NORMAL
 
@@ -198,7 +197,7 @@ class Hook(Generic[P, T]):  # noqa: WPS338
             )
             self.enabled = True
 
-    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> T | ContextDecorator:
+    def __call__(self, *args, **kwargs) -> T | ContextDecorator:
         """
         Calls the original callback with passed args.
 
@@ -361,7 +360,7 @@ class ContextDecorator:
         return None
 
 
-def hook(inp: Callable[P, T] | None = None, enabled: bool = True, priority: HookPriority = HookPriority.NORMAL):
+def hook(inp: Callable[..., T] | None = None, enabled: bool = True, priority: HookPriority = HookPriority.NORMAL):
     """
     Initialize hook from callable/context manager.
 
@@ -423,7 +422,7 @@ def hook(inp: Callable[P, T] | None = None, enabled: bool = True, priority: Hook
                 ...
     """
 
-    def inner_wrapper(callback: Callable[P, T]):  # noqa: WPS430
+    def inner_wrapper(callback: Callable[..., T]):  # noqa: WPS430
         if isinstance(callback, Hook):
             raise TypeError("@hook decorator can be applied only once")
 

--- a/onetl/hooks/slot.py
+++ b/onetl/hooks/slot.py
@@ -8,7 +8,7 @@ from contextlib import ExitStack, suppress
 from functools import partial, wraps
 from typing import Any, Callable, ContextManager, TypeVar
 
-from typing_extensions import ParamSpec, Protocol
+from typing_extensions import Protocol
 
 from onetl.exception import SignatureError
 from onetl.hooks.hook import CanProcessResult, Hook, HookPriority
@@ -17,13 +17,12 @@ from onetl.hooks.hooks_state import HooksState
 from onetl.hooks.method_inheritance_stack import MethodInheritanceStack
 from onetl.log import NOTICE
 
+Method = TypeVar("Method", bound=Callable[..., Any])
+
 logger = logging.getLogger(__name__)
 
-P = ParamSpec("P")
-T = TypeVar("T")
 
-
-def _unwrap_method(method: Callable[P, T]) -> Callable[P, T]:
+def _unwrap_method(method: Method) -> Method:
     """Unwrap @classmethod and @staticmethod to get original function"""
     return getattr(method, "__func__", method)
 
@@ -624,7 +623,7 @@ class Slot(Protocol):
         ...
 
 
-def slot(method: Callable[P, T]) -> Callable[P, T]:
+def slot(method: Method) -> Method:
     """
     Decorator which enables hooks functionality on a specific class method.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

<!-- Please give a short summary of the changes. -->

It looks like Pylance (VS Code extension for Python) does not recognize [typing_extensions.ParamSpec](https://docs.python.org/3/library/typing.html#typing.ParamSpec). 

With ParamsSpec:
![image](https://github.com/MobileTeleSystems/onetl/assets/4661021/5bdd2279-f99c-4e4b-8411-cb337f305d79)
![image](https://github.com/MobileTeleSystems/onetl/assets/4661021/4742531a-ec55-4200-a8f5-13eef81324c7)

Without:
![image](https://github.com/MobileTeleSystems/onetl/assets/4661021/068000a8-8bde-4b60-a05a-55806246741f)
![image](https://github.com/MobileTeleSystems/onetl/assets/4661021/cd6aa87a-a55c-416a-9ed5-1b2348340631)

`ParamSpec` is a recommended way to tell linters how inputs of `callable: Callable[Spec, ReturnType]` are passed to `def new_callable(*Spec.args, **Spec.kwargs) -> ReturnType:`. 
Fortunately, there is another (but less precise) way to describe this - `Callable[..., ReturnType]`. This is used for now.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
