### PR TITLE
[DOP-11906] Remove min/max workaround for Clickhouse

### DIFF
--- a/onetl/connection/db_connection/clickhouse/connection.py
+++ b/onetl/connection/db_connection/clickhouse/connection.py
@@ -16,15 +16,13 @@ from __future__ import annotations
 
 import logging
 import warnings
-from typing import Any, ClassVar, Optional
+from typing import ClassVar, Optional
 
 from onetl._util.classproperty import classproperty
 from onetl.connection.db_connection.clickhouse.dialect import ClickhouseDialect
 from onetl.connection.db_connection.jdbc_connection import JDBCConnection
-from onetl.connection.db_connection.jdbc_connection.options import JDBCReadOptions
 from onetl.connection.db_connection.jdbc_mixin import JDBCStatementType
 from onetl.hooks import slot, support_hooks
-from onetl.hwm import Window
 from onetl.impl import GenericOptions
 
 # do not import PySpark here, as we allow user to use `Clickhouse.get_packages()` for creating Spark session
@@ -110,8 +108,6 @@ class Clickhouse(JDBCConnection):
         from onetl.connection import Clickhouse
         from pyspark.sql import SparkSession
 
-        extra = {"continueBatchOnError": "false"}
-
         # Create Spark session with Clickhouse driver loaded
         maven_packages = Clickhouse.get_packages()
         spark = (
@@ -125,7 +121,7 @@ class Clickhouse(JDBCConnection):
             host="database.host.or.ip",
             user="user",
             password="*****",
-            extra=extra,
+            extra={"continueBatchOnError": "false"},
             spark=spark,
         )
 
@@ -174,27 +170,6 @@ class Clickhouse(JDBCConnection):
             return f"jdbc:clickhouse://{self.host}:{self.port}/{self.database}?{parameters}".rstrip("?")
 
         return f"jdbc:clickhouse://{self.host}:{self.port}?{parameters}".rstrip("?")
-
-    @slot
-    def get_min_max_values(
-        self,
-        source: str,
-        window: Window,
-        hint: Any | None = None,
-        where: Any | None = None,
-        options: JDBCReadOptions | None = None,
-    ) -> tuple[Any, Any]:
-        min_value, max_value = super().get_min_max_values(
-            source=source,
-            window=window,
-            hint=hint,
-            where=where,
-            options=options,
-        )
-        # Clickhouse for some reason return min/max=0 if there are no rows
-        if min_value == max_value == 0:
-            return None, None
-        return min_value, max_value
 
     @staticmethod
     def _build_statement(

--- a/onetl/connection/db_connection/clickhouse/dialect.py
+++ b/onetl/connection/db_connection/clickhouse/dialect.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 from datetime import date, datetime
+from typing import Any
 
 from onetl.connection.db_connection.jdbc_connection import JDBCDialect
 
@@ -25,6 +26,16 @@ class ClickhouseDialect(JDBCDialect):
 
     def get_partition_column_mod(self, partition_column: str, num_partitions: int) -> str:
         return f"{partition_column} % {num_partitions}"
+
+    def get_max_value(self, value: Any) -> str:
+        # Max function in Clickhouse returns 0 instead of NULL for empty table
+        result = self._serialize_value(value)
+        return f"maxOrNull({result})"
+
+    def get_min_value(self, value: Any) -> str:
+        # Min function in Clickhouse returns 0 instead of NULL for empty table
+        result = self._serialize_value(value)
+        return f"minOrNull({result})"
 
     def _serialize_datetime(self, value: datetime) -> str:
         result = value.strftime("%Y-%m-%d %H:%M:%S")

--- a/onetl/connection/db_connection/jdbc_mixin/connection.py
+++ b/onetl/connection/db_connection/jdbc_mixin/connection.py
@@ -601,7 +601,7 @@ class JDBCMixin(FrozenModel):
 
         result_set = jdbc_statement.getResultSet()
 
-        if not result_set:
+        if not result_set or result_set.isClosed():
             return None
 
         result_metadata = result_set.getMetaData()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Clickhouse's `min`/`max` functions return `0` if there is no data in the source. There was a workaround for that to return `None` from `get_min_max_values`.

But there are also `minOrNull`/`maxOrNull` variants of these functions which return `null` for empty result. Switched to these functions to simplify code a bit.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
