### PR TITLE
[DOP-9787] Test strategies when DBReader reads empty source

### DIFF
--- a/docs/changelog/next_release/188.feature.rst
+++ b/docs/changelog/next_release/188.feature.rst
@@ -1,0 +1,2 @@
+``SnapshotBatchStagy`` and ``IncrementalBatchStrategy`` does no raise exceptions if source does not contain any data.
+Instead they stop at first iteration and return empty dataframe.

--- a/onetl/base/base_db_connection.py
+++ b/onetl/base/base_db_connection.py
@@ -140,6 +140,7 @@ class BaseDBConnection(BaseConnection):
         where: Any | None = None,
         df_schema: StructType | None = None,
         window: Window | None = None,
+        limit: int | None = None,
     ) -> DataFrame:
         """
         Reads the source to dataframe. |support_hooks|

--- a/onetl/connection/db_connection/db_connection/dialect.py
+++ b/onetl/connection/db_connection/db_connection/dialect.py
@@ -37,6 +37,7 @@ class DBDialect(BaseDBDialect):
         columns: list[str] | None = None,
         where: str | list[str] | None = None,
         hint: str | None = None,
+        limit: int | None = None,
         compact: bool = False,
     ) -> str:
         """
@@ -58,6 +59,10 @@ class DBDialect(BaseDBDialect):
         if isinstance(where, str):
             where = [where]
 
+        if limit == 0:
+            # LIMIT 0 not valid in some databases
+            where = ["1 = 0"]
+
         where_clauses = []
         if len(where) == 1:
             where_clauses.append("WHERE" + indent + where[0])
@@ -70,6 +75,7 @@ class DBDialect(BaseDBDialect):
             f"SELECT{hint}{columns_str}",
             f"FROM{indent}{table}",
             *where_clauses,
+            f"LIMIT{indent}{limit}" if limit else "",
         ]
 
         return os.linesep.join(filter(None, query_parts)).strip()

--- a/onetl/connection/db_connection/hive/connection.py
+++ b/onetl/connection/db_connection/hive/connection.py
@@ -365,12 +365,14 @@ class Hive(DBConnection):
         where: str | None = None,
         df_schema: StructType | None = None,
         window: Window | None = None,
+        limit: int | None = None,
     ) -> DataFrame:
         query = self.dialect.get_sql_query(
             table=source,
             columns=columns,
             where=self.dialect.apply_window(where, window),
             hint=hint,
+            limit=limit,
         )
 
         return self.sql(query)

--- a/onetl/connection/db_connection/jdbc_connection/connection.py
+++ b/onetl/connection/db_connection/jdbc_connection/connection.py
@@ -157,6 +157,7 @@ class JDBCConnection(JDBCMixin, DBConnection):
         where: str | None = None,
         df_schema: StructType | None = None,
         window: Window | None = None,
+        limit: int | None = None,
         options: JDBCReadOptions | None = None,
     ) -> DataFrame:
         read_options = self._set_lower_upper_bound(
@@ -199,6 +200,7 @@ class JDBCConnection(JDBCMixin, DBConnection):
             columns=new_columns,
             where=where,
             hint=hint,
+            limit=limit,
         )
 
         result = self.sql(query, read_options)
@@ -235,7 +237,7 @@ class JDBCConnection(JDBCMixin, DBConnection):
     ) -> StructType:
         log.info("|%s| Fetching schema of table %r ...", self.__class__.__name__, source)
 
-        query = self.dialect.get_sql_query(source, columns=columns, where="1=0", compact=True)
+        query = self.dialect.get_sql_query(source, columns=columns, limit=0, compact=True)
         read_options = self._exclude_partition_options(self.ReadOptions.parse(options), fetchsize=0)
 
         log.debug("|%s| Executing SQL query (on driver):", self.__class__.__name__)

--- a/onetl/connection/db_connection/kafka/connection.py
+++ b/onetl/connection/db_connection/kafka/connection.py
@@ -266,6 +266,7 @@ class Kafka(DBConnection):
         where: Any | None = None,
         df_schema: StructType | None = None,
         window: Window | None = None,
+        limit: int | None = None,
         options: KafkaReadOptions = KafkaReadOptions(),  # noqa: B008, WPS404
     ) -> DataFrame:
         log.info("|%s| Reading data from topic %r", self.__class__.__name__, source)

--- a/onetl/connection/db_connection/oracle/dialect.py
+++ b/onetl/connection/db_connection/oracle/dialect.py
@@ -26,6 +26,7 @@ class OracleDialect(JDBCDialect):
         columns: list[str] | None = None,
         where: str | list[str] | None = None,
         hint: str | None = None,
+        limit: int | None = None,
         compact: bool = False,
     ) -> str:
         # https://stackoverflow.com/questions/27965130/how-to-select-column-from-table-in-oracle
@@ -37,6 +38,7 @@ class OracleDialect(JDBCDialect):
             columns=new_columns,
             where=where,
             hint=hint,
+            limit=limit,
             compact=compact,
         )
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -261,12 +261,14 @@ ignore =
 # WPS604 Found incorrect node inside `class` body: pass
     WPS604,
 # WPS100 Found wrong module name: util
-    WPS100
+    WPS100,
 # WPS436 Found protected module import: onetl._util
 # https://github.com/wemake-services/wemake-python-styleguide/issues/1441
-    WPS436
+    WPS436,
 # WPS201 Found module with too many imports: 26 > 25
-    WPS201
+    WPS201,
+# WPS429 Found multiple assign targets
+    WPS429
 
 # http://flake8.pycqa.org/en/latest/user/options.html?highlight=per-file-ignores#cmdoption-flake8-per-file-ignores
 per-file-ignores =
@@ -409,9 +411,11 @@ per-file-ignores =
 # WPS520 Found compare with falsy constant: == []
         WPS520,
 # B017 `pytest.raises(Exception)` should be considered evil
-        B017
+        B017,
 # WPS202 Found too many module members: 40 > 35
-        WPS202
+        WPS202,
+# WPS210 Found too many local variables: 21 > 20
+        WPS210
 
 
 [darglint]

--- a/tests/tests_integration/tests_core_integration/tests_db_reader_integration/test_clickhouse_reader_integration.py
+++ b/tests/tests_integration/tests_core_integration/tests_db_reader_integration/test_clickhouse_reader_integration.py
@@ -2,6 +2,11 @@ from string import ascii_letters
 
 import pytest
 
+try:
+    import pandas
+except ImportError:
+    pytest.skip("Missing pandas", allow_module_level=True)
+
 from onetl.connection import Clickhouse
 from onetl.db import DBReader
 from tests.util.rand import rand_str
@@ -300,3 +305,68 @@ def test_clickhouse_reader_snapshot_with_columns_and_where(spark, processing, lo
     count_df = reader2.run()
 
     assert count_df.collect()[0][0] == table_df.count()
+
+
+def test_clickhouse_reader_snapshot_nothing_to_read(spark, processing, prepare_schema_table):
+    clickhouse = Clickhouse(
+        host=processing.host,
+        port=processing.port,
+        user=processing.user,
+        password=processing.password,
+        database=processing.database,
+        spark=spark,
+    )
+
+    reader = DBReader(
+        connection=clickhouse,
+        source=prepare_schema_table.full_name,
+    )
+
+    span_gap = 10
+    span_length = 50
+
+    # there are 2 spans with a gap between
+
+    # 0..50
+    first_span_begin = 0
+    first_span_end = first_span_begin + span_length
+
+    # 60..110
+    second_span_begin = first_span_end + span_gap
+    second_span_end = second_span_begin + span_length
+
+    first_span = processing.create_pandas_df(min_id=first_span_begin, max_id=first_span_end)
+    second_span = processing.create_pandas_df(min_id=second_span_begin, max_id=second_span_end)
+
+    # no data yet, nothing to read
+    df = reader.run()
+    assert not df.count()
+
+    # insert first span
+    processing.insert_data(
+        schema=prepare_schema_table.schema,
+        table=prepare_schema_table.table,
+        values=first_span,
+    )
+
+    # .run() is not called, but dataframes are lazy, so it now contains all data from the source
+    processing.assert_equal_df(df=df, other_frame=first_span, order_by="id_int")
+
+    # read data explicitly
+    df = reader.run()
+    processing.assert_equal_df(df=df, other_frame=first_span, order_by="id_int")
+
+    # insert second span
+    processing.insert_data(
+        schema=prepare_schema_table.schema,
+        table=prepare_schema_table.table,
+        values=second_span,
+    )
+    total_span = pandas.concat([first_span, second_span], ignore_index=True)
+
+    # .run() is not called, but dataframes are lazy, so it now contains all data from the source
+    processing.assert_equal_df(df=df, other_frame=total_span, order_by="id_int")
+
+    # read data explicitly
+    df = reader.run()
+    processing.assert_equal_df(df=df, other_frame=total_span, order_by="id_int")

--- a/tests/tests_integration/tests_core_integration/tests_db_reader_integration/test_greenplum_reader_integration.py
+++ b/tests/tests_integration/tests_core_integration/tests_db_reader_integration/test_greenplum_reader_integration.py
@@ -2,6 +2,11 @@ from string import ascii_letters
 
 import pytest
 
+try:
+    import pandas
+except ImportError:
+    pytest.skip("Missing pandas", allow_module_level=True)
+
 from onetl.connection import Greenplum
 from onetl.db import DBReader
 from tests.util.rand import rand_str
@@ -241,3 +246,69 @@ def test_greenplum_reader_snapshot_with_columns_and_where(spark, processing, loa
     count_df = reader2.run()
 
     assert count_df.collect()[0][0] == table_df.count()
+
+
+def test_greenplum_reader_snapshot_nothing_to_read(spark, processing, prepare_schema_table):
+    greenplum = Greenplum(
+        host=processing.host,
+        port=processing.port,
+        user=processing.user,
+        password=processing.password,
+        database=processing.database,
+        spark=spark,
+        extra=processing.extra,
+    )
+
+    reader = DBReader(
+        connection=greenplum,
+        source=prepare_schema_table.full_name,
+    )
+
+    span_gap = 10
+    span_length = 50
+
+    # there are 2 spans with a gap between
+
+    # 0..50
+    first_span_begin = 0
+    first_span_end = first_span_begin + span_length
+
+    # 60..110
+    second_span_begin = first_span_end + span_gap
+    second_span_end = second_span_begin + span_length
+
+    first_span = processing.create_pandas_df(min_id=first_span_begin, max_id=first_span_end)
+    second_span = processing.create_pandas_df(min_id=second_span_begin, max_id=second_span_end)
+
+    # no data yet, nothing to read
+    df = reader.run()
+    assert not df.count()
+
+    # insert first span
+    processing.insert_data(
+        schema=prepare_schema_table.schema,
+        table=prepare_schema_table.table,
+        values=first_span,
+    )
+
+    # .run() is not called, but dataframes are lazy, so it now contains all data from the source
+    processing.assert_equal_df(df=df, other_frame=first_span, order_by="id_int")
+
+    # read data explicitly
+    df = reader.run()
+    processing.assert_equal_df(df=df, other_frame=first_span, order_by="id_int")
+
+    # insert second span
+    processing.insert_data(
+        schema=prepare_schema_table.schema,
+        table=prepare_schema_table.table,
+        values=second_span,
+    )
+    total_span = pandas.concat([first_span, second_span], ignore_index=True)
+
+    # .run() is not called, but dataframes are lazy, so it now contains all data from the source
+    processing.assert_equal_df(df=df, other_frame=total_span, order_by="id_int")
+
+    # read data explicitly
+    df = reader.run()
+    processing.assert_equal_df(df=df, other_frame=total_span, order_by="id_int")

--- a/tests/tests_integration/tests_core_integration/tests_db_reader_integration/test_hive_reader_integration.py
+++ b/tests/tests_integration/tests_core_integration/tests_db_reader_integration/test_hive_reader_integration.py
@@ -1,5 +1,10 @@
 import pytest
 
+try:
+    import pandas
+except ImportError:
+    pytest.skip("Missing pandas", allow_module_level=True)
+
 from onetl.connection import Hive
 from onetl.db import DBReader
 from tests.util.rand import rand_str
@@ -190,3 +195,60 @@ def test_hive_reader_non_existing_table(spark, get_schema_table):
     with pytest.raises(AnalysisException) as excinfo:
         reader.run()
         assert "does not exists" in str(excinfo.value)
+
+
+def test_hive_reader_snapshot_nothing_to_read(spark, processing, prepare_schema_table):
+    hive = Hive(cluster="rnd-dwh", spark=spark)
+    reader = DBReader(
+        connection=hive,
+        source=prepare_schema_table.full_name,
+    )
+
+    span_gap = 10
+    span_length = 50
+
+    # there are 2 spans with a gap between
+
+    # 0..50
+    first_span_begin = 0
+    first_span_end = first_span_begin + span_length
+
+    # 60..110
+    second_span_begin = first_span_end + span_gap
+    second_span_end = second_span_begin + span_length
+
+    first_span = processing.create_pandas_df(min_id=first_span_begin, max_id=first_span_end)
+    second_span = processing.create_pandas_df(min_id=second_span_begin, max_id=second_span_end)
+
+    # no data yet, nothing to read
+    df = reader.run()
+    assert not df.count()
+
+    # insert first span
+    processing.insert_data(
+        schema=prepare_schema_table.schema,
+        table=prepare_schema_table.table,
+        values=first_span,
+    )
+
+    # .run() is not called, but dataframes are lazy, so it now contains all data from the source
+    processing.assert_equal_df(df=df, other_frame=first_span, order_by="id_int")
+
+    # read data explicitly
+    df = reader.run()
+    processing.assert_equal_df(df=df, other_frame=first_span, order_by="id_int")
+
+    # insert second span
+    processing.insert_data(
+        schema=prepare_schema_table.schema,
+        table=prepare_schema_table.table,
+        values=second_span,
+    )
+    total_span = pandas.concat([first_span, second_span], ignore_index=True)
+
+    # .run() is not called, but dataframes are lazy, so it now contains all data from the source
+    processing.assert_equal_df(df=df, other_frame=total_span, order_by="id_int")
+
+    # read data explicitly
+    df = reader.run()
+    processing.assert_equal_df(df=df, other_frame=total_span, order_by="id_int")

--- a/tests/tests_integration/tests_core_integration/tests_db_reader_integration/test_kafka_reader_integration.py
+++ b/tests/tests_integration/tests_core_integration/tests_db_reader_integration/test_kafka_reader_integration.py
@@ -3,6 +3,11 @@ import secrets
 
 import pytest
 
+try:
+    import pandas
+except ImportError:
+    pytest.skip("Missing pandas", allow_module_level=True)
+
 from onetl._util.spark import get_spark_version
 from onetl.connection import Kafka
 from onetl.db import DBReader

--- a/tests/tests_integration/tests_core_integration/tests_db_reader_integration/test_mongodb_reader_integration.py
+++ b/tests/tests_integration/tests_core_integration/tests_db_reader_integration/test_mongodb_reader_integration.py
@@ -1,5 +1,10 @@
 import pytest
 
+try:
+    import pandas
+except ImportError:
+    pytest.skip("Missing pandas", allow_module_level=True)
+
 from onetl.connection import MongoDB
 from onetl.db import DBReader
 
@@ -121,3 +126,69 @@ def test_mongodb_reader_snapshot_with_where(spark, processing, load_table_data, 
     empty_df = empty_reader.run()
 
     assert not empty_df.count()
+
+
+def test_mongodb_reader_snapshot_nothing_to_read(spark, processing, prepare_schema_table, df_schema):
+    mongo = MongoDB(
+        host=processing.host,
+        port=processing.port,
+        user=processing.user,
+        password=processing.password,
+        database=processing.database,
+        spark=spark,
+    )
+
+    reader = DBReader(
+        connection=mongo,
+        source=prepare_schema_table.table,
+        df_schema=df_schema,
+    )
+
+    span_gap = 10
+    span_length = 50
+
+    # there are 2 spans with a gap between
+
+    # 0..50
+    first_span_begin = 0
+    first_span_end = first_span_begin + span_length
+
+    # 60..110
+    second_span_begin = first_span_end + span_gap
+    second_span_end = second_span_begin + span_length
+
+    first_span = processing.create_pandas_df(min_id=first_span_begin, max_id=first_span_end)
+    second_span = processing.create_pandas_df(min_id=second_span_begin, max_id=second_span_end)
+
+    # no data yet, nothing to read
+    df = reader.run()
+    assert not df.count()
+
+    # insert first span
+    processing.insert_data(
+        schema=prepare_schema_table.schema,
+        table=prepare_schema_table.table,
+        values=first_span,
+    )
+
+    # .run() is not called, but dataframes are lazy, so it now contains all data from the source
+    processing.assert_equal_df(df=df, other_frame=first_span, order_by="_id")
+
+    # read data explicitly
+    df = reader.run()
+    processing.assert_equal_df(df=df, other_frame=first_span, order_by="_id")
+
+    # insert second span
+    processing.insert_data(
+        schema=prepare_schema_table.schema,
+        table=prepare_schema_table.table,
+        values=second_span,
+    )
+    total_span = pandas.concat([first_span, second_span], ignore_index=True)
+
+    # .run() is not called, but dataframes are lazy, so it now contains all data from the source
+    processing.assert_equal_df(df=df, other_frame=total_span, order_by="_id")
+
+    # read data explicitly
+    df = reader.run()
+    processing.assert_equal_df(df=df, other_frame=total_span, order_by="_id")

--- a/tests/tests_integration/tests_core_integration/tests_db_reader_integration/test_mssql_reader_integration.py
+++ b/tests/tests_integration/tests_core_integration/tests_db_reader_integration/test_mssql_reader_integration.py
@@ -2,6 +2,11 @@ from string import ascii_letters
 
 import pytest
 
+try:
+    import pandas
+except ImportError:
+    pytest.skip("Missing pandas", allow_module_level=True)
+
 from onetl.connection import MSSQL
 from onetl.db import DBReader
 from tests.util.rand import rand_str
@@ -276,3 +281,69 @@ def test_mssql_reader_snapshot_with_columns_and_where(spark, processing, load_ta
     count_df = reader2.run()
 
     assert count_df.collect()[0][0] == table_df.count()
+
+
+def test_mssql_reader_snapshot_nothing_to_read(spark, processing, prepare_schema_table):
+    mssql = MSSQL(
+        host=processing.host,
+        port=processing.port,
+        user=processing.user,
+        password=processing.password,
+        database=processing.database,
+        spark=spark,
+        extra={"trustServerCertificate": "true"},
+    )
+
+    reader = DBReader(
+        connection=mssql,
+        source=prepare_schema_table.full_name,
+    )
+
+    span_gap = 10
+    span_length = 50
+
+    # there are 2 spans with a gap between
+
+    # 0..50
+    first_span_begin = 0
+    first_span_end = first_span_begin + span_length
+
+    # 60..110
+    second_span_begin = first_span_end + span_gap
+    second_span_end = second_span_begin + span_length
+
+    first_span = processing.create_pandas_df(min_id=first_span_begin, max_id=first_span_end)
+    second_span = processing.create_pandas_df(min_id=second_span_begin, max_id=second_span_end)
+
+    # no data yet, nothing to read
+    df = reader.run()
+    assert not df.count()
+
+    # insert first span
+    processing.insert_data(
+        schema=prepare_schema_table.schema,
+        table=prepare_schema_table.table,
+        values=first_span,
+    )
+
+    # .run() is not called, but dataframes are lazy, so it now contains all data from the source
+    processing.assert_equal_df(df=df, other_frame=first_span, order_by="id_int")
+
+    # read data explicitly
+    df = reader.run()
+    processing.assert_equal_df(df=df, other_frame=first_span, order_by="id_int")
+
+    # insert second span
+    processing.insert_data(
+        schema=prepare_schema_table.schema,
+        table=prepare_schema_table.table,
+        values=second_span,
+    )
+    total_span = pandas.concat([first_span, second_span], ignore_index=True)
+
+    # .run() is not called, but dataframes are lazy, so it now contains all data from the source
+    processing.assert_equal_df(df=df, other_frame=total_span, order_by="id_int")
+
+    # read data explicitly
+    df = reader.run()
+    processing.assert_equal_df(df=df, other_frame=total_span, order_by="id_int")

--- a/tests/tests_integration/tests_core_integration/tests_db_reader_integration/test_oracle_reader_integration.py
+++ b/tests/tests_integration/tests_core_integration/tests_db_reader_integration/test_oracle_reader_integration.py
@@ -2,6 +2,11 @@ from string import ascii_letters
 
 import pytest
 
+try:
+    import pandas
+except ImportError:
+    pytest.skip("Missing pandas", allow_module_level=True)
+
 from onetl.connection import Oracle
 from onetl.db import DBReader
 from tests.util.rand import rand_str
@@ -276,3 +281,69 @@ def test_oracle_reader_snapshot_with_columns_and_where(spark, processing, load_t
     count_df = reader2.run()
 
     assert count_df.collect()[0][0] == table_df.count()
+
+
+def test_oracle_reader_snapshot_nothing_to_read(spark, processing, prepare_schema_table):
+    oracle = Oracle(
+        host=processing.host,
+        port=processing.port,
+        user=processing.user,
+        password=processing.password,
+        spark=spark,
+        sid=processing.sid,
+        service_name=processing.service_name,
+    )
+
+    reader = DBReader(
+        connection=oracle,
+        source=prepare_schema_table.full_name,
+    )
+
+    span_gap = 10
+    span_length = 50
+
+    # there are 2 spans with a gap between
+
+    # 0..50
+    first_span_begin = 0
+    first_span_end = first_span_begin + span_length
+
+    # 60..110
+    second_span_begin = first_span_end + span_gap
+    second_span_end = second_span_begin + span_length
+
+    first_span = processing.create_pandas_df(min_id=first_span_begin, max_id=first_span_end)
+    second_span = processing.create_pandas_df(min_id=second_span_begin, max_id=second_span_end)
+
+    # no data yet, nothing to read
+    df = reader.run()
+    assert not df.count()
+
+    # insert first span
+    processing.insert_data(
+        schema=prepare_schema_table.schema,
+        table=prepare_schema_table.table,
+        values=first_span,
+    )
+
+    # .run() is not called, but dataframes are lazy, so it now contains all data from the source
+    processing.assert_equal_df(df=df, other_frame=first_span, order_by="id_int")
+
+    # read data explicitly
+    df = reader.run()
+    processing.assert_equal_df(df=df, other_frame=first_span, order_by="id_int")
+
+    # insert second span
+    processing.insert_data(
+        schema=prepare_schema_table.schema,
+        table=prepare_schema_table.table,
+        values=second_span,
+    )
+    total_span = pandas.concat([first_span, second_span], ignore_index=True)
+
+    # .run() is not called, but dataframes are lazy, so it now contains all data from the source
+    processing.assert_equal_df(df=df, other_frame=total_span, order_by="id_int")
+
+    # read data explicitly
+    df = reader.run()
+    processing.assert_equal_df(df=df, other_frame=total_span, order_by="id_int")

--- a/tests/tests_integration/tests_core_integration/tests_db_reader_integration/test_postgres_reader_integration.py
+++ b/tests/tests_integration/tests_core_integration/tests_db_reader_integration/test_postgres_reader_integration.py
@@ -2,6 +2,11 @@ from string import ascii_letters
 
 import pytest
 
+try:
+    import pandas
+except ImportError:
+    pytest.skip("Missing pandas", allow_module_level=True)
+
 from onetl.connection import Postgres
 from onetl.db import DBReader
 from tests.util.rand import rand_str
@@ -339,3 +344,68 @@ def test_postgres_reader_different_options(spark, processing, load_table_data, o
         df=table_df,
         order_by="id_int",
     )
+
+
+def test_postgres_reader_snapshot_nothing_to_read(spark, processing, prepare_schema_table):
+    postgres = Postgres(
+        host=processing.host,
+        port=processing.port,
+        user=processing.user,
+        password=processing.password,
+        database=processing.database,
+        spark=spark,
+    )
+
+    reader = DBReader(
+        connection=postgres,
+        source=prepare_schema_table.full_name,
+    )
+
+    span_gap = 10
+    span_length = 50
+
+    # there are 2 spans with a gap between
+
+    # 0..50
+    first_span_begin = 0
+    first_span_end = first_span_begin + span_length
+
+    # 60..110
+    second_span_begin = first_span_end + span_gap
+    second_span_end = second_span_begin + span_length
+
+    first_span = processing.create_pandas_df(min_id=first_span_begin, max_id=first_span_end)
+    second_span = processing.create_pandas_df(min_id=second_span_begin, max_id=second_span_end)
+
+    # no data yet, nothing to read
+    df = reader.run()
+    assert not df.count()
+
+    # insert first span
+    processing.insert_data(
+        schema=prepare_schema_table.schema,
+        table=prepare_schema_table.table,
+        values=first_span,
+    )
+
+    # .run() is not called, but dataframes are lazy, so it now contains all data from the source
+    processing.assert_equal_df(df=df, other_frame=first_span, order_by="id_int")
+
+    # read data explicitly
+    df = reader.run()
+    processing.assert_equal_df(df=df, other_frame=first_span, order_by="id_int")
+
+    # insert second span
+    processing.insert_data(
+        schema=prepare_schema_table.schema,
+        table=prepare_schema_table.table,
+        values=second_span,
+    )
+    total_span = pandas.concat([first_span, second_span], ignore_index=True)
+
+    # .run() is not called, but dataframes are lazy, so it now contains all data from the source
+    processing.assert_equal_df(df=df, other_frame=total_span, order_by="id_int")
+
+    # read data explicitly
+    df = reader.run()
+    processing.assert_equal_df(df=df, other_frame=total_span, order_by="id_int")

--- a/tests/tests_integration/tests_core_integration/tests_db_writer_integration/test_mongodb_writer_integration.py
+++ b/tests/tests_integration/tests_core_integration/tests_db_writer_integration/test_mongodb_writer_integration.py
@@ -50,6 +50,8 @@ def test_mongodb_writer_snapshot(spark, processing, get_schema_table, options, c
     )
 
 
+# old MongoDB versions sometimes is missing some part of data during insert
+@pytest.mark.flaky(reruns=2)
 def test_mongodb_writer_if_exists_append(spark, processing, get_schema_table):
     df = processing.create_spark_df(spark=spark, min_id=1, max_id=1500)
     df1 = df[df._id < 1001]
@@ -80,6 +82,8 @@ def test_mongodb_writer_if_exists_append(spark, processing, get_schema_table):
     )
 
 
+# old MongoDB versions sometimes is missing some part of data during insert
+@pytest.mark.flaky(reruns=2)
 def test_mongodb_writer_if_exists_replace_entire_collection(spark, processing, get_schema_table):
     df = processing.create_spark_df(spark=spark, min_id=1, max_id=1500)
     df1 = df[df._id < 1001]
@@ -110,7 +114,9 @@ def test_mongodb_writer_if_exists_replace_entire_collection(spark, processing, g
     )
 
 
-def test_mongodb_writer_if_exists_error(spark, processing, get_schema_table, caplog):
+# old MongoDB versions sometimes is missing some part of data during insert
+@pytest.mark.flaky(reruns=2)
+def test_mongodb_writer_if_exists_error(spark, processing, get_schema_table):
     df = processing.create_spark_df(spark=spark, min_id=1, max_id=1500)
 
     mongo = MongoDB(
@@ -143,6 +149,8 @@ def test_mongodb_writer_if_exists_error(spark, processing, get_schema_table, cap
     )
 
 
+# old MongoDB versions sometimes is missing some part of data during insert
+@pytest.mark.flaky(reruns=2)
 def test_mongodb_writer_if_exists_ignore(spark, processing, get_schema_table, caplog):
     df = processing.create_spark_df(spark=spark, min_id=1, max_id=1500)
     df1 = df[df._id < 1001]

--- a/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_clickhouse.py
+++ b/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_clickhouse.py
@@ -105,6 +105,102 @@ def test_clickhouse_strategy_incremental(
         processing.assert_subset_df(df=second_df, other_frame=second_span)
 
 
+def test_clickhouse_strategy_incremental_nothing_to_read(spark, processing, prepare_schema_table):
+    clickhouse = Clickhouse(
+        host=processing.host,
+        port=processing.port,
+        user=processing.user,
+        password=processing.password,
+        spark=spark,
+    )
+
+    store = HWMStoreStackManager.get_current()
+    hwm_name = secrets.token_hex(5)
+    hwm_column = "hwm_int"
+
+    reader = DBReader(
+        connection=clickhouse,
+        source=prepare_schema_table.full_name,
+        hwm=DBReader.AutoDetectHWM(name=hwm_name, expression=hwm_column),
+    )
+
+    span_gap = 10
+    span_length = 50
+
+    # there are 2 spans with a gap between
+
+    # 0..50
+    first_span_begin = 0
+    first_span_end = first_span_begin + span_length
+
+    # 60..110
+    second_span_begin = first_span_end + span_gap
+    second_span_end = second_span_begin + span_length
+
+    first_span = processing.create_pandas_df(min_id=first_span_begin, max_id=first_span_end)
+    second_span = processing.create_pandas_df(min_id=second_span_begin, max_id=second_span_end)
+
+    first_span_max = first_span[hwm_column].max()
+    second_span_max = second_span[hwm_column].max()
+
+    # no data yet, nothing to read
+    with IncrementalStrategy():
+        df = reader.run()
+
+    assert not df.count()
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value is None
+
+    # insert first span
+    processing.insert_data(
+        schema=prepare_schema_table.schema,
+        table=prepare_schema_table.table,
+        values=first_span,
+    )
+
+    # .run() is not called - dataframe still empty - HWM not updated
+    assert not df.count()
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value is None
+
+    # set hwm value to 50
+    with IncrementalStrategy():
+        df = reader.run()
+
+    processing.assert_equal_df(df=df, other_frame=first_span, order_by="id_int")
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value == first_span_max
+
+    # no new data yet, nothing to read
+    with IncrementalStrategy():
+        df = reader.run()
+
+    assert not df.count()
+    # HWM value is unchanged
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value == first_span_max
+
+    # insert second span
+    processing.insert_data(
+        schema=prepare_schema_table.schema,
+        table=prepare_schema_table.table,
+        values=second_span,
+    )
+
+    # .run() is not called - dataframe still empty - HWM not updated
+    assert not df.count()
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value == first_span_max
+
+    # read data
+    with IncrementalStrategy():
+        df = reader.run()
+
+    processing.assert_equal_df(df=df, other_frame=second_span, order_by="id_int")
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value == second_span_max
+
+
 @pytest.mark.flaky(
     # sometimes test fails with vague error on Spark side, e.g. `An error occurred while calling o58.version`
     only_rerun="py4j.protocol.Py4JError",

--- a/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_hive.py
+++ b/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_hive.py
@@ -102,6 +102,96 @@ def test_hive_strategy_incremental(
         processing.assert_subset_df(df=second_df, other_frame=second_span)
 
 
+def test_hive_strategy_incremental_nothing_to_read(spark, processing, prepare_schema_table):
+    hive = Hive(cluster="rnd-dwh", spark=spark)
+
+    store = HWMStoreStackManager.get_current()
+    hwm_name = secrets.token_hex(5)
+    hwm_column = "hwm_int"
+
+    reader = DBReader(
+        connection=hive,
+        source=prepare_schema_table.full_name,
+        hwm=DBReader.AutoDetectHWM(name=hwm_name, expression=hwm_column),
+    )
+
+    span_gap = 10
+    span_length = 50
+
+    # there are 2 spans with a gap between
+
+    # 0..50
+    first_span_begin = 0
+    first_span_end = first_span_begin + span_length
+
+    # 60..110
+    second_span_begin = first_span_end + span_gap
+    second_span_end = second_span_begin + span_length
+
+    first_span = processing.create_pandas_df(min_id=first_span_begin, max_id=first_span_end)
+    second_span = processing.create_pandas_df(min_id=second_span_begin, max_id=second_span_end)
+
+    first_span_max = first_span[hwm_column].max()
+    second_span_max = second_span[hwm_column].max()
+
+    # no data yet, nothing to read
+    with IncrementalStrategy():
+        df = reader.run()
+
+    assert not df.count()
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value is None
+
+    # insert first span
+    processing.insert_data(
+        schema=prepare_schema_table.schema,
+        table=prepare_schema_table.table,
+        values=first_span,
+    )
+
+    # .run() is not called - dataframe still empty - HWM not updated
+    assert not df.count()
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value is None
+
+    # set hwm value to 50
+    with IncrementalStrategy():
+        df = reader.run()
+
+    processing.assert_equal_df(df=df, other_frame=first_span, order_by="id_int")
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value == first_span_max
+
+    # no new data yet, nothing to read
+    with IncrementalStrategy():
+        df = reader.run()
+
+    assert not df.count()
+    # HWM value is unchanged
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value == first_span_max
+
+    # insert second span
+    processing.insert_data(
+        schema=prepare_schema_table.schema,
+        table=prepare_schema_table.table,
+        values=second_span,
+    )
+
+    # .run() is not called - dataframe still empty - HWM not updated
+    assert not df.count()
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value == first_span_max
+
+    # read data
+    with IncrementalStrategy():
+        df = reader.run()
+
+    processing.assert_equal_df(df=df, other_frame=second_span, order_by="id_int")
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value == second_span_max
+
+
 # Fail if HWM is Numeric, or Decimal with fractional part, or string
 @pytest.mark.parametrize(
     "hwm_column, exception_type, error_message",

--- a/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_mongodb.py
+++ b/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_mongodb.py
@@ -134,6 +134,109 @@ def test_mongodb_strategy_incremental(
         processing.assert_subset_df(df=second_df, other_frame=second_span)
 
 
+def test_mongodb_strategy_incremental_nothing_to_read(
+    spark,
+    processing,
+    df_schema,
+    prepare_schema_table,
+):
+    mongodb = MongoDB(
+        host=processing.host,
+        port=processing.port,
+        user=processing.user,
+        password=processing.password,
+        database=processing.database,
+        spark=spark,
+    )
+
+    store = HWMStoreStackManager.get_current()
+    hwm_name = secrets.token_hex(5)
+    hwm_column = "hwm_int"
+
+    reader = DBReader(
+        connection=mongodb,
+        source=prepare_schema_table.table,
+        df_schema=df_schema,
+        hwm=DBReader.AutoDetectHWM(name=hwm_name, expression=hwm_column),
+    )
+
+    span_gap = 10
+    span_length = 50
+
+    # there are 2 spans with a gap between
+
+    # 0..50
+    first_span_begin = 0
+    first_span_end = first_span_begin + span_length
+
+    # 60..110
+    second_span_begin = first_span_end + span_gap
+    second_span_end = second_span_begin + span_length
+
+    first_span = processing.create_pandas_df(min_id=first_span_begin, max_id=first_span_end)
+    second_span = processing.create_pandas_df(min_id=second_span_begin, max_id=second_span_end)
+
+    first_span_max = first_span[hwm_column].max()
+    second_span_max = second_span[hwm_column].max()
+
+    # no data yet, nothing to read
+    with IncrementalStrategy():
+        df = reader.run()
+
+    assert not df.count()
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value is None
+
+    # insert first span
+    processing.insert_data(
+        schema=prepare_schema_table.schema,
+        table=prepare_schema_table.table,
+        values=first_span,
+    )
+
+    # .run() is not called - dataframe still empty - HWM not updated
+    assert not df.count()
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value is None
+
+    # set hwm value to 50
+    with IncrementalStrategy():
+        df = reader.run()
+
+    processing.assert_equal_df(df=df, other_frame=first_span, order_by="_id")
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value == first_span_max
+
+    # no new data yet, nothing to read
+    with IncrementalStrategy():
+        df = reader.run()
+
+    assert not df.count()
+    # HWM value is unchanged
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value == first_span_max
+
+    # insert second span
+    processing.insert_data(
+        schema=prepare_schema_table.schema,
+        table=prepare_schema_table.table,
+        values=second_span,
+    )
+
+    # .run() is not called - dataframe still empty - HWM not updated
+    assert not df.count()
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value == first_span_max
+
+    # read data
+    with IncrementalStrategy():
+        df = reader.run()
+
+    processing.assert_equal_df(df=df, other_frame=second_span, order_by="_id")
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value == second_span_max
+
+
 # Fail if HWM is Numeric, or Decimal with fractional part, or string
 @pytest.mark.parametrize(
     "hwm_column, exception_type, error_message",

--- a/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_mssql.py
+++ b/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_mssql.py
@@ -110,6 +110,104 @@ def test_mssql_strategy_incremental(
         processing.assert_subset_df(df=second_df, other_frame=second_span)
 
 
+def test_mssql_strategy_incremental_nothing_to_read(spark, processing, prepare_schema_table):
+    mssql = MSSQL(
+        host=processing.host,
+        port=processing.port,
+        user=processing.user,
+        password=processing.password,
+        database=processing.database,
+        spark=spark,
+        extra={"trustServerCertificate": "true"},
+    )
+
+    store = HWMStoreStackManager.get_current()
+    hwm_name = secrets.token_hex(5)
+    hwm_column = "hwm_int"
+
+    reader = DBReader(
+        connection=mssql,
+        source=prepare_schema_table.full_name,
+        hwm=DBReader.AutoDetectHWM(name=hwm_name, expression=hwm_column),
+    )
+
+    span_gap = 10
+    span_length = 50
+
+    # there are 2 spans with a gap between
+
+    # 0..50
+    first_span_begin = 0
+    first_span_end = first_span_begin + span_length
+
+    # 60..110
+    second_span_begin = first_span_end + span_gap
+    second_span_end = second_span_begin + span_length
+
+    first_span = processing.create_pandas_df(min_id=first_span_begin, max_id=first_span_end)
+    second_span = processing.create_pandas_df(min_id=second_span_begin, max_id=second_span_end)
+
+    first_span_max = first_span[hwm_column].max()
+    second_span_max = second_span[hwm_column].max()
+
+    # no data yet, nothing to read
+    with IncrementalStrategy():
+        df = reader.run()
+
+    assert not df.count()
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value is None
+
+    # insert first span
+    processing.insert_data(
+        schema=prepare_schema_table.schema,
+        table=prepare_schema_table.table,
+        values=first_span,
+    )
+
+    # .run() is not called - dataframe still empty - HWM not updated
+    assert not df.count()
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value is None
+
+    # set hwm value to 50
+    with IncrementalStrategy():
+        df = reader.run()
+
+    processing.assert_equal_df(df=df, other_frame=first_span, order_by="id_int")
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value == first_span_max
+
+    # no new data yet, nothing to read
+    with IncrementalStrategy():
+        df = reader.run()
+
+    assert not df.count()
+    # HWM value is unchanged
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value == first_span_max
+
+    # insert second span
+    processing.insert_data(
+        schema=prepare_schema_table.schema,
+        table=prepare_schema_table.table,
+        values=second_span,
+    )
+
+    # .run() is not called - dataframe still empty - HWM not updated
+    assert not df.count()
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value == first_span_max
+
+    # read data
+    with IncrementalStrategy():
+        df = reader.run()
+
+    processing.assert_equal_df(df=df, other_frame=second_span, order_by="id_int")
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value == second_span_max
+
+
 # Fail if HWM is Numeric, or Decimal with fractional part, or string
 @pytest.mark.parametrize(
     "hwm_column, exception_type, error_message",

--- a/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_mysql.py
+++ b/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_mysql.py
@@ -109,6 +109,103 @@ def test_mysql_strategy_incremental(
         processing.assert_subset_df(df=second_df, other_frame=second_span)
 
 
+def test_mysql_strategy_incremental_nothing_to_read(spark, processing, prepare_schema_table):
+    mysql = MySQL(
+        host=processing.host,
+        port=processing.port,
+        user=processing.user,
+        password=processing.password,
+        database=processing.database,
+        spark=spark,
+    )
+
+    store = HWMStoreStackManager.get_current()
+    hwm_name = secrets.token_hex(5)
+    hwm_column = "hwm_int"
+
+    reader = DBReader(
+        connection=mysql,
+        source=prepare_schema_table.full_name,
+        hwm=DBReader.AutoDetectHWM(name=hwm_name, expression=hwm_column),
+    )
+
+    span_gap = 10
+    span_length = 50
+
+    # there are 2 spans with a gap between
+
+    # 0..50
+    first_span_begin = 0
+    first_span_end = first_span_begin + span_length
+
+    # 60..110
+    second_span_begin = first_span_end + span_gap
+    second_span_end = second_span_begin + span_length
+
+    first_span = processing.create_pandas_df(min_id=first_span_begin, max_id=first_span_end)
+    second_span = processing.create_pandas_df(min_id=second_span_begin, max_id=second_span_end)
+
+    first_span_max = first_span[hwm_column].max()
+    second_span_max = second_span[hwm_column].max()
+
+    # no data yet, nothing to read
+    with IncrementalStrategy():
+        df = reader.run()
+
+    assert not df.count()
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value is None
+
+    # insert first span
+    processing.insert_data(
+        schema=prepare_schema_table.schema,
+        table=prepare_schema_table.table,
+        values=first_span,
+    )
+
+    # .run() is not called - dataframe still empty - HWM not updated
+    assert not df.count()
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value is None
+
+    # set hwm value to 50
+    with IncrementalStrategy():
+        df = reader.run()
+
+    processing.assert_equal_df(df=df, other_frame=first_span, order_by="id_int")
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value == first_span_max
+
+    # no new data yet, nothing to read
+    with IncrementalStrategy():
+        df = reader.run()
+
+    assert not df.count()
+    # HWM value is unchanged
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value == first_span_max
+
+    # insert second span
+    processing.insert_data(
+        schema=prepare_schema_table.schema,
+        table=prepare_schema_table.table,
+        values=second_span,
+    )
+
+    # .run() is not called - dataframe still empty - HWM not updated
+    assert not df.count()
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value == first_span_max
+
+    # read data
+    with IncrementalStrategy():
+        df = reader.run()
+
+    processing.assert_equal_df(df=df, other_frame=second_span, order_by="id_int")
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value == second_span_max
+
+
 # Fail if HWM is Numeric, or Decimal with fractional part, or string
 @pytest.mark.parametrize(
     "hwm_column, exception_type, error_message",

--- a/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_oracle.py
+++ b/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_oracle.py
@@ -123,6 +123,104 @@ def test_oracle_strategy_incremental(
         processing.assert_subset_df(df=second_df, other_frame=second_span)
 
 
+def test_oracle_strategy_incremental_nothing_to_read(spark, processing, prepare_schema_table):
+    oracle = Oracle(
+        host=processing.host,
+        port=processing.port,
+        user=processing.user,
+        password=processing.password,
+        sid=processing.sid,
+        service_name=processing.service_name,
+        spark=spark,
+    )
+
+    store = HWMStoreStackManager.get_current()
+    hwm_name = secrets.token_hex(5)
+    hwm_column = "HWM_INT"
+
+    reader = DBReader(
+        connection=oracle,
+        source=prepare_schema_table.full_name,
+        hwm=DBReader.AutoDetectHWM(name=hwm_name, expression=hwm_column),
+    )
+
+    span_gap = 10
+    span_length = 50
+
+    # there are 2 spans with a gap between
+
+    # 0..50
+    first_span_begin = 0
+    first_span_end = first_span_begin + span_length
+
+    # 60..110
+    second_span_begin = first_span_end + span_gap
+    second_span_end = second_span_begin + span_length
+
+    first_span = processing.create_pandas_df(min_id=first_span_begin, max_id=first_span_end)
+    second_span = processing.create_pandas_df(min_id=second_span_begin, max_id=second_span_end)
+
+    first_span_max = first_span["hwm_int"].max()
+    second_span_max = second_span["hwm_int"].max()
+
+    # no data yet, nothing to read
+    with IncrementalStrategy():
+        df = reader.run()
+
+    assert not df.count()
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value is None
+
+    # insert first span
+    processing.insert_data(
+        schema=prepare_schema_table.schema,
+        table=prepare_schema_table.table,
+        values=first_span,
+    )
+
+    # .run() is not called - dataframe still empty - HWM not updated
+    assert not df.count()
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value is None
+
+    # set hwm value to 50
+    with IncrementalStrategy():
+        df = reader.run()
+
+    processing.assert_equal_df(df=df, other_frame=first_span, order_by="id_int")
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value == first_span_max
+
+    # no new data yet, nothing to read
+    with IncrementalStrategy():
+        df = reader.run()
+
+    assert not df.count()
+    # HWM value is unchanged
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value == first_span_max
+
+    # insert second span
+    processing.insert_data(
+        schema=prepare_schema_table.schema,
+        table=prepare_schema_table.table,
+        values=second_span,
+    )
+
+    # .run() is not called - dataframe still empty - HWM not updated
+    assert not df.count()
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value == first_span_max
+
+    # read data
+    with IncrementalStrategy():
+        df = reader.run()
+
+    processing.assert_equal_df(df=df, other_frame=second_span, order_by="id_int")
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value == second_span_max
+
+
 # Fail if HWM is Numeric, or Decimal with fractional part, or string
 @pytest.mark.parametrize(
     "hwm_column, exception_type, error_message",

--- a/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_postgres.py
+++ b/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_postgres.py
@@ -211,6 +211,103 @@ def test_postgres_strategy_incremental_with_hwm_expr(
         processing.assert_subset_df(df=second_df, other_frame=second_span)
 
 
+def test_postgres_strategy_incremental_nothing_to_read(spark, processing, prepare_schema_table):
+    postgres = Postgres(
+        host=processing.host,
+        port=processing.port,
+        user=processing.user,
+        password=processing.password,
+        database=processing.database,
+        spark=spark,
+    )
+
+    store = HWMStoreStackManager.get_current()
+    hwm_name = secrets.token_hex(5)
+    hwm_column = "hwm_int"
+
+    reader = DBReader(
+        connection=postgres,
+        source=prepare_schema_table.full_name,
+        hwm=DBReader.AutoDetectHWM(name=hwm_name, expression=hwm_column),
+    )
+
+    span_gap = 10
+    span_length = 50
+
+    # there are 2 spans with a gap between
+
+    # 0..50
+    first_span_begin = 0
+    first_span_end = first_span_begin + span_length
+
+    # 60..110
+    second_span_begin = first_span_end + span_gap
+    second_span_end = second_span_begin + span_length
+
+    first_span = processing.create_pandas_df(min_id=first_span_begin, max_id=first_span_end)
+    second_span = processing.create_pandas_df(min_id=second_span_begin, max_id=second_span_end)
+
+    first_span_max = first_span[hwm_column].max()
+    second_span_max = second_span[hwm_column].max()
+
+    # no data yet, nothing to read
+    with IncrementalStrategy():
+        df = reader.run()
+
+    assert not df.count()
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value is None
+
+    # insert first span
+    processing.insert_data(
+        schema=prepare_schema_table.schema,
+        table=prepare_schema_table.table,
+        values=first_span,
+    )
+
+    # .run() is not called - dataframe still empty - HWM not updated
+    assert not df.count()
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value is None
+
+    # set hwm value to 50
+    with IncrementalStrategy():
+        df = reader.run()
+
+    processing.assert_equal_df(df=df, other_frame=first_span, order_by="id_int")
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value == first_span_max
+
+    # no new data yet, nothing to read
+    with IncrementalStrategy():
+        df = reader.run()
+
+    assert not df.count()
+    # HWM value is unchanged
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value == first_span_max
+
+    # insert second span
+    processing.insert_data(
+        schema=prepare_schema_table.schema,
+        table=prepare_schema_table.table,
+        values=second_span,
+    )
+
+    # .run() is not called - dataframe still empty - HWM not updated
+    assert not df.count()
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value == first_span_max
+
+    # read data
+    with IncrementalStrategy():
+        df = reader.run()
+
+    processing.assert_equal_df(df=df, other_frame=second_span, order_by="id_int")
+    hwm = store.get_hwm(name=hwm_name)
+    assert hwm.value == second_span_max
+
+
 # Fail if HWM is Numeric, or Decimal with fractional part, or string
 @pytest.mark.parametrize(
     "hwm_column, exception_type, error_message",

--- a/tests/tests_unit/tests_db_connection_unit/test_dialect_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_dialect_unit.py
@@ -163,6 +163,50 @@ def test_db_dialect_get_sql_query_hint(spark_mock):
     assert result == expected
 
 
+def test_db_dialect_get_sql_query_limit(spark_mock):
+    conn = Postgres(host="some_host", user="user", database="database", password="passwd", spark=spark_mock)
+
+    result = conn.dialect.get_sql_query(
+        table="default.test",
+        limit=5,
+    )
+
+    expected = textwrap.dedent(
+        """
+        SELECT
+               *
+        FROM
+               default.test
+        LIMIT
+               5
+        """,
+    ).strip()
+
+    assert result == expected
+
+
+def test_db_dialect_get_sql_query_limit_0(spark_mock):
+    conn = Postgres(host="some_host", user="user", database="database", password="passwd", spark=spark_mock)
+
+    result = conn.dialect.get_sql_query(
+        table="default.test",
+        limit=0,
+    )
+
+    expected = textwrap.dedent(
+        """
+        SELECT
+               *
+        FROM
+               default.test
+        WHERE
+               1 = 0
+        """,
+    ).strip()
+
+    assert result == expected
+
+
 def test_db_dialect_get_sql_query_compact_false(spark_mock):
     conn = Postgres(host="some_host", user="user", database="database", password="passwd", spark=spark_mock)
 
@@ -171,6 +215,7 @@ def test_db_dialect_get_sql_query_compact_false(spark_mock):
         hint="NOWAIT",
         columns=["d_id", "d_name", "d_age"],
         where=["d_id > 100", "d_id < 200"],
+        limit=5,
         compact=False,
     )
 
@@ -186,6 +231,8 @@ def test_db_dialect_get_sql_query_compact_false(spark_mock):
                (d_id > 100)
           AND
                (d_id < 200)
+        LIMIT
+               5
         """,
     ).strip()
 
@@ -200,6 +247,7 @@ def test_db_dialect_get_sql_query_compact_true(spark_mock):
         hint="NOWAIT",
         columns=["d_id", "d_name", "d_age"],
         where=["d_id > 100", "d_id < 200"],
+        limit=5,
         compact=True,
     )
 
@@ -209,6 +257,7 @@ def test_db_dialect_get_sql_query_compact_true(spark_mock):
         FROM default.test
         WHERE (d_id > 100)
           AND (d_id < 200)
+        LIMIT 5
         """,
     ).strip()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

<!-- Please give a short summary of the changes. -->

If DBReader reads data from source (including empty source), the resulting dataframe contains all the data from the source at the moment of calling `.run()`. But some data is appended to the source after `.run()` is called, the result if different for different strategies:
1. Dataframe returned within `SnapshotStrategy` always contains all the source data. This is because no additional filters are applied to original query, and Spark dataframes are lazy.
2. Other strategies return dataframes which contains *only* data present in the source at the moment of calling `.run()`, but not data added to source after it. This is because filters based on current HWM value & strategy are baked into the query.

Added tests covering these edge cases.

Handling case `source is empty -> HWM value is None -> cannot apply filter to query -> return e empty dataframe` required adding new `limit` option to `DBConnection.read_source_as_df`. Passing `limit=0` returns dataframe which is always empty, which is implementation detail.

Also improved behavior of batch strategies - if source contains no data, instead of raising `ValueError` just stop after first iteration, and return empty dataframe.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [X] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
