### PR TITLE
[DOP-11365] Update etl-entities to 2.1

### DIFF
--- a/docs/changelog/next_release/179.breaking.rst
+++ b/docs/changelog/next_release/179.breaking.rst
@@ -16,10 +16,9 @@ after:
     reader = DBReader(
         connection=...,
         source=...,
-        hwm=DBReader.AutoHWM(
-            entity="col1",
-            expression="cast(col1 as date)",
+        hwm=DBReader.AutoDetectHWM(
             name="my_unique_hwm_name",
+            expression="cast(col1 as date)",
         ),
     )
 
@@ -42,7 +41,7 @@ after:
         connection=...,
         source_path=...,
         target_path=...,
-        hwm=FileListHWM(name="another_mandatory_unique_hwm_name", directory=source_path),
+        hwm=FileListHWM(name="another_mandatory_unique_hwm_name"),
     )
 
 | Now user can pass custom hwm classes into ``HWM`` field in ``DBReader`` or ``FileDownloader``

--- a/onetl/connection/db_connection/kafka/dialect.py
+++ b/onetl/connection/db_connection/kafka/dialect.py
@@ -49,19 +49,17 @@ class KafkaDialect(  # noqa: WPS215
         if not hwm:
             return None
 
-        if hwm.entity not in self.SUPPORTED_HWM_COLUMNS:
-            raise ValueError(f"{hwm.entity} is not a valid hwm column. Valid options are: {self.SUPPORTED_HWM_COLUMNS}")
+        if hwm.expression not in self.SUPPORTED_HWM_COLUMNS:
+            raise ValueError(
+                f"hwm.expression={hwm.expression!r} is not supported by {self.connection.__class__.__name__}. "
+                f"Valid values are: {self.SUPPORTED_HWM_COLUMNS}",
+            )
 
-        if hwm.entity == "timestamp":
+        if hwm.expression == "timestamp":
             # Spark version less 3.x does not support reading from Kafka with the timestamp parameter
             spark_version = get_spark_version(self.connection.spark)  # type: ignore[attr-defined]
             if spark_version.major < 3:
                 raise ValueError(
                     f"Spark version must be 3.x for the timestamp column. Current version is: {spark_version}",
                 )
-
-        if hwm.expression is not None:
-            raise ValueError(
-                f"'hwm.expression' parameter is not supported by {self.connection.__class__.__name__}",
-            )
         return hwm

--- a/onetl/connection/db_connection/mongodb/dialect.py
+++ b/onetl/connection/db_connection/mongodb/dialect.py
@@ -17,12 +17,11 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Iterable, Mapping
 
-from etl_entities.hwm import HWM
-
 from onetl.connection.db_connection.db_connection.dialect import DBDialect
 from onetl.connection.db_connection.dialect_mixins import (
     NotSupportColumns,
     RequiresDFSchema,
+    SupportHWMExpressionStr,
     SupportNameAny,
 )
 from onetl.hwm import Edge, Window
@@ -75,6 +74,7 @@ class MongoDBDialect(  # noqa: WPS215
     SupportNameAny,
     NotSupportColumns,
     RequiresDFSchema,
+    SupportHWMExpressionStr,
     DBDialect,
 ):
     def validate_where(
@@ -107,13 +107,6 @@ class MongoDBDialect(  # noqa: WPS215
                 f"got {hint.__class__.__name__!r}",
             )
         return hint
-
-    def validate_hwm(self, hwm: HWM | None) -> HWM | None:
-        if hwm and hwm.expression is not None:
-            raise ValueError(
-                f"'hwm.expression' parameter is not supported by {self.connection.__class__.__name__}",
-            )
-        return hwm
 
     def prepare_pipeline(
         self,

--- a/onetl/file/filter/file_hwm.py
+++ b/onetl/file/filter/file_hwm.py
@@ -47,7 +47,7 @@ class FileHWMFilter(BaseFileFilter, FrozenModel):
         return not self.hwm.covers(path)
 
     def __str__(self):
-        return self.hwm.qualified_name
+        return self.hwm.name
 
     def __repr__(self):
-        return f"{self.hwm.__class__.__name__}(qualified_name={self.hwm.qualified_name!r})"
+        return f"{self.hwm.__class__.__name__}(name={self.hwm.name!r})"

--- a/onetl/hwm/store/yaml_hwm_store.py
+++ b/onetl/hwm/store/yaml_hwm_store.py
@@ -119,7 +119,7 @@ class YAMLHWMStore(BaseHWMStore, FrozenModel):
             connection=postgres,
             source="public.mydata",
             columns=["id", "data"],
-            hwm_column="id",
+            hwm=DBReader.AutoDetectHWM(name="some_unique_name", expression="id"),
         )
 
         writer = DBWriter(connection=hive, target="newtable")
@@ -209,9 +209,9 @@ class YAMLHWMStore(BaseHWMStore, FrozenModel):
 
     @slot
     def set_hwm(self, hwm: HWM) -> LocalPath:  # type: ignore
-        data = self._load(hwm.qualified_name)
-        self._dump(hwm.qualified_name, [hwm.serialize()] + data)
-        return self.get_file_path(hwm.qualified_name)
+        data = self._load(hwm.name)
+        self._dump(hwm.name, [hwm.serialize()] + data)
+        return self.get_file_path(hwm.name)
 
     @classmethod
     def cleanup_file_name(cls, name: str) -> str:

--- a/onetl/log.py
+++ b/onetl/log.py
@@ -491,7 +491,7 @@ def log_dataframe_schema(logger: logging.Logger, df: DataFrame, indent: int = 0,
         log_with_indent(logger, "%s", line, indent=indent + 4, stacklevel=stacklevel)
 
 
-def log_hwm(logger: logging.Logger, hwm: HWM, with_value: bool = True, indent: int = 0, stacklevel: int = 1):
+def log_hwm(logger: logging.Logger, hwm: HWM, indent: int = 0, stacklevel: int = 1):
     """Log HWM in the following format:
 
     Examples
@@ -528,9 +528,11 @@ def log_hwm(logger: logging.Logger, hwm: HWM, with_value: bool = True, indent: i
 
     log_with_indent(logger, "hwm = %s(", type(hwm).__name__, indent=indent, stacklevel=stacklevel)
     log_with_indent(logger, "name = %r,", hwm.name, indent=indent + 4, stacklevel=stacklevel)
+    if hwm.description:
+        log_with_indent(logger, "description = %r,", hwm.name, indent=indent + 4, stacklevel=stacklevel)
     log_with_indent(logger, "entity = %r,", hwm.entity, indent=indent + 4, stacklevel=stacklevel)
     log_with_indent(logger, "expression = %r,", hwm.expression, indent=indent + 4, stacklevel=stacklevel)
-    if with_value:
+    if hwm.value is not None:
         if isinstance(hwm.value, Collection):
             log_collection(logger, "value", hwm.value, max_items=10, indent=indent + 4, stacklevel=stacklevel)
         else:

--- a/onetl/strategy/batch_hwm_strategy.py
+++ b/onetl/strategy/batch_hwm_strategy.py
@@ -109,7 +109,7 @@ class BatchHWMStrategy(HWMStrategy):
             return
 
         if self.stop is not None and self.current.value == self.stop:
-            # if rows all have the same hwm_column value, this is not an error, read them all
+            # if rows all have the same expression value, this is not an error, read them all
             return
 
         if next_value is not None and self.current.value >= next_value:

--- a/onetl/strategy/incremental_strategy.py
+++ b/onetl/strategy/incremental_strategy.py
@@ -72,9 +72,9 @@ class IncrementalStrategy(OffsetMixin, HWMStrategy):
             This allows to resume reading process from the *last successful run*.
 
     For :ref:`file-downloader`:
-        Behavior depends on ``hwm_type`` parameter.
+        Behavior depends on ``hwm`` type.
 
-        ``hwm_type="file_list"``:
+        ``hwm=FileListHWM(...)``:
             First incremental run is just the same as :obj:`onetl.strategy.snapshot_strategy.SnapshotStrategy` - all
             files are downloaded:
 
@@ -202,7 +202,7 @@ class IncrementalStrategy(OffsetMixin, HWMStrategy):
 
         .. warning::
 
-            Cannot be used with :ref:`file-downloader` and ``hwm_type="file_list"``
+            Cannot be used with :ref:`file-downloader` and ``hwm=FileListHWM(...)``
 
         .. note::
 
@@ -243,7 +243,7 @@ class IncrementalStrategy(OffsetMixin, HWMStrategy):
             connection=postgres,
             source="public.mydata",
             columns=["id", "data"],
-            hwm=DBReader.AutoDetectHWM(name="some_hwm_name", column="id"),
+            hwm=DBReader.AutoDetectHWM(name="some_hwm_name", expression="id"),
         )
 
         writer = DBWriter(connection=hive, target="newtable")
@@ -280,7 +280,7 @@ class IncrementalStrategy(OffsetMixin, HWMStrategy):
         FROM public.mydata
         WHERE id > 900; --- from HWM-offset (EXCLUDING first row)
 
-    ``hwm_column`` can be a date or datetime, not only integer:
+    ``hwm.expression`` can be a date or datetime, not only integer:
 
     .. code:: python
 
@@ -290,7 +290,7 @@ class IncrementalStrategy(OffsetMixin, HWMStrategy):
             connection=postgres,
             source="public.mydata",
             columns=["business_dt", "data"],
-            hwm=DBReader.AutoDetectHWM(name="some_hwm_name", column="business_dt"),
+            hwm=DBReader.AutoDetectHWM(name="some_hwm_name", expression="business_dt"),
         )
 
         with IncrementalStrategy(offset=timedelta(days=1)):
@@ -306,7 +306,7 @@ class IncrementalStrategy(OffsetMixin, HWMStrategy):
         FROM public.mydata
         WHERE business_dt > CAST('2021-01-09' AS DATE);
 
-    Incremental run with :ref:`file-downloader` and ``hwm_type="file_list"``:
+    Incremental run with :ref:`file-downloader` and ``hwm=FileListHWM(...)``:
 
     .. code:: python
 
@@ -325,7 +325,7 @@ class IncrementalStrategy(OffsetMixin, HWMStrategy):
             connection=sftp,
             source_path="/remote",
             local_path="/local",
-            hwm_type=FileListHWM(name="some_hwm_name", directory="/remote"),
+            hwm=FileListHWM(name="some_hwm_name"),
         )
 
         with IncrementalStrategy():
@@ -408,7 +408,7 @@ class IncrementalBatchStrategy(OffsetMixin, BatchHWMStrategy):
 
     stop : Any, default: ``None``
 
-        If passed, the value will be used for generating WHERE clauses with ``hwm_column`` filter,
+        If passed, the value will be used for generating WHERE clauses with ``hwm.expression`` filter,
         as a stop value for the last batch.
 
         If not set, the value is determined by a separated query:
@@ -421,7 +421,7 @@ class IncrementalBatchStrategy(OffsetMixin, BatchHWMStrategy):
 
         .. note::
 
-            ``stop`` should be the same type as ``hwm_column`` value,
+            ``stop`` should be the same type as ``hwm.expression`` value,
             e.g. :obj:`datetime.datetime` for ``TIMESTAMP`` column, :obj:`datetime.date` for ``DATE``, and so on
 
     offset : Any, default: ``None``
@@ -510,7 +510,7 @@ class IncrementalBatchStrategy(OffsetMixin, BatchHWMStrategy):
             connection=postgres,
             source="public.mydata",
             columns=["id", "data"],
-            hwm=DBReader.AutoDetectHWM(name="some_hwm_name", column="id"),
+            hwm=DBReader.AutoDetectHWM(name="some_hwm_name", expression="id"),
         )
 
         writer = DBWriter(connection=hive, target="newtable")
@@ -604,7 +604,7 @@ class IncrementalBatchStrategy(OffsetMixin, BatchHWMStrategy):
         ...
         N:  WHERE id > 1900 AND id <= 2000; -- until stop
 
-    ``hwm_column`` can be a date or datetime, not only integer:
+    ``hwm.expression`` can be a date or datetime, not only integer:
 
     .. code:: python
 
@@ -614,7 +614,7 @@ class IncrementalBatchStrategy(OffsetMixin, BatchHWMStrategy):
             connection=postgres,
             source="public.mydata",
             columns=["business_dt", "data"],
-            hwm=DBReader.AutoDetectHWM(name="some_hwm_name", column="business_dt"),
+            hwm=DBReader.AutoDetectHWM(name="some_hwm_name", expression="business_dt"),
         )
 
         with IncrementalBatchStrategy(

--- a/onetl/strategy/snapshot_strategy.py
+++ b/onetl/strategy/snapshot_strategy.py
@@ -90,7 +90,7 @@ class SnapshotStrategy(BaseStrategy):
             connection=postgres,
             source="public.mydata",
             columns=["id", "data"],
-            hwm=DBReader.AutoDetectHWM(name="some_hwm_name", column="id"),
+            hwm=DBReader.AutoDetectHWM(name="some_hwm_name", expression="id"),
         )
 
         writer = DBWriter(connection=hive, target="newtable")
@@ -195,7 +195,7 @@ class SnapshotBatchStrategy(BatchHWMStrategy):
 
     start : Any, default: ``None``
 
-        If passed, the value will be used for generating WHERE clauses with ``hwm_column`` filter,
+        If passed, the value will be used for generating WHERE clauses with ``hwm.expression`` filter,
         as a start value for the first batch.
 
         If not set, the value is determined by a separated query:
@@ -208,12 +208,12 @@ class SnapshotBatchStrategy(BatchHWMStrategy):
 
         .. note::
 
-            ``start`` should be the same type as ``hwm_column`` value,
+            ``start`` should be the same type as ``hwm.expression`` value,
             e.g. :obj:`datetime.datetime` for ``TIMESTAMP`` column, :obj:`datetime.date` for ``DATE``, and so on
 
     stop : Any, default: ``None``
 
-        If passed, the value will be used for generating WHERE clauses with ``hwm_column`` filter,
+        If passed, the value will be used for generating WHERE clauses with ``hwm.expression`` filter,
         as a stop value for the last batch.
 
         If not set, the value is determined by a separated query:
@@ -226,7 +226,7 @@ class SnapshotBatchStrategy(BatchHWMStrategy):
 
         .. note::
 
-            ``stop`` should be the same type as ``hwm_column`` value,
+            ``stop`` should be the same type as ``hwm.expression`` value,
             e.g. :obj:`datetime.datetime` for ``TIMESTAMP`` column, :obj:`datetime.date` for ``DATE``, and so on
 
     Examples
@@ -264,7 +264,7 @@ class SnapshotBatchStrategy(BatchHWMStrategy):
             connection=postgres,
             source="public.mydata",
             columns=["id", "data"],
-            hwm=DBReader.AutoDetectHWM(name="some_hwm_name", column="id"),
+            hwm=DBReader.AutoDetectHWM(name="some_hwm_name", expression="id"),
         )
 
         writer = DBWriter(connection=hive, target="newtable")
@@ -379,7 +379,7 @@ class SnapshotBatchStrategy(BatchHWMStrategy):
         ...
         N:  WHERE id >  1900 AND id <= 2000; -- until stop
 
-    ``hwm_column`` can be a date or datetime, not only integer:
+    ``hwm.expression`` can be a date or datetime, not only integer:
 
     .. code:: python
 
@@ -389,7 +389,7 @@ class SnapshotBatchStrategy(BatchHWMStrategy):
             connection=postgres,
             source="public.mydata",
             columns=["business_dt", "data"],
-            hwm=DBReader.AutoDetectHWM(name="some_hwm_name", column="business_dt"),
+            hwm=DBReader.AutoDetectHWM(name="some_hwm_name", expression="business_dt"),
         )
 
         with SnapshotBatchStrategy(

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -1,5 +1,5 @@
 deprecated
-etl-entities>=2.0.8,<2.1
+etl-entities>=2.1.2,<2.2
 evacuator>=1.0,<1.1
 frozendict
 humanize

--- a/tests/fixtures/hwm_delta.py
+++ b/tests/fixtures/hwm_delta.py
@@ -10,7 +10,17 @@ from etl_entities.hwm import ColumnDateHWM, ColumnDateTimeHWM, ColumnIntHWM, Fil
         (
             ColumnIntHWM(
                 name=secrets.token_hex(5),
-                column=secrets.token_hex(5),
+                # no source
+                expression=secrets.token_hex(5),
+                value=10,
+            ),
+            5,
+        ),
+        (
+            ColumnIntHWM(
+                name=secrets.token_hex(5),
+                source=secrets.token_hex(5),
+                expression=secrets.token_hex(5),
                 value=10,
             ),
             5,
@@ -18,7 +28,8 @@ from etl_entities.hwm import ColumnDateHWM, ColumnDateTimeHWM, ColumnIntHWM, Fil
         (
             ColumnDateHWM(
                 name=secrets.token_hex(5),
-                column=secrets.token_hex(5),
+                source=secrets.token_hex(5),
+                expression=secrets.token_hex(5),
                 value=date(year=2023, month=8, day=15),
             ),
             timedelta(days=31),
@@ -26,7 +37,8 @@ from etl_entities.hwm import ColumnDateHWM, ColumnDateTimeHWM, ColumnIntHWM, Fil
         (
             ColumnDateTimeHWM(
                 name=secrets.token_hex(5),
-                column=secrets.token_hex(5),
+                source=secrets.token_hex(5),
+                expression=secrets.token_hex(5),
                 value=datetime(year=2023, month=8, day=15, hour=11, minute=22, second=33),
             ),
             timedelta(seconds=50),
@@ -34,10 +46,18 @@ from etl_entities.hwm import ColumnDateHWM, ColumnDateTimeHWM, ColumnIntHWM, Fil
         (
             FileListHWM(
                 name=secrets.token_hex(5),
-                directory=f"/absolute/{secrets.token_hex(5)}",
-                value=["some/path", "another.file"],
+                # not directory
+                value=["/some/path", "/another.file"],
             ),
-            "third.file",
+            "/third.file",
+        ),
+        (
+            FileListHWM(
+                name=secrets.token_hex(5),
+                directory="/absolute/path",
+                value=["/absolute/path/file1", "/absolute/path/file2"],
+            ),
+            "/absolute/path/file3",
         ),
     ],
 )

--- a/tests/tests_integration/tests_core_integration/test_file_downloader_integration.py
+++ b/tests/tests_integration/tests_core_integration/test_file_downloader_integration.py
@@ -881,7 +881,7 @@ def test_file_downloader_detect_hwm_type_snapshot_batch_strategy(
         connection=file_connection,
         local_path=local_path,
         source_path=remote_path,
-        hwm=FileListHWM(name=secrets.token_hex(5), directory=remote_path),
+        hwm=FileListHWM(name=secrets.token_hex(5)),
     )
 
     error_message = "FileDownloader(hwm=...) cannot be used with SnapshotBatchStrategy"
@@ -901,7 +901,7 @@ def test_file_downloader_detect_hwm_type_incremental_batch_strategy(
         connection=file_connection,
         local_path=local_path,
         source_path=remote_path,
-        hwm=FileListHWM(name=secrets.token_hex(5), directory=remote_path),
+        hwm=FileListHWM(name=secrets.token_hex(5)),
     )
 
     error_message = "FileDownloader(hwm=...) cannot be used with IncrementalBatchStrategy"
@@ -924,7 +924,7 @@ def test_file_downloader_detect_hwm_type_snapshot_strategy(
         connection=file_connection,
         local_path=local_path,
         source_path=remote_path,
-        hwm=FileListHWM(name=secrets.token_hex(5), directory=remote_path),
+        hwm=FileListHWM(name=secrets.token_hex(5)),
     )
 
     error_message = "FileDownloader(hwm=...) cannot be used with SnapshotStrategy"
@@ -944,7 +944,7 @@ def test_file_downloader_file_hwm_strategy_with_wrong_parameters(
         connection=file_connection,
         local_path=local_path,
         source_path=remote_path,
-        hwm=FileListHWM(name=secrets.token_hex(5), directory=remote_path),
+        hwm=FileListHWM(name=secrets.token_hex(5)),
     )
 
     error_message = "FileDownloader(hwm=...) cannot be used with IncrementalStrategy(offset=1, ...)"
@@ -967,7 +967,7 @@ def test_file_downloader_file_hwm_strategy(
         connection=file_connection,
         local_path=local_path,
         source_path=remote_path,
-        hwm=FileListHWM(name=secrets.token_hex(5), directory=remote_path),
+        hwm=FileListHWM(name=secrets.token_hex(5)),
     )
 
     with IncrementalStrategy():

--- a/tests/tests_integration/tests_strategy_integration/tests_incremental_batch_strategy_integration/test_strategy_incremental_batch_kafka.py
+++ b/tests/tests_integration/tests_strategy_integration/tests_incremental_batch_strategy_integration/test_strategy_incremental_batch_kafka.py
@@ -29,7 +29,7 @@ def test_strategy_kafka_with_batch_strategy_error(strategy, spark):
                 spark=spark,
             ),
             table="topic",
-            hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), column="offset"),
+            hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), expression="offset"),
         )
         with pytest.raises(RuntimeError):
             reader.run()

--- a/tests/tests_integration/tests_strategy_integration/tests_incremental_batch_strategy_integration/test_strategy_incremental_batch_mongodb.py
+++ b/tests/tests_integration/tests_strategy_integration/tests_incremental_batch_strategy_integration/test_strategy_incremental_batch_mongodb.py
@@ -81,7 +81,7 @@ def test_mongodb_strategy_incremental_batch(
     reader = DBReader(
         connection=mongodb,
         table=prepare_schema_table.table,
-        hwm=DBReader.AutoDetectHWM(name=hwm_name, column=hwm_column),
+        hwm=DBReader.AutoDetectHWM(name=hwm_name, expression=hwm_column),
         df_schema=df_schema,
     )
 
@@ -193,7 +193,7 @@ def test_mongodb_strategy_incremental_batch_where(spark, processing, prepare_sch
         connection=mongodb,
         table=prepare_schema_table.table,
         where={"$or": [{"float_value": {"$lt": 51}}, {"float_value": {"$gt": 101, "$lt": 120}}]},
-        hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), column="hwm_int"),
+        hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), expression="hwm_int"),
         df_schema=df_schema,
     )
 

--- a/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_clickhouse.py
+++ b/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_clickhouse.py
@@ -49,7 +49,7 @@ def test_clickhouse_strategy_incremental(
     reader = DBReader(
         connection=clickhouse,
         source=prepare_schema_table.full_name,
-        hwm=DBReader.AutoDetectHWM(name=hwm_name, column=hwm_column),
+        hwm=DBReader.AutoDetectHWM(name=hwm_name, expression=hwm_column),
     )
 
     # there are 2 spans with a gap between
@@ -135,7 +135,7 @@ def test_clickhouse_strategy_incremental_wrong_hwm(
     reader = DBReader(
         connection=clickhouse,
         source=prepare_schema_table.full_name,
-        hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), column=hwm_column),
+        hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), expression=hwm_column),
     )
 
     data = processing.create_pandas_df()
@@ -170,7 +170,7 @@ def test_clickhouse_strategy_incremental_explicit_hwm_type(
         connection=clickhouse,
         source=prepare_schema_table.full_name,
         # tell DBReader that text_string column contains integer values, and can be used for HWM
-        hwm=ColumnIntHWM(name=secrets.token_hex(5), column="text_string"),
+        hwm=ColumnIntHWM(name=secrets.token_hex(5), expression="text_string"),
     )
 
     data = processing.create_pandas_df()
@@ -190,25 +190,22 @@ def test_clickhouse_strategy_incremental_explicit_hwm_type(
 
 
 @pytest.mark.parametrize(
-    "hwm_source, hwm_column, hwm_expr, hwm_type, func",
+    "hwm_source, hwm_expr, hwm_type, func",
     [
         (
             "hwm_int",
-            "hwm1_int",
             "CAST(text_string AS Integer)",
             ColumnIntHWM,
             str,
         ),
         (
             "hwm_date",
-            "hwm1_date",
             "CAST(text_string AS Date)",
             ColumnDateHWM,
             lambda x: x.isoformat(),
         ),
         (
             "hwm_datetime",
-            "HWM1_DATETIME",
             "CAST(text_string AS DateTime)",
             ColumnDateTimeHWM,
             lambda x: x.isoformat(),
@@ -220,7 +217,6 @@ def test_clickhouse_strategy_incremental_with_hwm_expr(
     processing,
     prepare_schema_table,
     hwm_source,
-    hwm_column,
     hwm_expr,
     hwm_type,
     func,
@@ -236,7 +232,7 @@ def test_clickhouse_strategy_incremental_with_hwm_expr(
     reader = DBReader(
         connection=clickhouse,
         source=prepare_schema_table.full_name,
-        hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), column=hwm_column, expression=hwm_expr),
+        hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), expression=hwm_expr),
     )
 
     # there are 2 spans with a gap between

--- a/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_file.py
+++ b/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_file.py
@@ -2,21 +2,23 @@ import contextlib
 import secrets
 
 import pytest
-from etl_entities.hwm import FileListHWM
-from etl_entities.instance import RelativePath
+from etl_entities.hwm import ColumnIntHWM, FileListHWM
+from etl_entities.hwm_store import HWMStoreStackManager
+from etl_entities.instance import AbsolutePath
 
 from onetl.file import FileDownloader
-from onetl.hwm.store import YAMLHWMStore
 from onetl.strategy import IncrementalStrategy
+from tests.util.rand import rand_str
 
 
-def test_file_downloader_increment_hwm(
+def test_file_downloader_incremental_strategy(
     file_connection_with_path_and_files,
     tmp_path_factory,
     tmp_path,
 ):
+    hwm_store = HWMStoreStackManager.get_current()
+
     file_connection, remote_path, uploaded_files = file_connection_with_path_and_files
-    hwm_store = YAMLHWMStore(path=tmp_path_factory.mktemp("hwmstore"))  # noqa: S306
     local_path = tmp_path_factory.mktemp("local_path")
 
     hwm_name = secrets.token_hex(5)
@@ -25,20 +27,19 @@ def test_file_downloader_increment_hwm(
         connection=file_connection,
         source_path=remote_path,
         local_path=local_path,
-        hwm=FileListHWM(name=hwm_name, directory=remote_path),
+        hwm=FileListHWM(name=hwm_name),
     )
 
     # load first batch of the files
-    with hwm_store:
-        with IncrementalStrategy():
-            available = downloader.view_files()
-            downloaded = downloader.run()
+    with IncrementalStrategy():
+        available = downloader.view_files()
+        downloaded = downloader.run()
 
-        # without HWM value all the files are shown and uploaded
-        assert len(available) == len(downloaded.successful) == len(uploaded_files)
-        assert sorted(available) == sorted(uploaded_files)
+    # without HWM value all the files are shown and uploaded
+    assert len(available) == len(downloaded.successful) == len(uploaded_files)
+    assert sorted(available) == sorted(uploaded_files)
 
-    source_files = {RelativePath(file.relative_to(remote_path)) for file in uploaded_files}
+    source_files = {AbsolutePath(file) for file in uploaded_files}
     assert source_files == hwm_store.get_hwm(hwm_name).value
 
     for _ in "first_inc", "second_inc":
@@ -46,12 +47,12 @@ def test_file_downloader_increment_hwm(
         tmp_file = tmp_path / new_file_name
         tmp_file.write_text(f"{secrets.token_hex(10)}")
 
+        target_file = remote_path / new_file_name
         file_connection.upload_file(tmp_file, remote_path / new_file_name)
 
-        with hwm_store:
-            with IncrementalStrategy():
-                available = downloader.view_files()
-                downloaded = downloader.run()
+        with IncrementalStrategy():
+            available = downloader.view_files()
+            downloaded = downloader.run()
 
         # without HWM value all the files are shown and uploaded
         assert len(available) == len(downloaded.successful) == 1
@@ -61,17 +62,18 @@ def test_file_downloader_increment_hwm(
         assert downloaded.missing_count == 0
         assert downloaded.failed_count == 0
 
-        source_files.add(RelativePath(new_file_name))
+        source_files.add(AbsolutePath(target_file))
         assert source_files == hwm_store.get_hwm(hwm_name).value
 
 
-def test_file_downloader_increment_fail(
+def test_file_downloader_incremental_strategy_fail(
     file_connection_with_path_and_files,
     tmp_path_factory,
     tmp_path,
 ):
+    hwm_store = HWMStoreStackManager.get_current()
+
     file_connection, remote_path, uploaded_files = file_connection_with_path_and_files
-    hwm_store = YAMLHWMStore(path=tmp_path_factory.mktemp("hwmstore"))
     local_path = tmp_path_factory.mktemp("local_path")
 
     hwm_name = secrets.token_hex(5)
@@ -80,55 +82,53 @@ def test_file_downloader_increment_fail(
         connection=file_connection,
         source_path=remote_path,
         local_path=local_path,
-        hwm=FileListHWM(name=hwm_name, directory=remote_path),
+        hwm=FileListHWM(name=hwm_name),
     )
 
-    with hwm_store:
-        with IncrementalStrategy():
-            available = downloader.view_files()
-            downloaded = downloader.run()
+    with IncrementalStrategy():
+        available = downloader.view_files()
+        downloaded = downloader.run()
 
-            # without HWM value all the files are shown and uploaded
-            assert len(available) == len(downloaded.successful) == len(uploaded_files)
-            assert sorted(available) == sorted(uploaded_files)
+        # without HWM value all the files are shown and uploaded
+        assert len(available) == len(downloaded.successful) == len(uploaded_files)
+        assert sorted(available) == sorted(uploaded_files)
 
-            # HWM is updated in HWMStore
-            source_files = {RelativePath(file.relative_to(remote_path)) for file in uploaded_files}
+        # HWM is updated in HWMStore
+        source_files = {AbsolutePath(file) for file in uploaded_files}
+        assert source_files == hwm_store.get_hwm(hwm_name).value
+
+        for _ in "first_inc", "second_inc":
+            new_file_name = f"{secrets.token_hex(5)}.txt"
+            tmp_file = tmp_path / new_file_name
+            tmp_file.write_text(f"{secrets.token_hex(10)}")
+
+            target_file = remote_path / new_file_name
+            file_connection.upload_file(tmp_file, target_file)
+
+            # while loading data, a crash occurs before exiting the context manager
+            with contextlib.suppress(RuntimeError):
+                available = downloader.view_files()
+                downloaded = downloader.run()
+                # simulating a failure after download
+                raise RuntimeError("some exception")
+
+            assert len(available) == len(downloaded.successful) == 1
+            assert downloaded.successful[0].name == tmp_file.name
+            assert downloaded.successful[0].read_text() == tmp_file.read_text()
+            assert downloaded.skipped_count == 0
+            assert downloaded.missing_count == 0
+            assert downloaded.failed_count == 0
+
+            # HWM is saved after downloading each file, not after exiting from .run
+            source_files.add(AbsolutePath(target_file))
             assert source_files == hwm_store.get_hwm(hwm_name).value
 
-            for _ in "first_inc", "second_inc":
-                new_file_name = f"{secrets.token_hex(5)}.txt"
-                tmp_file = tmp_path / new_file_name
-                tmp_file.write_text(f"{secrets.token_hex(10)}")
 
-                file_connection.upload_file(tmp_file, remote_path / new_file_name)
-
-                # while loading data, a crash occurs before exiting the context manager
-                with contextlib.suppress(RuntimeError):
-                    available = downloader.view_files()
-                    downloaded = downloader.run()
-                    # simulating a failure after download
-                    raise RuntimeError("some exception")
-
-                assert len(available) == len(downloaded.successful) == 1
-                assert downloaded.successful[0].name == tmp_file.name
-                assert downloaded.successful[0].read_text() == tmp_file.read_text()
-                assert downloaded.skipped_count == 0
-                assert downloaded.missing_count == 0
-                assert downloaded.failed_count == 0
-
-                # HWM is saved after downloading each file, not after exiting from .run
-                source_files.add(RelativePath(new_file_name))
-                assert source_files == hwm_store.get_hwm(hwm_name).value
-
-
-def test_file_downloader_increment_hwm_is_ignored_for_user_input(
+def test_file_downloader_incremental_strategy_hwm_is_ignored_for_user_input(
     file_connection_with_path_and_files,
     tmp_path_factory,
-    tmp_path,
 ):
     file_connection, remote_path, uploaded_files = file_connection_with_path_and_files
-    hwm_store = YAMLHWMStore(path=tmp_path_factory.mktemp("hwm_store"))
     local_path = tmp_path_factory.mktemp("local_path")
     file_hwm_name = secrets.token_hex(5)
 
@@ -136,41 +136,143 @@ def test_file_downloader_increment_hwm_is_ignored_for_user_input(
         connection=file_connection,
         source_path=remote_path,
         local_path=local_path,
-        hwm=FileListHWM(
-            name=file_hwm_name,
-            directory=remote_path,
-        ),
+        hwm=FileListHWM(name=file_hwm_name),
         options=FileDownloader.Options(if_exists="replace_file"),
     )
 
-    with hwm_store:
-        with IncrementalStrategy():
-            # load first batch of the files
-            downloader.run()
+    with IncrementalStrategy():
+        # load first batch of the files
+        downloader.run()
 
-            # download files from list
-            download_result = downloader.run(uploaded_files)
+        # download files from list
+        download_result = downloader.run(uploaded_files)
 
     # all the files are downloaded, HWM is ignored
     assert len(download_result.successful) == len(uploaded_files)
 
 
-def test_file_downloader_hwm_type_deprecated(
+def test_file_downloader_incremental_strategy_different_hwm_type_in_store(
     file_connection_with_path_and_files,
     tmp_path_factory,
-    tmp_path,
 ):
-    file_connection, remote_path, uploaded_files = file_connection_with_path_and_files
+    hwm_store = HWMStoreStackManager.get_current()
+    hwm_name = secrets.token_hex(5)
+
+    file_connection, remote_path, _ = file_connection_with_path_and_files
     local_path = tmp_path_factory.mktemp("local_path")
 
-    msg = r'Passing "hwm_type" in FileDownloader class is deprecated since version 0.10.0. It will be removed in future versions. Use hwm=FileListHWM(.*) class instead.'
-    with pytest.warns(DeprecationWarning, match=msg):
-        downloader = FileDownloader(
-            connection=file_connection,
-            source_path=remote_path,
-            local_path=local_path,
-            hwm_type="file_list",
-        )
+    downloader = FileDownloader(
+        connection=file_connection,
+        source_path=remote_path,
+        local_path=local_path,
+        hwm=FileListHWM(name=hwm_name),
+    )
 
-    assert isinstance(downloader.hwm, FileListHWM)
-    assert downloader.hwm.entity == remote_path
+    # HWM Store contains HWM with same name, but different type
+    hwm_store.set_hwm(ColumnIntHWM(name=hwm_name, expression="hwm_int"))
+
+    with pytest.raises(TypeError, match="Cannot cast HWM of type .* as .*"):
+        with IncrementalStrategy():
+            downloader.run()
+
+
+def test_file_downloader_incremental_strategy_different_hwm_directory_in_store(
+    file_connection_with_path_and_files,
+    tmp_path_factory,
+):
+    hwm_store = HWMStoreStackManager.get_current()
+    hwm_name = secrets.token_hex(5)
+
+    file_connection, remote_path, _ = file_connection_with_path_and_files
+    local_path = tmp_path_factory.mktemp("local_path")
+
+    downloader = FileDownloader(
+        connection=file_connection,
+        source_path=remote_path,
+        local_path=local_path,
+        hwm=FileListHWM(name=hwm_name),
+    )
+
+    # HWM Store contains HWM with same name, but different directory
+    hwm_store.set_hwm(FileListHWM(name=hwm_name, directory=local_path))
+    with pytest.raises(ValueError, match="Detected HWM with different `entity` attribute"):
+        with IncrementalStrategy():
+            downloader.run()
+
+
+@pytest.mark.parametrize("attribute", ["expression", "description"])
+def test_file_downloader_incremental_strategy_different_hwm_optional_attribute_in_store(
+    file_connection_with_path_and_files,
+    tmp_path_factory,
+    attribute,
+):
+    hwm_store = HWMStoreStackManager.get_current()
+    hwm_name = secrets.token_hex(5)
+
+    file_connection, remote_path, _ = file_connection_with_path_and_files
+    local_path = tmp_path_factory.mktemp("local_path")
+
+    old_hwm = FileListHWM(name=hwm_name, directory=AbsolutePath(remote_path), expression="some", description="another")
+    # HWM Store contains HWM with same name, but different optional attribute
+    fake_hwm = old_hwm.copy(update={attribute: rand_str()})
+    hwm_store.set_hwm(fake_hwm)
+
+    downloader = FileDownloader(
+        connection=file_connection,
+        source_path=remote_path,
+        local_path=local_path,
+        hwm=old_hwm,
+    )
+    with pytest.warns(UserWarning, match=f"Detected HWM with different `{attribute}` attribute"):
+        with IncrementalStrategy():
+            downloader.run()
+
+    # attributes from FileDownloader have higher priority, except value
+    new_hwm = hwm_store.get_hwm(name=hwm_name)
+    assert new_hwm.dict(exclude={"value", "modified_time"}) == old_hwm.dict(exclude={"value", "modified_time"})
+
+
+def test_file_downloader_incremental_strategy_hwm_set_twice(
+    file_connection_with_path_and_files,
+    tmp_path_factory,
+):
+    file_connection, remote_path, _ = file_connection_with_path_and_files
+    local_path = tmp_path_factory.mktemp("local_path")
+
+    downloader1 = FileDownloader(
+        connection=file_connection,
+        source_path=remote_path,
+        local_path=local_path,
+        hwm=FileListHWM(name=secrets.token_hex(5)),
+    )
+
+    downloader2 = FileDownloader(
+        connection=file_connection,
+        source_path=remote_path,
+        local_path=local_path,
+        hwm=FileListHWM(name=secrets.token_hex(5)),
+    )
+
+    file_connection.create_dir(remote_path / "different")
+    file_connection.write_text(remote_path / "different/file.txt", "abc")
+    downloader3 = FileDownloader(
+        connection=file_connection,
+        source_path=remote_path / "different",
+        local_path=local_path,
+        hwm=FileListHWM(name=secrets.token_hex(5)),
+    )
+
+    with IncrementalStrategy():
+        downloader1.run()
+
+        with pytest.raises(
+            ValueError,
+            match="Detected wrong IncrementalStrategy usage.",
+        ):
+            downloader2.run()
+
+        with pytest.raises(
+            ValueError,
+            match="Detected wrong IncrementalStrategy usage.",
+        ):
+            downloader3.run()

--- a/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_greenplum.py
+++ b/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_greenplum.py
@@ -51,7 +51,7 @@ def test_greenplum_strategy_incremental(
     reader = DBReader(
         connection=greenplum,
         source=prepare_schema_table.full_name,
-        hwm=DBReader.AutoDetectHWM(name=hwm_name, column=hwm_column),
+        hwm=DBReader.AutoDetectHWM(name=hwm_name, expression=hwm_column),
     )
 
     # there are 2 spans with a gap between
@@ -139,7 +139,7 @@ def test_greenplum_strategy_incremental_wrong_wm_type(
     reader = DBReader(
         connection=greenplum,
         source=prepare_schema_table.full_name,
-        hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), column=hwm_column),
+        hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), expression=hwm_column),
     )
 
     data = processing.create_pandas_df()
@@ -178,7 +178,7 @@ def test_greenplum_strategy_incremental_explicit_hwm_type(
         connection=greenplum,
         source=prepare_schema_table.full_name,
         # tell DBReader that text_string column contains integer values, and can be used for HWM
-        hwm=ColumnIntHWM(name=hwm_name, column="text_string"),
+        hwm=ColumnIntHWM(name=hwm_name, expression="text_string"),
     )
 
     data = processing.create_pandas_df()
@@ -205,25 +205,22 @@ def test_greenplum_strategy_incremental_explicit_hwm_type(
 
 
 @pytest.mark.parametrize(
-    "hwm_source, hwm_column, hwm_expr, hwm_type, func",
+    "hwm_source, hwm_expr, hwm_type, func",
     [
         (
             "hwm_int",
-            "hwm1_int",
             "cast(text_string as int)",
             ColumnIntHWM,
             str,
         ),
         (
             "hwm_date",
-            "hwm1_date",
             "cast(text_string as date)",
             ColumnDateHWM,
             lambda x: x.isoformat(),
         ),
         (
             "hwm_datetime",
-            "HWM1_DATETIME",
             "cast(text_string as timestamp)",
             ColumnDateTimeHWM,
             lambda x: x.isoformat(),
@@ -235,7 +232,6 @@ def test_greenplum_strategy_incremental_with_hwm_expr(
     processing,
     prepare_schema_table,
     hwm_source,
-    hwm_column,
     hwm_expr,
     hwm_type,
     func,
@@ -253,7 +249,7 @@ def test_greenplum_strategy_incremental_with_hwm_expr(
     reader = DBReader(
         connection=greenplum,
         source=prepare_schema_table.full_name,
-        hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), column=hwm_column, expression=hwm_expr),
+        hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), expression=hwm_expr),
     )
 
     # there are 2 spans with a gap between

--- a/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_hive.py
+++ b/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_hive.py
@@ -43,7 +43,7 @@ def test_hive_strategy_incremental(
     reader = DBReader(
         connection=hive,
         source=prepare_schema_table.full_name,
-        hwm=DBReader.AutoDetectHWM(name=hwm_name, column=hwm_column),
+        hwm=DBReader.AutoDetectHWM(name=hwm_name, expression=hwm_column),
     )
 
     # there are 2 spans with a gap between
@@ -123,7 +123,7 @@ def test_hive_strategy_incremental_wrong_hwm(
     reader = DBReader(
         connection=hive,
         source=prepare_schema_table.full_name,
-        hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), column=hwm_column),
+        hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), expression=hwm_column),
     )
 
     data = processing.create_pandas_df()
@@ -155,7 +155,7 @@ def test_hive_strategy_incremental_explicit_hwm_type(
         connection=hive,
         source=prepare_schema_table.full_name,
         # tell DBReader that text_string column contains integer values, and can be used for HWM
-        hwm=ColumnIntHWM(name=hwm_name, column="text_string"),
+        hwm=ColumnIntHWM(name=hwm_name, expression="text_string"),
     )
 
     data = processing.create_pandas_df()
@@ -182,14 +182,13 @@ def test_hive_strategy_incremental_explicit_hwm_type(
 
 
 @pytest.mark.parametrize(
-    "hwm_source, hwm_expr, hwm_column, hwm_type, func",
+    "hwm_source, hwm_expr, hwm_type, func",
     [
-        ("hwm_int", "CAST(text_string AS INT)", "hwm1_int", ColumnIntHWM, str),
-        ("hwm_date", "CAST(text_string AS DATE)", "hwm1_date", ColumnDateHWM, lambda x: x.isoformat()),
+        ("hwm_int", "CAST(text_string AS INT)", ColumnIntHWM, str),
+        ("hwm_date", "CAST(text_string AS DATE)", ColumnDateHWM, lambda x: x.isoformat()),
         (
             "hwm_datetime",
             "CAST(text_string AS TIMESTAMP)",
-            "HWM1_DATETIME",
             ColumnDateTimeHWM,
             lambda x: x.isoformat(),
         ),
@@ -201,7 +200,6 @@ def test_hive_strategy_incremental_with_hwm_expr(
     prepare_schema_table,
     hwm_source,
     hwm_expr,
-    hwm_column,
     hwm_type,
     func,
 ):
@@ -210,7 +208,7 @@ def test_hive_strategy_incremental_with_hwm_expr(
     reader = DBReader(
         connection=hive,
         source=prepare_schema_table.full_name,
-        hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), column=hwm_column, expression=hwm_expr),
+        hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), expression=hwm_expr),
     )
 
     # there are 2 spans with a gap between

--- a/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_mongodb.py
+++ b/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_mongodb.py
@@ -74,7 +74,7 @@ def test_mongodb_strategy_incremental(
     reader = DBReader(
         connection=mongodb,
         table=prepare_schema_table.table,
-        hwm=DBReader.AutoDetectHWM(name=hwm_name, column=hwm_column),
+        hwm=DBReader.AutoDetectHWM(name=hwm_name, expression=hwm_column),
         df_schema=df_schema,
     )
 
@@ -164,7 +164,7 @@ def test_mongodb_strategy_incremental_wrong_hwm(
     reader = DBReader(
         connection=mongodb,
         table=prepare_schema_table.table,
-        hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), column=hwm_column),
+        hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), expression=hwm_column),
         df_schema=df_schema,
     )
 
@@ -205,7 +205,7 @@ def test_mongodb_strategy_incremental_explicit_hwm_type(
         source=prepare_schema_table.table,
         df_schema=df_schema,
         # tell DBReader that text_string column contains integer values, and can be used for HWM
-        hwm=ColumnIntHWM(name=hwm_name, column="text_string"),
+        hwm=ColumnIntHWM(name=hwm_name, expression="text_string"),
     )
 
     data = processing.create_pandas_df()

--- a/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_mssql.py
+++ b/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_mssql.py
@@ -51,7 +51,7 @@ def test_mssql_strategy_incremental(
     reader = DBReader(
         connection=mssql,
         source=prepare_schema_table.full_name,
-        hwm=DBReader.AutoDetectHWM(name=hwm_name, column=hwm_column),
+        hwm=DBReader.AutoDetectHWM(name=hwm_name, expression=hwm_column),
     )
 
     # there are 2 spans with a gap between
@@ -139,7 +139,7 @@ def test_mssql_strategy_incremental_wrong_hwm(
     reader = DBReader(
         connection=mssql,
         source=prepare_schema_table.full_name,
-        hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), column=hwm_column),
+        hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), expression=hwm_column),
     )
 
     data = processing.create_pandas_df()
@@ -178,7 +178,7 @@ def test_mssql_strategy_incremental_explicit_hwm_type(
         connection=mssql,
         source=prepare_schema_table.full_name,
         # tell DBReader that text_string column contains integer values, and can be used for HWM
-        hwm=ColumnIntHWM(name=hwm_name, column="text_string"),
+        hwm=ColumnIntHWM(name=hwm_name, expression="text_string"),
     )
 
     data = processing.create_pandas_df()
@@ -205,25 +205,22 @@ def test_mssql_strategy_incremental_explicit_hwm_type(
 
 
 @pytest.mark.parametrize(
-    "hwm_source, hwm_column, hwm_expr, hwm_type, func",
+    "hwm_source, hwm_expr, hwm_type, func",
     [
         (
             "hwm_int",
-            "hwm1_int",
             "CAST(text_string AS int)",
             ColumnIntHWM,
             str,
         ),
         (
             "hwm_date",
-            "hwm1_date",
             "CAST(text_string AS Date)",
             ColumnDateHWM,
             lambda x: x.isoformat(),
         ),
         (
             "hwm_datetime",
-            "HWM1_DATETIME",
             "CAST(text_string AS datetime2)",
             ColumnDateTimeHWM,
             lambda x: x.isoformat(),
@@ -235,7 +232,6 @@ def test_mssql_strategy_incremental_with_hwm_expr(
     processing,
     prepare_schema_table,
     hwm_source,
-    hwm_column,
     hwm_expr,
     hwm_type,
     func,
@@ -253,7 +249,7 @@ def test_mssql_strategy_incremental_with_hwm_expr(
     reader = DBReader(
         connection=mssql,
         source=prepare_schema_table.full_name,
-        hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), column=hwm_column, expression=hwm_expr),
+        hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), expression=hwm_expr),
     )
 
     # there are 2 spans with a gap between

--- a/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_mysql.py
+++ b/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_mysql.py
@@ -50,7 +50,7 @@ def test_mysql_strategy_incremental(
     reader = DBReader(
         connection=mysql,
         source=prepare_schema_table.full_name,
-        hwm=DBReader.AutoDetectHWM(name=hwm_name, column=hwm_column),
+        hwm=DBReader.AutoDetectHWM(name=hwm_name, expression=hwm_column),
     )
 
     # there are 2 spans with a gap between
@@ -137,7 +137,7 @@ def test_mysql_strategy_incremental_wrong_hwm(
     reader = DBReader(
         connection=mysql,
         source=prepare_schema_table.full_name,
-        hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), column=hwm_column),
+        hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), expression=hwm_column),
     )
 
     data = processing.create_pandas_df()
@@ -175,7 +175,7 @@ def test_mysql_strategy_incremental_explicit_hwm_type(
         connection=mysql,
         source=prepare_schema_table.full_name,
         # tell DBReader that text_string column contains integer values, and can be used for HWM
-        hwm=ColumnIntHWM(name=hwm_name, column="text_string"),
+        hwm=ColumnIntHWM(name=hwm_name, expression="text_string"),
     )
 
     data = processing.create_pandas_df()
@@ -202,25 +202,22 @@ def test_mysql_strategy_incremental_explicit_hwm_type(
 
 
 @pytest.mark.parametrize(
-    "hwm_source, hwm_column, hwm_expr, hwm_type, func",
+    "hwm_source, hwm_expr, hwm_type, func",
     [
         (
             "hwm_int",
-            "hwm1_int",
             "(text_string+0)",
             ColumnIntHWM,
             str,
         ),
         (
             "hwm_date",
-            "hwm1_date",
             "STR_TO_DATE(text_string, '%Y-%m-%d')",
             ColumnDateHWM,
             lambda x: x.isoformat(),
         ),
         (
             "hwm_datetime",
-            "HWM1_DATETIME",
             "STR_TO_DATE(text_string, '%Y-%m-%dT%H:%i:%s.%f')",
             ColumnDateTimeHWM,
             lambda x: x.isoformat(),
@@ -232,7 +229,6 @@ def test_mysql_strategy_incremental_with_hwm_expr(
     processing,
     prepare_schema_table,
     hwm_source,
-    hwm_column,
     hwm_expr,
     hwm_type,
     func,
@@ -249,7 +245,7 @@ def test_mysql_strategy_incremental_with_hwm_expr(
     reader = DBReader(
         connection=mysql,
         source=prepare_schema_table.full_name,
-        hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), column=hwm_column, expression=hwm_expr),
+        hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), expression=hwm_expr),
     )
 
     # there are 2 spans with a gap between

--- a/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_oracle.py
+++ b/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_oracle.py
@@ -55,7 +55,7 @@ def test_oracle_strategy_incremental(
     reader = DBReader(
         connection=oracle,
         source=prepare_schema_table.full_name,
-        hwm=DBReader.AutoDetectHWM(name=hwm_name, column=hwm_column),
+        hwm=DBReader.AutoDetectHWM(name=hwm_name, expression=hwm_column),
     )
 
     # there are 2 spans with a gap between
@@ -152,7 +152,7 @@ def test_oracle_strategy_incremental_wrong_hwm(
     reader = DBReader(
         connection=oracle,
         source=prepare_schema_table.full_name,
-        hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), column=hwm_column),
+        hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), expression=hwm_column),
     )
 
     data = processing.create_pandas_df()
@@ -191,7 +191,7 @@ def test_oracle_strategy_incremental_explicit_hwm_type(
         connection=oracle,
         source=prepare_schema_table.full_name,
         # tell DBReader that text_string column contains integer values, and can be used for HWM
-        hwm=ColumnIntHWM(name=hwm_name, column="TEXT_STRING"),
+        hwm=ColumnIntHWM(name=hwm_name, expression="TEXT_STRING"),
     )
 
     data = processing.create_pandas_df()
@@ -218,25 +218,22 @@ def test_oracle_strategy_incremental_explicit_hwm_type(
 
 
 @pytest.mark.parametrize(
-    "hwm_source, hwm_column, hwm_expr, hwm_type, func",
+    "hwm_source, hwm_expr, hwm_type, func",
     [
         (
             "hwm_int",
-            "HWM1_INT",
             "TO_NUMBER(TEXT_STRING)",
             ColumnIntHWM,
             str,
         ),
         (
             "hwm_date",
-            "HWM1_DATE",
             "TO_DATE(TEXT_STRING, 'YYYY-MM-DD')",
             ColumnDateHWM,
             lambda x: x.isoformat(),
         ),
         (
             "hwm_datetime",
-            "hwm1_datetime",
             "TO_DATE(TEXT_STRING, 'YYYY-MM-DD HH24:MI:SS')",
             ColumnDateTimeHWM,
             lambda x: x.strftime("%Y-%m-%d %H:%M:%S"),
@@ -248,7 +245,6 @@ def test_oracle_strategy_incremental_with_hwm_expr(
     processing,
     prepare_schema_table,
     hwm_source,
-    hwm_column,
     hwm_expr,
     hwm_type,
     func,
@@ -266,7 +262,7 @@ def test_oracle_strategy_incremental_with_hwm_expr(
     reader = DBReader(
         connection=oracle,
         source=prepare_schema_table.full_name,
-        hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), column=hwm_column, expression=hwm_expr),
+        hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), expression=hwm_expr),
     )
 
     # there are 2 spans with a gap between

--- a/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_postgres.py
+++ b/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_postgres.py
@@ -51,7 +51,7 @@ def test_postgres_strategy_incremental(
     reader = DBReader(
         connection=postgres,
         source=prepare_schema_table.full_name,
-        hwm=DBReader.AutoDetectHWM(name=hwm_name, entity=hwm_column),
+        hwm=DBReader.AutoDetectHWM(name=hwm_name, expression=hwm_column),
     )
 
     # there are 2 spans with a gap between
@@ -114,25 +114,22 @@ def test_postgres_strategy_incremental(
 
 
 @pytest.mark.parametrize(
-    "hwm_source, hwm_column, hwm_expr, hwm_type, func",
+    "hwm_source, hwm_expr, hwm_type, func",
     [
         (
             "hwm_int",
-            "hwm1_int",
             "text_string::int",
             ColumnIntHWM,
             str,
         ),
         (
             "hwm_date",
-            "hwm1_date",
             "text_string::date",
             ColumnDateHWM,
             lambda x: x.isoformat(),
         ),
         (
             "hwm_datetime",
-            "HWM1_DATETIME",
             "text_string::timestamp",
             ColumnDateTimeHWM,
             lambda x: x.isoformat(),
@@ -144,7 +141,6 @@ def test_postgres_strategy_incremental_with_hwm_expr(
     processing,
     prepare_schema_table,
     hwm_source,
-    hwm_column,
     hwm_expr,
     hwm_type,
     func,
@@ -161,9 +157,7 @@ def test_postgres_strategy_incremental_with_hwm_expr(
     reader = DBReader(
         connection=postgres,
         source=prepare_schema_table.full_name,
-        # hwm_column is present in the dataframe even if it was not passed in columns list
-        columns=[column for column in processing.column_names if column != hwm_column],
-        hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), column=hwm_column, expression=hwm_expr),
+        hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), expression=hwm_expr),
     )
 
     # there are 2 spans with a gap between
@@ -244,7 +238,7 @@ def test_postgres_strategy_incremental_wrong_hwm(
     reader = DBReader(
         connection=postgres,
         source=prepare_schema_table.full_name,
-        hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), column=hwm_column),
+        hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), expression=hwm_column),
     )
 
     data = processing.create_pandas_df()
@@ -278,7 +272,7 @@ def test_postgres_strategy_incremental_explicit_hwm_type(
         connection=postgres,
         source=prepare_schema_table.full_name,
         # tell DBReader that text_string column contains integer values, and can be used for HWM
-        hwm=ColumnIntHWM(name=secrets.token_hex(5), column="text_string"),
+        hwm=ColumnIntHWM(name=secrets.token_hex(5), expression="text_string"),
     )
 
     data = processing.create_pandas_df()

--- a/tests/tests_unit/test_db/test_db_reader_unit/test_common_reader_unit.py
+++ b/tests/tests_unit/test_db/test_db_reader_unit/test_common_reader_unit.py
@@ -1,11 +1,12 @@
 import re
-import secrets
 import textwrap
 
 import pytest
 
 from onetl.connection import Hive
 from onetl.db import DBReader
+
+pytestmark = pytest.mark.hive
 
 
 def test_reader_deprecated_import():
@@ -55,23 +56,7 @@ def test_reader_hive_with_read_options(spark_mock):
         (),
         {},
         set(),
-        " \t\n",
-        [""],
-        [" \t\n"],
-        ["", "abc"],
-        [" \t\n", "abc"],
-        "",
-        " \t\n",
-        ",abc",
-        "abc,",
-        "cde,,abc",
-        "cde, ,abc",
-        "*,*,cde",
-        "abc,abc,cde",
-        "abc,ABC,cde",
-        ["*", "*", "cde"],
-        ["abc", "abc", "cde"],
-        ["abc", "ABC", "cde"],
+        "any,string",
     ],
 )
 def test_reader_invalid_columns(spark_mock, columns):
@@ -86,9 +71,6 @@ def test_reader_invalid_columns(spark_mock, columns):
 @pytest.mark.parametrize(
     "columns, real_columns",
     [
-        ("*", ["*"]),
-        ("abc, cde", ["abc", "cde"]),
-        ("*, abc", ["*", "abc"]),
         (["*"], ["*"]),
         (["abc", "cde"], ["abc", "cde"]),
         (["*", "abc"], ["*", "abc"]),
@@ -105,129 +87,74 @@ def test_reader_valid_columns(spark_mock, columns, real_columns):
 
 
 @pytest.mark.parametrize(
-    "hwm_column",
+    "hwm_column, real_hwm_expression",
     [
-        "wrong/name",
-        "wrong@name",
-        "wrong=name",
-        "wrong#name",
-        [],
-        {},
-        (),
-        set(),
-        frozenset(),
-        ("name",),
-        ["name"],
-        {"name"},
-        ("wrong/name", "statement"),
-        ("wrong@name", "statement"),
-        ("wrong=name", "statement"),
-        ("wrong#name", "statement"),
-        ["wrong/name", "statement"],
-        ["wrong@name", "statement"],
-        ["wrong=name", "statement"],
-        ["wrong#name", "statement"],
-        ("wrong/name", "statement", "too", "many"),
-        ("wrong@name", "statement", "too", "many"),
-        ("wrong=name", "statement", "too", "many"),
-        ("wrong#name", "statement", "too", "many"),
-        ["wrong/name", "statement", "too", "many"],
-        ["wrong@name", "statement", "too", "many"],
-        ["wrong=name", "statement", "too", "many"],
-        ["wrong#name", "statement", "too", "many"],
-        {"wrong/name", "statement", "too", "many"},
-        {"wrong@name", "statement", "too", "many"},
-        {"wrong=name", "statement", "too", "many"},
-        {"wrong#name", "statement", "too", "many"},
-        (None, "statement"),
-        [None, "statement"],
-        # this is the same as HWM(name=..., column="name"),
-        # but if user implicitly passed a tuple
-        # both of values should be set to avoid unexpected errors
-        ("name", None),
-        ["name", None],
+        ("hwm_column", "hwm_column"),
+        (("hwm_column", "expression"), "expression"),
+        (("hwm_column", "hwm_column"), "hwm_column"),
     ],
 )
-def test_reader_invalid_hwm_column(spark_mock, hwm_column):
-    with pytest.raises(ValueError):
-        DBReader(
+def test_reader_deprecated_hwm_column(spark_mock, hwm_column, real_hwm_expression):
+    error_msg = 'Passing "hwm_column" in DBReader class is deprecated since version 0.10.0'
+    with pytest.warns(UserWarning, match=error_msg):
+        reader = DBReader(
             connection=Hive(cluster="rnd-dwh", spark=spark_mock),
             table="schema.table",
             hwm_column=hwm_column,
         )
 
-
-@pytest.mark.parametrize(
-    "hwm_column, real_hwm_column, real_hwm_expression",
-    [
-        ("hwm_column", "hwm_column", None),
-        (("hwm_column", "expression"), "hwm_column", "expression"),
-        (("hwm_column", "hwm_column"), "hwm_column", "hwm_column"),
-    ],
-)
-def test_reader_valid_hwm_column(spark_mock, hwm_column, real_hwm_column, real_hwm_expression):
-    reader = DBReader(
-        connection=Hive(cluster="rnd-dwh", spark=spark_mock),
-        table="schema.table",
-        hwm_column=hwm_column,
-    )
-
-    assert reader.hwm.entity == real_hwm_column
+    assert isinstance(reader.hwm, reader.AutoDetectHWM)
+    assert reader.hwm.entity == "schema.table"
     assert reader.hwm.expression == real_hwm_expression
 
 
-@pytest.mark.parametrize(
-    "columns, hwm_column",
-    [
-        (["a", "b", "c", "d"], "d"),
-        (["a", "b", "c", "d"], "D"),
-        (["a", "b", "c", "D"], "d"),
-        ("a, b, c, d", "d"),
-        ("a, b, c, d", "D"),
-        ("a, b, c, D", "d"),
-        (["*", "d"], "d"),
-        (["*", "d"], "D"),
-        (["*", "D"], "d"),
-        ("*, d", "d"),
-        ("*, d", "D"),
-        ("*, D", "d"),
-        (["*"], "d"),
-        (["*"], "D"),
-        (["*"], ("d", "cast")),
-        (["*"], ("D", "cast")),
-    ],
-)
-def test_reader_hwm_column_and_columns_are_not_in_conflict(spark_mock, columns, hwm_column):
-    DBReader(
+def test_reader_autofill_hwm_source(spark_mock):
+    reader = DBReader(
         connection=Hive(cluster="rnd-dwh", spark=spark_mock),
         table="schema.table",
-        columns=columns,
-        hwm_column=hwm_column,
+        hwm=DBReader.AutoDetectHWM(
+            name="some_name",
+            expression="some_expression",
+        ),
     )
 
+    assert reader.hwm.entity == "schema.table"
+    assert reader.hwm.expression == "some_expression"
 
-@pytest.mark.parametrize(
-    "columns, hwm_column",
-    [
-        (["a", "b", "c", "d"], ("d", "cast")),
-        (["a", "b", "c", "d"], ("D", "cast")),
-        (["a", "b", "c", "D"], ("d", "cast")),
-        ("a, b, c, d", ("d", "cast")),
-        ("a, b, c, d", ("D", "cast")),
-        ("a, b, c, D", ("d", "cast")),
-        (["*", "d"], ("d", "cast")),
-        (["*", "d"], ("D", "cast")),
-        (["*", "D"], ("d", "cast")),
-        ("*, d", ("d", "cast")),
-        ("*, d", ("D", "cast")),
-        ("*, D", ("d", "cast")),
-    ],
-)
-def test_reader_hwm_column_and_columns_are_in_conflict(spark_mock, columns, hwm_column):
-    with pytest.raises(ValueError):
+
+def test_reader_hwm_has_same_source(spark_mock):
+    reader = DBReader(
+        connection=Hive(cluster="rnd-dwh", spark=spark_mock),
+        source="schema.table",
+        hwm=DBReader.AutoDetectHWM(
+            name="some_name",
+            source="schema.table",
+            expression="some_expression",
+        ),
+    )
+
+    assert reader.hwm.entity == "schema.table"
+    assert reader.hwm.expression == "some_expression"
+
+
+def test_reader_hwm_has_different_source(spark_mock):
+    error_msg = "Passed `hwm.source` is different from `source`"
+    with pytest.raises(ValueError, match=error_msg):
         DBReader(
             connection=Hive(cluster="rnd-dwh", spark=spark_mock),
             table="schema.table",
-            columns=columns,
-            hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), column=hwm_column),
+            hwm=DBReader.AutoDetectHWM(
+                name="some_name",
+                source="another.table",
+                expression="some_expression",
+            ),
+        )
+
+
+def test_reader_no_hwm_expression(spark_mock):
+    with pytest.raises(ValueError, match="`hwm.expression` cannot be None"):
+        DBReader(
+            connection=Hive(cluster="rnd-dwh", spark=spark_mock),
+            table="schema.table",
+            hwm=DBReader.AutoDetectHWM(name="some_name"),
         )

--- a/tests/tests_unit/test_db/test_db_reader_unit/test_kafka_reader_unit.py
+++ b/tests/tests_unit/test_db/test_db_reader_unit/test_kafka_reader_unit.py
@@ -78,7 +78,7 @@ def test_kafka_reader_hwm_offset_is_valid(spark_mock):
     DBReader(
         connection=kafka,
         table="table",
-        hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), column="offset"),
+        hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), expression="offset"),
     )
 
 
@@ -92,7 +92,7 @@ def test_kafka_reader_hwm_timestamp_depends_on_spark_version(spark_mock, mocker)
     DBReader(
         connection=kafka,
         table="table",
-        hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), column="timestamp"),
+        hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), expression="timestamp"),
     )
 
     mocker.patch.object(spark_mock, "version", new="2.4.0")
@@ -100,7 +100,7 @@ def test_kafka_reader_hwm_timestamp_depends_on_spark_version(spark_mock, mocker)
         DBReader(
             connection=kafka,
             table="table",
-            hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), column="timestamp"),
+            hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), expression="timestamp"),
         )
 
 
@@ -113,28 +113,10 @@ def test_kafka_reader_invalid_hwm_column(spark_mock):
 
     with pytest.raises(
         ValueError,
-        match="is not a valid hwm column",
+        match="hwm.expression='unknown' is not supported by Kafka",
     ):
         DBReader(
             connection=kafka,
             table="table",
-            hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), column="unknown"),
-        )
-
-
-def test_kafka_reader_hwm_expression_unsupported(spark_mock):
-    kafka = Kafka(
-        addresses=["localhost:9092"],
-        cluster="my_cluster",
-        spark=spark_mock,
-    )
-
-    with pytest.raises(
-        ValueError,
-        match="'hwm.expression' parameter is not supported by Kafka",
-    ):
-        DBReader(
-            connection=kafka,
-            table="table",
-            hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), column="offset", expression="some"),
+            hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), expression="unknown"),
         )

--- a/tests/tests_unit/test_db/test_db_reader_unit/test_mongodb_reader_unit.py
+++ b/tests/tests_unit/test_db/test_db_reader_unit/test_mongodb_reader_unit.py
@@ -1,5 +1,3 @@
-import secrets
-
 import pytest
 
 from onetl.connection import MongoDB
@@ -133,27 +131,6 @@ def test_mongodb_reader_without_df_schema(spark_mock):
         DBReader(
             connection=mongo,
             table="table",
-        )
-
-
-def test_mongodb_reader_error_pass_hwm_expression(spark_mock, df_schema):
-    mongo = MongoDB(
-        host="host",
-        user="user",
-        password="password",
-        database="database",
-        spark=spark_mock,
-    )
-
-    with pytest.raises(
-        ValueError,
-        match="'hwm.expression' parameter is not supported by MongoDB",
-    ):
-        DBReader(
-            connection=mongo,
-            table="table",
-            df_schema=df_schema,
-            hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), column="hwm_int", expression="expr"),
         )
 
 

--- a/tests/tests_unit/test_file/test_file_downloader_unit.py
+++ b/tests/tests_unit/test_file/test_file_downloader_unit.py
@@ -9,7 +9,10 @@ from etl_entities.hwm import (
     ColumnDateTimeHWM,
     ColumnHWM,
     ColumnIntHWM,
+    FileListHWM,
 )
+from etl_entities.instance import AbsolutePath
+from etl_entities.old_hwm import FileListHWM as OldFileListHWM
 
 from onetl.base import BaseFileConnection
 from onetl.core import FileFilter, FileLimit
@@ -37,51 +40,124 @@ def test_file_downloader_deprecated_import():
         assert OldFileDownloader is FileDownloader
 
 
+@pytest.mark.parametrize(
+    "hwm_type",
+    [
+        "file_list",
+        OldFileListHWM,
+    ],
+)
+def test_file_downloader_hwm_type_deprecated(hwm_type):
+    warning_msg = 'Passing "hwm_type" to FileDownloader class is deprecated since version 0.10.0'
+    connection = Mock(spec=BaseFileConnection)
+    connection.instance_url = "abc"
+
+    with pytest.warns(UserWarning, match=warning_msg):
+        downloader = FileDownloader(
+            connection=connection,
+            local_path="/local/path",
+            source_path="/source/path",
+            hwm_type=hwm_type,
+        )
+
+    assert isinstance(downloader.hwm, FileListHWM)
+    assert downloader.hwm.entity == AbsolutePath("/source/path")
+
+
 def test_file_downloader_unknown_hwm_type():
     # fails on pydantic issubclass(hwm_type, OldFileListHWM) in FileDownloader
     with pytest.raises(ValueError):
         FileDownloader(
-            connection=Mock(),
-            local_path="/path",
-            source_path="/path",
+            connection=Mock(spec=BaseFileConnection),
+            local_path="/local/path",
+            source_path="/source/path",
             hwm_type="abc",
         )
 
 
 @pytest.mark.parametrize(
-    "hwm_type, hwm_type_name",
+    "hwm_type",
     [
-        (ColumnIntHWM, "ColumnIntHWM"),
-        (ColumnDateHWM, "ColumnDateHWM"),
-        (ColumnDateTimeHWM, "ColumnDateTimeHWM"),
-        (HWM, "HWM"),
-        (ColumnHWM, "ColumnHWM"),
+        ColumnIntHWM,
+        ColumnDateHWM,
+        ColumnDateTimeHWM,
+        ColumnHWM,
+        HWM,
     ],
 )
-def test_file_downloader_wrong_hwm_type(hwm_type, hwm_type_name):
+def test_file_downloader_wrong_hwm_type(hwm_type):
     # pydantic validation fails, as new hwm classes are passed into hwm_type
     with pytest.raises(ValueError):
         FileDownloader(
-            connection=Mock(),
-            local_path="/path",
-            source_path="/path",
+            connection=Mock(spec=BaseFileConnection),
+            local_path="/local/path",
+            source_path="/source/path",
             hwm_type=hwm_type,
         )
 
 
-def test_file_downloader_hwm_type_without_source_path():
-    with pytest.raises(ValueError, match="If `hwm_type` is passed, `source_path` must be specified"):
+@pytest.mark.parametrize(
+    "hwm_type",
+    [
+        "file_list",
+        OldFileListHWM,
+    ],
+)
+def test_file_downloader_hwm_type_without_source_path(hwm_type):
+    warning_msg = "If `hwm` is passed, `source_path` must be specified"
+    with pytest.raises(ValueError, match=warning_msg):
         FileDownloader(
-            connection=Mock(),
-            local_path="/path",
-            hwm_type="file_list",
+            connection=Mock(spec=BaseFileConnection),
+            local_path="/local/path",
+            hwm_type=hwm_type,
+        )
+
+
+def test_file_downloader_hwm_without_source_path():
+    warning_msg = "If `hwm` is passed, `source_path` must be specified"
+    with pytest.raises(ValueError, match=warning_msg):
+        FileDownloader(
+            connection=Mock(spec=BaseFileConnection),
+            local_path="/local/path",
+            hwm=FileListHWM(name="abc"),
+        )
+
+
+def test_file_downloader_hwm_autofill_directory():
+    downloader = FileDownloader(
+        connection=Mock(spec=BaseFileConnection),
+        local_path="/local/path",
+        source_path="/source/path",
+        hwm=FileListHWM(name="abc"),
+    )
+    assert downloader.hwm.entity == AbsolutePath("/source/path")
+
+
+def test_file_downloader_hwm_with_same_directory():
+    downloader = FileDownloader(
+        connection=Mock(spec=BaseFileConnection),
+        local_path="/local/path",
+        source_path="/source/path",
+        hwm=FileListHWM(name="abc", directory="/source/path"),
+    )
+    assert downloader.hwm.entity == AbsolutePath("/source/path")
+
+
+def test_file_downloader_hwm_with_different_directory_error():
+    error_msg = "Passed `hwm.directory` is different from `source_path`"
+    with pytest.raises(ValueError, match=error_msg):
+        FileDownloader(
+            connection=Mock(spec=BaseFileConnection),
+            local_path="/local/path",
+            source_path="/source/path",
+            hwm=FileListHWM(name="abc", directory="/another/path"),
         )
 
 
 def test_file_downloader_filter_default():
     downloader = FileDownloader(
         connection=Mock(spec=BaseFileConnection),
-        local_path="/path",
+        local_path="/local/path",
     )
 
     assert downloader.filters == []
@@ -91,7 +167,7 @@ def test_file_downloader_filter_none():
     with pytest.warns(UserWarning, match=re.escape("filter=None is deprecated in v0.8.0, use filters=[] instead")):
         downloader = FileDownloader(
             connection=Mock(spec=BaseFileConnection),
-            local_path="/path",
+            local_path="/local/path",
             filter=None,
         )
 
@@ -109,7 +185,7 @@ def test_file_downloader_filter_legacy(file_filter):
     with pytest.warns(UserWarning, match=re.escape("filter=... is deprecated in v0.8.0, use filters=[...] instead")):
         downloader = FileDownloader(
             connection=Mock(spec=BaseFileConnection),
-            local_path="/path",
+            local_path="/local/path",
             filter=file_filter,
         )
 
@@ -119,7 +195,7 @@ def test_file_downloader_filter_legacy(file_filter):
 def test_file_downloader_limit_default():
     downloader = FileDownloader(
         connection=Mock(spec=BaseFileConnection),
-        local_path="/path",
+        local_path="/local/path",
     )
 
     assert downloader.limits == []
@@ -129,7 +205,7 @@ def test_file_downloader_limit_none():
     with pytest.warns(UserWarning, match=re.escape("limit=None is deprecated in v0.8.0, use limits=[] instead")):
         downloader = FileDownloader(
             connection=Mock(spec=BaseFileConnection),
-            local_path="/path",
+            local_path="/local/path",
             limit=None,
         )
 
@@ -147,7 +223,7 @@ def test_file_downloader_limit_legacy(file_limit):
     with pytest.warns(UserWarning, match=re.escape("limit=... is deprecated in v0.8.0, use limits=[...] instead")):
         downloader = FileDownloader(
             connection=Mock(spec=BaseFileConnection),
-            local_path="/path",
+            local_path="/local/path",
             limit=file_limit,
         )
 

--- a/tests/tests_unit/tests_hwm_store_unit/test_yaml_hwm_store_unit.py
+++ b/tests/tests_unit/tests_hwm_store_unit/test_yaml_hwm_store_unit.py
@@ -77,7 +77,7 @@ def test_hwm_store_yaml_path_no_access(request, tmp_path_factory, hwm_delta):
     store = YAMLHWMStore(path=path)
 
     with pytest.raises(OSError):
-        store.get_hwm(hwm.qualified_name)
+        store.get_hwm(hwm.name)
 
     with pytest.raises(OSError):
         store.set_hwm(hwm)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

<!-- Please give a short summary of the changes. -->

Upgrade etl-entities to [2.1.x](https://github.com/MobileTeleSystems/etl-entities/releases/tag/2.1.0):
- `ColumnHWM.column` is merged to `ColumnHWM.expression`. Updated related tests.
- `ColumnHWM.entity` is now renamed to `ColumnHWM.source`, and contains table/topic/collection name. `DBReader` can automatically fill up this attribute using `source` field.
- `FileHWM.directory` is now optional. `FileDownloader` can automatically fill up this attribute using `source_path` field.
-  User cannot pass `ColumnHWM.source` and `FileHWM.directory` which is different from `DBReader.source`/`FileDownloader.source_path`. Firstly, `FileListHWM.update(path)` will raise an exception if `path` is not consistent with `directory`. Secondly, if these values are different in the code and HWMStore, we know that this probably a user mistake, and this check allows us to avoid data loss.
- Added tests for using `FileDownloader` inside `IncrementalStrategy` with some negative edge cases
- Replaced `DeprecationWarning` with `UserWarning` because it is muted on Python 3.7.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [ ] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [X] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
