### PR TITLE
[DOP-9787] Add test for explicit DBReader.hwm type

### DIFF
--- a/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_hive.py
+++ b/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_hive.py
@@ -141,6 +141,46 @@ def test_hive_strategy_incremental_wrong_hwm(
             reader.run()
 
 
+def test_hive_strategy_incremental_explicit_hwm_type(
+    spark,
+    processing,
+    prepare_schema_table,
+):
+    store = HWMStoreStackManager.get_current()
+    hwm_name = secrets.token_hex(5)
+
+    hive = Hive(cluster="rnd-dwh", spark=spark)
+
+    reader = DBReader(
+        connection=hive,
+        source=prepare_schema_table.full_name,
+        # tell DBReader that text_string column contains integer values, and can be used for HWM
+        hwm=ColumnIntHWM(name=hwm_name, column="text_string"),
+    )
+
+    data = processing.create_pandas_df()
+    data["text_string"] = data["hwm_int"].apply(str)
+
+    # insert first span
+    processing.insert_data(
+        schema=prepare_schema_table.schema,
+        table=prepare_schema_table.table,
+        values=data,
+    )
+
+    # incremental run
+    with IncrementalStrategy():
+        df = reader.run()
+
+    hwm = store.get_hwm(name=hwm_name)
+    # type is exactly as set by user
+    assert isinstance(hwm, ColumnIntHWM)
+
+    # due to alphabetic sort min=0 and max=99
+    assert hwm.value == 99
+    processing.assert_equal_df(df=df, other_frame=data[data.hwm_int < 100], order_by="id_int")
+
+
 @pytest.mark.parametrize(
     "hwm_source, hwm_expr, hwm_column, hwm_type, func",
     [

--- a/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_mssql.py
+++ b/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_mssql.py
@@ -157,6 +157,53 @@ def test_mssql_strategy_incremental_wrong_hwm(
             reader.run()
 
 
+def test_mssql_strategy_incremental_explicit_hwm_type(
+    spark,
+    processing,
+    prepare_schema_table,
+):
+    store = HWMStoreStackManager.get_current()
+    hwm_name = secrets.token_hex(5)
+
+    mssql = MSSQL(
+        host=processing.host,
+        port=processing.port,
+        user=processing.user,
+        password=processing.password,
+        database=processing.database,
+        spark=spark,
+        extra={"trustServerCertificate": "true"},
+    )
+    reader = DBReader(
+        connection=mssql,
+        source=prepare_schema_table.full_name,
+        # tell DBReader that text_string column contains integer values, and can be used for HWM
+        hwm=ColumnIntHWM(name=hwm_name, column="text_string"),
+    )
+
+    data = processing.create_pandas_df()
+    data["text_string"] = data["hwm_int"].apply(str)
+
+    # insert first span
+    processing.insert_data(
+        schema=prepare_schema_table.schema,
+        table=prepare_schema_table.table,
+        values=data,
+    )
+
+    # incremental run
+    with IncrementalStrategy():
+        df = reader.run()
+
+    hwm = store.get_hwm(name=hwm_name)
+    # type is exactly as set by user
+    assert isinstance(hwm, ColumnIntHWM)
+
+    # due to alphabetic sort min=0 and max=99
+    assert hwm.value == 99
+    processing.assert_equal_df(df=df, other_frame=data[data.hwm_int < 100], order_by="id_int")
+
+
 @pytest.mark.parametrize(
     "hwm_source, hwm_column, hwm_expr, hwm_type, func",
     [

--- a/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_mysql.py
+++ b/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_mysql.py
@@ -155,6 +155,52 @@ def test_mysql_strategy_incremental_wrong_hwm(
             reader.run()
 
 
+def test_mysql_strategy_incremental_explicit_hwm_type(
+    spark,
+    processing,
+    prepare_schema_table,
+):
+    store = HWMStoreStackManager.get_current()
+    hwm_name = secrets.token_hex(5)
+
+    mysql = MySQL(
+        host=processing.host,
+        port=processing.port,
+        user=processing.user,
+        password=processing.password,
+        spark=spark,
+        database=processing.database,
+    )
+    reader = DBReader(
+        connection=mysql,
+        source=prepare_schema_table.full_name,
+        # tell DBReader that text_string column contains integer values, and can be used for HWM
+        hwm=ColumnIntHWM(name=hwm_name, column="text_string"),
+    )
+
+    data = processing.create_pandas_df()
+    data["text_string"] = data["hwm_int"].apply(str)
+
+    # insert first span
+    processing.insert_data(
+        schema=prepare_schema_table.schema,
+        table=prepare_schema_table.table,
+        values=data,
+    )
+
+    # incremental run
+    with IncrementalStrategy():
+        df = reader.run()
+
+    hwm = store.get_hwm(name=hwm_name)
+    # type is exactly as set by user
+    assert isinstance(hwm, ColumnIntHWM)
+
+    # due to alphabetic sort min=0 and max=99
+    assert hwm.value == 99
+    processing.assert_equal_df(df=df, other_frame=data[data.hwm_int < 100], order_by="id_int")
+
+
 @pytest.mark.parametrize(
     "hwm_source, hwm_column, hwm_expr, hwm_type, func",
     [

--- a/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_oracle.py
+++ b/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_oracle.py
@@ -170,6 +170,53 @@ def test_oracle_strategy_incremental_wrong_hwm(
             reader.run()
 
 
+def test_oracle_strategy_incremental_explicit_hwm_type(
+    spark,
+    processing,
+    prepare_schema_table,
+):
+    store = HWMStoreStackManager.get_current()
+    hwm_name = secrets.token_hex(5)
+
+    oracle = Oracle(
+        host=processing.host,
+        port=processing.port,
+        user=processing.user,
+        password=processing.password,
+        sid=processing.sid,
+        service_name=processing.service_name,
+        spark=spark,
+    )
+    reader = DBReader(
+        connection=oracle,
+        source=prepare_schema_table.full_name,
+        # tell DBReader that text_string column contains integer values, and can be used for HWM
+        hwm=ColumnIntHWM(name=hwm_name, column="TEXT_STRING"),
+    )
+
+    data = processing.create_pandas_df()
+    data["text_string"] = data["hwm_int"].apply(str)
+
+    # insert first span
+    processing.insert_data(
+        schema=prepare_schema_table.schema,
+        table=prepare_schema_table.table,
+        values=data,
+    )
+
+    # incremental run
+    with IncrementalStrategy():
+        df = reader.run()
+
+    hwm = store.get_hwm(name=hwm_name)
+    # type is exactly as set by user
+    assert isinstance(hwm, ColumnIntHWM)
+
+    # due to alphabetic sort min=0 and max=99
+    assert hwm.value == 99
+    processing.assert_equal_df(df=df, other_frame=data[data.hwm_int < 100], order_by="id_int")
+
+
 @pytest.mark.parametrize(
     "hwm_source, hwm_column, hwm_expr, hwm_type, func",
     [


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

<!-- Please give a short summary of the changes. -->

Added test that user can pass exact HWM type instead of `AutoDetectHWM`, and HWM type autodetection will not be used in this case. This can produce weird results, and behavior depends on database type, but it's up to user.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
