### PR TITLE
[DOP-9787] Avoid race condition in FileDownloader while updating HWM

### DIFF
--- a/docs/changelog/next_release/189.breaking.rst
+++ b/docs/changelog/next_release/189.breaking.rst
@@ -1,0 +1,4 @@
+``FileDownloader.run()`` now updates HWM in HWM Store not after each file is being successfully downloaded,
+but after all files are finished. This is because:
+* FileDownloader can be used with ``DownloadOptions(workers=N)``, which could lead to race condition - one thread can reset HWM value which is updated by another thread at the same time.
+* FileDownloader can download hundreds and thousands of files, and issuing a request to HWM Store for each file could potentially DDoS HWM Store.

--- a/onetl/strategy/incremental_strategy.py
+++ b/onetl/strategy/incremental_strategy.py
@@ -135,22 +135,10 @@ class IncrementalStrategy(OffsetMixin, HWMStrategy):
 
         .. warning::
 
-            FileDownload updates HWM in HWM Store after downloading **each** file, because files are downloading
-            one after another, not in one batch.
+            FileDownload updates HWM in HWM Store at the end of ``.run()`` call,
+            **NOT** while exiting strategy context. This is because:
 
-        .. warning::
-
-            If code inside the context manager raised an exception, like:
-
-            .. code:: python
-
-                with IncrementalStrategy():
-                    download_result = downloader.run()  # something went wrong here
-                    uploader.run(download_result.success)  # or here
-                    # or here...
-
-            When FileDownloader **will** update HWM in HWM Store, because:
-
+            * FileDownloader does not raise exceptions if some file cannot be downloaded.
             * FileDownloader creates files on local filesystem, and file content may differ for different :obj:`modes <onetl.file.file_downloader.file_downloader.FileDownloader.Options.mode>`.
             * It can remove files from the source if :obj:`delete_source <onetl.file.file_downloader.file_downloader.FileDownloader.Options.delete_source>` is set to ``True``.
 

--- a/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_file.py
+++ b/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_file.py
@@ -119,7 +119,7 @@ def test_file_downloader_incremental_strategy_fail(
             assert downloaded.missing_count == 0
             assert downloaded.failed_count == 0
 
-            # HWM is saved after downloading each file, not after exiting from .run
+            # HWM is saved at the end of `FileDownloader.run()` call`, not after exiting from strategy
             source_files.add(AbsolutePath(target_file))
             assert source_files == hwm_store.get_hwm(hwm_name).value
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

<!-- Please give a short summary of the changes. -->

Using `FileDownloader` with `DownloadOptions(workers=N)` has a potential race condition because there is no thread lock on `Strategy.hwm` attribute.

Instead of adding such a lock, I've updated current implementation to update HWM only after all files were handled. This also avoid issuing too many requests to HWM Store which could potentially DDoS the service if large number of files are being downloaded.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [X] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
