### PR TITLE
[DOP-11980] - add KeyValueIntHWM support in DBReader

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -334,3 +334,44 @@ How to skip change notes check?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Just add ``ci:skip-changelog`` label to pull request.
+
+Release Process
+^^^^^^^^^^^^^^^
+
+Before making a release from the ``develop`` branch, follow these steps:
+
+1. Backup ``NEXT_RELEASE.rst``
+
+.. code:: bash
+
+    cp docs/changelog/NEXT_RELEASE.rst docs/changelog/temp_NEXT_RELEASE.rst
+
+2. Build the Release notes with Towncrier
+
+.. code:: bash
+
+    export VERSION=$(cat onetl/VERSION)
+    towncrier build  --version=${VERSION}
+
+3. Update Changelog
+
+.. code:: bash
+
+    mv docs/changelog/NEXT_RELEASE.rst docs/changelog/${VERSION}.rst
+
+4. Edit the ``${VERSION}.rst`` file
+Remove content above the version number heading in the ``${VERSION}.rst`` file.
+
+5. Update Changelog Index
+
+.. code:: bash
+
+    awk -v version=${VERSION} '/NEXT_RELEASE/{print;print "    " version;next}1' docs/changelog/index.rst > temp && mv temp docs/changelog/index.rst
+
+6. Reset ``NEXT_RELEASE.rst`` file
+
+.. code:: bash
+
+    mv docs/changelog/temp_NEXT_RELEASE.rst docs/changelog/NEXT_RELEASE.rst
+
+7. Update the patch version in the ``VERSION`` file of ``develop`` branch **after release**.

--- a/onetl/base/base_db_connection.py
+++ b/onetl/base/base_db_connection.py
@@ -21,7 +21,7 @@ from onetl.base.base_connection import BaseConnection
 from onetl.hwm import Window
 
 if TYPE_CHECKING:
-    from etl_entities.hwm import HWM, ColumnHWM
+    from etl_entities.hwm import HWM
     from pyspark.sql import DataFrame
     from pyspark.sql.types import StructField, StructType
 
@@ -107,7 +107,7 @@ class BaseDBDialect(ABC):
         """
 
     @abstractmethod
-    def detect_hwm_class(self, field: StructField) -> type[ColumnHWM] | None:
+    def detect_hwm_class(self, field: StructField) -> type[HWM] | None:
         """
         Detects hwm column type based on specific data types in connections data stores
         """

--- a/onetl/connection/db_connection/db_connection/dialect.py
+++ b/onetl/connection/db_connection/db_connection/dialect.py
@@ -23,12 +23,12 @@ from onetl.hwm import Edge, Window
 from onetl.hwm.store import SparkTypeToHWM
 
 if TYPE_CHECKING:
-    from etl_entities.hwm import ColumnHWM
+    from etl_entities.hwm import HWM
     from pyspark.sql.types import StructField
 
 
 class DBDialect(BaseDBDialect):
-    def detect_hwm_class(self, field: StructField) -> type[ColumnHWM] | None:
+    def detect_hwm_class(self, field: StructField) -> type[HWM] | None:
         return SparkTypeToHWM.get(field.dataType.typeName())  # type: ignore
 
     def get_sql_query(

--- a/onetl/connection/db_connection/kafka/connection.py
+++ b/onetl/connection/db_connection/kafka/connection.py
@@ -346,31 +346,31 @@ class Kafka(DBConnection):
             TimestampType,
         )
 
-        schema = StructType(
-            [
-                StructField("key", BinaryType(), nullable=True),
-                StructField("value", BinaryType(), nullable=False),
-                StructField("topic", StringType(), nullable=True),
-                StructField("partition", IntegerType(), nullable=True),
-                StructField("offset", LongType(), nullable=True),
-                StructField("timestamp", TimestampType(), nullable=True),
-                StructField("timestampType", IntegerType(), nullable=True),
-                StructField(
-                    "headers",
-                    ArrayType(
-                        StructType(
-                            [
-                                StructField("key", StringType(), nullable=True),
-                                StructField("value", BinaryType(), nullable=True),
-                            ],
-                        ),
+        all_fields = [
+            StructField("key", BinaryType(), nullable=True),
+            StructField("value", BinaryType(), nullable=False),
+            StructField("topic", StringType(), nullable=True),
+            StructField("partition", IntegerType(), nullable=True),
+            StructField("offset", LongType(), nullable=True),
+            StructField("timestamp", TimestampType(), nullable=True),
+            StructField("timestampType", IntegerType(), nullable=True),
+            StructField(
+                "headers",
+                ArrayType(
+                    StructType(
+                        [
+                            StructField("key", StringType(), nullable=True),
+                            StructField("value", BinaryType(), nullable=True),
+                        ],
                     ),
-                    nullable=True,
                 ),
-            ],
-        )
+                nullable=True,
+            ),
+        ]
 
-        return schema  # noqa:  WPS331
+        filtered_fields = [field for field in all_fields if columns is None or field.name in columns]
+
+        return StructType(filtered_fields)
 
     @slot
     @classmethod

--- a/onetl/connection/db_connection/kafka/dialect.py
+++ b/onetl/connection/db_connection/kafka/dialect.py
@@ -68,11 +68,9 @@ class KafkaDialect(  # noqa: WPS215
                 )
         return hwm
 
-    def detect_hwm_class(self, field: StructField) -> type[KeyValueIntHWM]:
-        # mapping of Kafka field names to HWM classes
+    def detect_hwm_class(self, field: StructField) -> type[KeyValueIntHWM] | None:
         kafka_field_to_hwm_class = {
             "offset": KeyValueIntHWM,
             # add "timestamp" in future
         }
-
-        return kafka_field_to_hwm_class.get(field.name, super().detect_hwm_class(field))
+        return kafka_field_to_hwm_class.get(field.name)

--- a/onetl/db/db_reader/db_reader.py
+++ b/onetl/db/db_reader/db_reader.py
@@ -6,7 +6,7 @@ from logging import getLogger
 from typing import TYPE_CHECKING, Any, List, Optional, Union
 
 import frozendict
-from etl_entities.hwm import HWM, ColumnHWM
+from etl_entities.hwm import HWM, ColumnHWM, KeyValueHWM
 from etl_entities.old_hwm import IntHWM as OldColumnHWM
 from etl_entities.source import Column, Table
 from pydantic import Field, PrivateAttr, root_validator, validator
@@ -370,7 +370,7 @@ class DBReader(FrozenModel):
     df_schema: Optional[StructType] = None
     hwm_column: Optional[Union[str, tuple]] = None
     hwm_expression: Optional[str] = None
-    hwm: Optional[HWM] = None
+    hwm: Optional[Union[AutoDetectHWM, ColumnHWM, KeyValueHWM]] = None
     options: Optional[GenericOptions] = None
 
     AutoDetectHWM = AutoDetectHWM

--- a/onetl/db/db_reader/db_reader.py
+++ b/onetl/db/db_reader/db_reader.py
@@ -123,7 +123,7 @@ class DBReader(FrozenModel):
             Some sources does not support data filtering.
 
     hwm : type[HWM] | None, default: ``None``
-        HWM class to be used as :etl-entities:`HWM <hwm/column/index.html>` value.
+        HWM class to be used as :etl-entities:`HWM <hwm/index.html>` value.
 
         .. code:: python
 
@@ -362,8 +362,6 @@ class DBReader(FrozenModel):
             df = reader.run()
     """
 
-    AutoDetectHWM = AutoDetectHWM
-
     connection: BaseDBConnection
     source: str = Field(alias="table")
     columns: Optional[List[str]] = Field(default=None, min_items=1)
@@ -372,8 +370,10 @@ class DBReader(FrozenModel):
     df_schema: Optional[StructType] = None
     hwm_column: Optional[Union[str, tuple]] = None
     hwm_expression: Optional[str] = None
-    hwm: Optional[ColumnHWM] = None
+    hwm: Optional[HWM] = None
     options: Optional[GenericOptions] = None
+
+    AutoDetectHWM = AutoDetectHWM
 
     _connection_checked: bool = PrivateAttr(default=False)
 
@@ -414,7 +414,7 @@ class DBReader(FrozenModel):
         source: str = values["source"]
         hwm_column: str | tuple[str, str] | None = values.get("hwm_column")
         hwm_expression: str | None = values.get("hwm_expression")
-        hwm: ColumnHWM | None = values.get("hwm")
+        hwm: HWM | None = values.get("hwm")
 
         if hwm_column is not None:
             if hwm:

--- a/onetl/hwm/auto_hwm.py
+++ b/onetl/hwm/auto_hwm.py
@@ -39,7 +39,7 @@ class AutoDetectHWM(HWM):
 
     def update(self: AutoDetectHWM, value: Any) -> AutoDetectHWM:
         """Update current HWM value with some implementation-specific logic, and return HWM"""
-        return self
+        raise NotImplementedError("update method should be implemented in auto detected subclasses")
 
     def dict(self, **kwargs):
         serialized_data = super().dict(**kwargs)

--- a/onetl/hwm/auto_hwm.py
+++ b/onetl/hwm/auto_hwm.py
@@ -11,11 +11,39 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+from __future__ import annotations
 
+from typing import Any
 
-from etl_entities.hwm import ColumnHWM
+from etl_entities.hwm import HWM
+from pydantic import root_validator
 from typing_extensions import Literal
 
 
-class AutoDetectHWM(ColumnHWM):
+class AutoDetectHWM(HWM):
     value: Literal[None] = None
+
+    @root_validator(pre=True)
+    def handle_aliases(cls, values):
+        # this validator is hack for accommodating multiple aliases for a single field in pydantic v1.
+
+        # 'column' is an alias used specifically for instances of the ColumnHWM class.
+        if "source" in values and "entity" not in values:
+            values["entity"] = values.pop("source")
+
+        # 'topic' is an alias used for instances of the KeyValueHWM class.
+        elif "topic" in values and "entity" not in values:
+            values["entity"] = values.pop("topic")
+
+        return values
+
+    def update(self: AutoDetectHWM, value: Any) -> AutoDetectHWM:
+        """Update current HWM value with some implementation-specific logic, and return HWM"""
+        return self
+
+    def dict(self, **kwargs):
+        serialized_data = super().dict(**kwargs)
+        # as in HWM classes default value for 'value' may be any structure,
+        # e.g. frozendict for KeyValueHWM, there should unifed dict representation
+        serialized_data.pop("value")
+        return serialized_data

--- a/onetl/impl/frozen_model.py
+++ b/onetl/impl/frozen_model.py
@@ -19,4 +19,5 @@ from onetl.impl.base_model import BaseModel
 
 class FrozenModel(BaseModel):
     class Config:
+        smart_union = True
         frozen = True

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -1,5 +1,5 @@
 deprecated
-etl-entities>=2.1.2,<2.2
+etl-entities>=2.2,<2.3
 evacuator>=1.0,<1.1
 frozendict
 humanize

--- a/tests/tests_unit/test_db/test_db_reader_unit/test_kafka_reader_unit.py
+++ b/tests/tests_unit/test_db/test_db_reader_unit/test_kafka_reader_unit.py
@@ -1,6 +1,16 @@
 import secrets
 
 import pytest
+from pyspark.sql.types import (
+    BinaryType,
+    DoubleType,
+    IntegerType,
+    LongType,
+    StringType,
+    StructField,
+    StructType,
+    TimestampType,
+)
 
 from onetl.connection import Kafka
 from onetl.db import DBReader
@@ -10,15 +20,6 @@ pytestmark = pytest.mark.kafka
 
 @pytest.fixture(scope="function")
 def df_schema():
-    from pyspark.sql.types import (
-        DoubleType,
-        IntegerType,
-        StringType,
-        StructField,
-        StructType,
-        TimestampType,
-    )
-
     return StructType(
         [
             StructField("id", IntegerType()),
@@ -82,29 +83,11 @@ def test_kafka_reader_hwm_offset_is_valid(spark_mock):
     )
 
 
-def test_kafka_reader_hwm_timestamp_depends_on_spark_version(spark_mock, mocker):
-    kafka = Kafka(
-        addresses=["localhost:9092"],
-        cluster="my_cluster",
-        spark=spark_mock,
-    )
-    mocker.patch.object(spark_mock, "version", new="3.2.0")
-    DBReader(
-        connection=kafka,
-        table="table",
-        hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), expression="timestamp"),
-    )
-
-    mocker.patch.object(spark_mock, "version", new="2.4.0")
-    with pytest.raises(ValueError, match="Spark version must be 3.x"):
-        DBReader(
-            connection=kafka,
-            table="table",
-            hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), expression="timestamp"),
-        )
-
-
-def test_kafka_reader_invalid_hwm_column(spark_mock):
+@pytest.mark.parametrize(
+    "hwm_expression",
+    ["unknown", "timestamp"],
+)
+def test_kafka_reader_invalid_hwm_column(spark_mock, hwm_expression):
     kafka = Kafka(
         addresses=["localhost:9092"],
         cluster="my_cluster",
@@ -113,10 +96,53 @@ def test_kafka_reader_invalid_hwm_column(spark_mock):
 
     with pytest.raises(
         ValueError,
-        match="hwm.expression='unknown' is not supported by Kafka",
+        match=f"hwm.expression='{hwm_expression}' is not supported by Kafka",
     ):
         DBReader(
             connection=kafka,
             table="table",
-            hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), expression="unknown"),
+            hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), expression=hwm_expression),
         )
+
+
+@pytest.mark.parametrize(
+    "columns,expected_schema",
+    [
+        (
+            ["key", "value", "offset"],
+            StructType(
+                [
+                    StructField("key", BinaryType(), nullable=True),
+                    StructField("value", BinaryType(), nullable=False),
+                    StructField("offset", LongType(), nullable=True),
+                ],
+            ),
+        ),
+        (
+            ["key", "timestamp"],
+            StructType(
+                [
+                    StructField("key", BinaryType(), nullable=True),
+                    StructField("timestamp", TimestampType(), nullable=True),
+                ],
+            ),
+        ),
+        (
+            ["value"],
+            StructType(
+                [
+                    StructField("value", BinaryType(), nullable=False),
+                ],
+            ),
+        ),
+    ],
+)
+def test_get_df_schema(spark_mock, columns, expected_schema):
+    kafka = Kafka(
+        addresses=["localhost:9092"],
+        cluster="my_cluster",
+        spark=spark_mock,
+    )
+
+    df_schema = kafka.get_df_schema(source="test_topic", columns=columns)
+    assert df_schema == expected_schema


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

- add `KeyValueIntHWM` support in `DBReader` (update `etl-entities` version to `2.2.0`)
- add following tests and documentation
- add **Release Process** in Contribution guide

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [ ] Tests pass on CI and coverage does not decrease
* [x] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
