### PR TITLE
[DOP-11682] Cache result of connection.check()

### DIFF
--- a/docs/changelog/next_release/190.feature.rst
+++ b/docs/changelog/next_release/190.feature.rst
@@ -1,0 +1,1 @@
+Cache result of ``connection.check()`` in high-level classes like ``DBReader``, ``FileDownloader`` and so on. This makes logs less verbose.

--- a/onetl/db/db_writer/db_writer.py
+++ b/onetl/db/db_writer/db_writer.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from logging import getLogger
 from typing import TYPE_CHECKING, Optional
 
-from pydantic import Field, validator
+from pydantic import Field, PrivateAttr, validator
 
 from onetl.base import BaseDBConnection
 from onetl.hooks import slot, support_hooks
@@ -153,6 +153,8 @@ class DBWriter(FrozenModel):
     target: str = Field(alias="table")
     options: Optional[GenericOptions] = None
 
+    _connection_checked: bool = PrivateAttr(default=False)
+
     @validator("target", pre=True, always=True)
     def validate_target(cls, target, values):
         connection: BaseDBConnection = values["connection"]
@@ -196,18 +198,21 @@ class DBWriter(FrozenModel):
         if df.isStreaming:
             raise ValueError(f"DataFrame is streaming. {self.__class__.__name__} supports only batch DataFrames.")
 
-        entity_boundary_log(log, msg="DBWriter starts")
+        entity_boundary_log(log, msg=f"{self.__class__.__name__}.run() starts")
 
-        self._log_parameters()
-        log_dataframe_schema(log, df)
-        self.connection.check()
+        if not self._connection_checked:
+            self._log_parameters()
+            log_dataframe_schema(log, df)
+            self.connection.check()
+            self._connection_checked = True
+
         self.connection.write_df_to_target(
             df=df,
             target=str(self.target),
             **self._get_write_kwargs(),
         )
 
-        entity_boundary_log(log, msg="DBWriter ends", char="-")
+        entity_boundary_log(log, msg=f"{self.__class__.__name__}.run() ends", char="-")
 
     def _log_parameters(self) -> None:
         log.info("|Spark| -> |%s| Writing DataFrame to target using parameters:", self.connection.__class__.__name__)

--- a/onetl/file/file_mover/file_mover.py
+++ b/onetl/file/file_mover/file_mover.py
@@ -21,7 +21,7 @@ from enum import Enum
 from typing import Iterable, List, Optional, Tuple
 
 from ordered_set import OrderedSet
-from pydantic import Field, validator
+from pydantic import Field, PrivateAttr, validator
 
 from onetl.base import BaseFileConnection, BaseFileFilter, BaseFileLimit
 from onetl.base.path_protocol import PathProtocol, PathWithStatsProtocol
@@ -152,6 +152,8 @@ class FileMover(FrozenModel):
 
     """
 
+    Options = FileMoverOptions
+
     connection: BaseFileConnection
 
     target_path: RemotePath
@@ -162,7 +164,7 @@ class FileMover(FrozenModel):
 
     options: FileMoverOptions = FileMoverOptions()
 
-    Options = FileMoverOptions
+    _connection_checked: bool = PrivateAttr(default=False)
 
     @slot
     def run(self, files: Iterable[str | os.PathLike] | None = None) -> MoveResult:  # noqa: WPS231
@@ -272,22 +274,25 @@ class FileMover(FrozenModel):
             assert not moved_files.missing
         """
 
+        entity_boundary_log(log, f"{self.__class__.__name__}.run() starts")
+
         if files is None and not self.source_path:
             raise ValueError("Neither file list nor `source_path` are passed")
 
-        self._log_parameters(files)
+        if not self._connection_checked:
+            self._log_parameters(files)
 
-        # Check everything
-        self.connection.check()
-        self._check_target_path()
-        log_with_indent(log, "")
+            self.connection.check()
+            self._check_target_path()
+            log_with_indent(log, "")
 
-        if self.source_path:
-            self._check_source_path()
+            if self.source_path:
+                self._check_source_path()
+
+            self._connection_checked = True
 
         if files is None:
-            log.info("|%s| File list is not passed to `run` method", self.__class__.__name__)
-
+            log.debug("|%s| File list is not passed to `run` method", self.__class__.__name__)
             files = self.view_files()
 
         if not files:
@@ -303,6 +308,7 @@ class FileMover(FrozenModel):
 
         result = self._move_files(to_move)
         self._log_result(result)
+        entity_boundary_log(log, f"{self.__class__.__name__}.run() ends", char="-")
         return result
 
     @slot
@@ -347,9 +353,14 @@ class FileMover(FrozenModel):
             }
         """
 
+        if not self.source_path:
+            raise ValueError("Cannot call `.view_files()` without `source_path`")
+
         log.debug("|%s| Getting files list from path '%s'", self.connection.__class__.__name__, self.source_path)
 
-        self._check_source_path()
+        if not self._connection_checked:
+            self._check_source_path()
+
         result = FileSet()
 
         try:
@@ -365,8 +376,6 @@ class FileMover(FrozenModel):
         return result
 
     def _log_parameters(self, files: Iterable[str | os.PathLike] | None = None) -> None:
-        entity_boundary_log(log, msg="FileMover starts")
-
         connection_class = self.connection.__class__.__name__
         log.info("|%s| -> |%s| Moving files using parameters:", connection_class, connection_class)
         log_with_indent(log, "source_path = %s", f"'{self.source_path}'" if self.source_path else "None")
@@ -566,4 +575,3 @@ class FileMover(FrozenModel):
         log_with_indent(log, "")
         log.info("|%s| Move result:", self.__class__.__name__)
         log_lines(log, str(result))
-        entity_boundary_log(log, msg=f"{self.__class__.__name__} ends", char="-")

--- a/onetl/strategy/incremental_strategy.py
+++ b/onetl/strategy/incremental_strategy.py
@@ -638,9 +638,8 @@ class IncrementalBatchStrategy(OffsetMixin, BatchHWMStrategy):
     """
 
     def __next__(self):
-        result = super().__next__()
         self.save_hwm()
-        return result
+        return super().__next__()
 
     @classmethod
     def _log_exclude_fields(cls) -> set[str]:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

<!-- Please give a short summary of the changes. -->

`connection.check()` is being called only once inside `.run()` method of DBReader/FileDownloader/... object, to avoid printing same connection detauls into logs again and again.

Before:
```log
|onETL| Using IncrementalBatchStrategy as a strategy
        step = 10
|IncrementalBatchStrategy| First iteration
=================================== DBReader.run() starts ===================================
|DBReader| Getting Spark type for HWM expression: 'hwm_int'
|Postgres| Fetching schema of table 'onetl.test_b47b282cf4' ...
|Postgres| Schema fetched.
|DBReader| Got Spark field: StructField('hwm_int', LongType(), True)
|DBReader| Detected HWM type: 'ColumnIntHWM'
|IncrementalBatchStrategy| Fetching HWM from MemoryHWMStore:
        name = 'd5930cc53b'
|IncrementalBatchStrategy| Fetched HWM:
        hwm = ColumnIntHWM(
            name = 'd5930cc53b',
            entity = 'onetl.test_b47b282cf4',
            expression = 'hwm_int',
        )
|Postgres| -> |Spark| Reading DataFrame from source using parameters:
        source = 'onetl.test_b47b282cf4'
        columns = [
            '*',
        ]
        hwm = AutoDetectHWM(
            name = 'd5930cc53b',
            entity = 'onetl.test_b47b282cf4',
            expression = 'hwm_int',
        )
        options = {
            'fetchsize': 100000,
            'numPartitions': 1,
            'partitioningMode': 'range',
        }
|Postgres| Checking connection availability...
|Postgres| Using connection parameters:
        user = 'onetl'
        password = SecretStr('**********')
        host = 'localhost'
        port = 5432
        database = 'onetl'
        extra = {}
        jdbc_url = 'jdbc:postgresql://localhost:5432/onetl?ApplicationName=onetl'
|Postgres| Connection is available.
|Postgres| Getting min and max values for expression 'hwm_int' ...
|Postgres| Executing SQL query (on driver):
        SELECT
               MIN(hwm_int) AS "min",
               MAX(hwm_int) AS "max"
        FROM
               onetl.test_b47b282cf4
|Postgres| Received values:
        MIN(hwm_int) = 0
        MAX(hwm_int) = 50
|Postgres| Executing SQL query (on executor):
        SELECT
               *
        FROM
               onetl.test_b47b282cf4
        WHERE
               (hwm_int >= 0)
          AND
               (hwm_int <= 10)
|Spark| DataFrame successfully created from SQL statement 
------------------------------------ DBReader.run() ends ------------------------------------
|IncrementalBatchStrategy| Next iteration
|IncrementalBatchStrategy| Saving HWM to 'MemoryHWMStore':
        hwm = ColumnIntHWM(
            name = 'd5930cc53b',
            entity = 'onetl.test_b47b282cf4',
            expression = 'hwm_int',
            value = 10,
        )
|IncrementalBatchStrategy| HWM has been saved
=================================== DBReader.run() starts ===================================
|Postgres| -> |Spark| Reading DataFrame from source using parameters:
        source = 'onetl.test_b47b282cf4'
        columns = [
            '*',
        ]
        hwm = AutoDetectHWM(
            name = 'd5930cc53b',
            entity = 'onetl.test_b47b282cf4',
            expression = 'hwm_int',
        )
        options = {
            'fetchsize': 100000,
            'numPartitions': 1,
            'partitioningMode': 'range',
        }
|Postgres| Checking connection availability...
|Postgres| Using connection parameters:
        user = 'onetl'
        password = SecretStr('**********')
        host = 'localhost'
        port = 5432
        database = 'onetl'
        extra = {}
        jdbc_url = 'jdbc:postgresql://localhost:5432/onetl?ApplicationName=onetl'
|Postgres| Connection is available.
|Postgres| Executing SQL query (on executor):
        SELECT
               *
        FROM
               onetl.test_b47b282cf4
        WHERE
               (hwm_int >  10)
          AND
               (hwm_int <= 20)
|Spark| DataFrame successfully created from SQL statement 
------------------------------------ DBReader.run() ends ------------------------------------
|IncrementalBatchStrategy| Next iteration
|IncrementalBatchStrategy| Saving HWM to 'MemoryHWMStore':
        hwm = ColumnIntHWM(
            name = 'd5930cc53b',
            entity = 'onetl.test_b47b282cf4',
            expression = 'hwm_int',
            value = 20,
        )
|IncrementalBatchStrategy| HWM has been saved
=================================== DBReader.run() starts ===================================
|Postgres| -> |Spark| Reading DataFrame from source using parameters:
        source = 'onetl.test_b47b282cf4'
        columns = [
            '*',
        ]
        hwm = AutoDetectHWM(
            name = 'd5930cc53b',
            entity = 'onetl.test_b47b282cf4',
            expression = 'hwm_int',
        )
        options = {
            'fetchsize': 100000,
            'numPartitions': 1,
            'partitioningMode': 'range',
        }
|Postgres| Checking connection availability...
|Postgres| Using connection parameters:
        user = 'onetl'
        password = SecretStr('**********')
        host = 'localhost'
        port = 5432
        database = 'onetl'
        extra = {}
        jdbc_url = 'jdbc:postgresql://localhost:5432/onetl?ApplicationName=onetl'
|Postgres| Connection is available.
|Postgres| Executing SQL query (on executor):
        SELECT
               *
        FROM
               onetl.test_b47b282cf4
        WHERE
               (hwm_int >  20)
          AND
               (hwm_int <= 30)
|Spark| DataFrame successfully created from SQL statement 
------------------------------------ DBReader.run() ends ------------------------------------
```

After:
```log
|onETL| Using IncrementalBatchStrategy as a strategy
        step = 10
|IncrementalBatchStrategy| First iteration
=================================== DBReader.run() starts ===================================
|DBReader| Getting Spark type for HWM expression: 'hwm_int'
|Postgres| Fetching schema of table 'onetl.test_a0662ca113' ...
|Postgres| Schema fetched.
|DBReader| Got Spark field: StructField('hwm_int', LongType(), True)
|DBReader| Detected HWM type: 'ColumnIntHWM'
|IncrementalBatchStrategy| Fetching HWM from MemoryHWMStore:
        name = 'e71fa4d9b1'
|IncrementalBatchStrategy| Fetched HWM:
        hwm = ColumnIntHWM(
            name = 'e71fa4d9b1',
            entity = 'onetl.test_a0662ca113',
            expression = 'hwm_int',
        )
|Postgres| Getting min and max values for expression 'hwm_int' ...
|Postgres| Executing SQL query (on driver):
        SELECT
               MIN(hwm_int) AS "min",
               MAX(hwm_int) AS "max"
        FROM
               onetl.test_a0662ca113
|Postgres| Received values:
        MIN(hwm_int) = 0
        MAX(hwm_int) = 50
|Postgres| Executing SQL query (on executor):
        SELECT
               *
        FROM
               onetl.test_a0662ca113
        WHERE
               (hwm_int >= 0)
          AND
               (hwm_int <= 10)
|Spark| DataFrame successfully created from SQL statement 
------------------------------------ DBReader.run() ends ------------------------------------
|IncrementalBatchStrategy| Saving HWM to 'MemoryHWMStore':
        hwm = ColumnIntHWM(
            name = 'e71fa4d9b1',
            entity = 'onetl.test_a0662ca113',
            expression = 'hwm_int',
            value = 10,
        )
|IncrementalBatchStrategy| HWM has been saved
|IncrementalBatchStrategy| Next iteration
=================================== DBReader.run() starts ===================================
|Postgres| Executing SQL query (on executor):
        SELECT
               *
        FROM
               onetl.test_a0662ca113
        WHERE
               (hwm_int >  10)
          AND
               (hwm_int <= 20)
|Spark| DataFrame successfully created from SQL statement 
------------------------------------ DBReader.run() ends ------------------------------------
|IncrementalBatchStrategy| Saving HWM to 'MemoryHWMStore':
        hwm = ColumnIntHWM(
            name = 'e71fa4d9b1',
            entity = 'onetl.test_a0662ca113',
            expression = 'hwm_int',
            value = 20,
        )
|IncrementalBatchStrategy| HWM has been saved
|IncrementalBatchStrategy| Next iteration
=================================== DBReader.run() starts ===================================
|Postgres| Executing SQL query (on executor):
        SELECT
               *
        FROM
               onetl.test_a0662ca113
        WHERE
               (hwm_int >  20)
          AND
               (hwm_int <= 30)
|Spark| DataFrame successfully created from SQL statement
------------------------------------ DBReader.run() ends ------------------------------------
|IncrementalBatchStrategy| Saving HWM to 'MemoryHWMStore':
        hwm = ColumnIntHWM(
            name = 'e71fa4d9b1',
            entity = 'onetl.test_a0662ca113',
            expression = 'hwm_int',
            value = 30,
        )
|IncrementalBatchStrategy| HWM has been saved
```

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [X] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
