### PR TITLE
[DOP-13251] Add Greenplum type mapping to documentation

### DIFF
--- a/docs/changelog/next_release/228.improvement.rst
+++ b/docs/changelog/next_release/228.improvement.rst
@@ -1,0 +1,3 @@
+Improve Greenplum documentation:
+  * Add "Types" section describing mapping between Greenplum and Spark types
+  * Add more examples of reading and writing data from Greenplum

--- a/docs/connection/db_connection/clickhouse/execute.rst
+++ b/docs/connection/db_connection/clickhouse/execute.rst
@@ -62,6 +62,7 @@ This method supports **any** query syntax supported by Clickhouse, like:
 * ``CREATE TABLE ...``
 * ``ALTER ...``
 * ``INSERT INTO ... AS SELECT ...``
+* etc
 
 It does not support multiple queries in the same operation, like ``SET ...; CREATE TABLE ...;``.
 
@@ -88,7 +89,6 @@ Examples
             """,
             options=Clickhouse.JDBCOptions(query_timeout=10),
         )
-
 
 References
 ----------

--- a/docs/connection/db_connection/greenplum/execute.rst
+++ b/docs/connection/db_connection/greenplum/execute.rst
@@ -3,6 +3,101 @@
 Executing statements in Greenplum
 ==================================
 
+.. warning::
+
+    Unlike ``DBReader``, ``Greenplum.fetch`` and ``Greenplum.execute`` are implemented using Postgres JDBC connection,
+    and so types are handled a bit differently. See :ref:`postgres-types`.
+
+How to
+------
+
+There are 2 ways to execute some statement in Greenplum
+
+Use :obj:`Greenplum.fetch <onetl.connection.db_connection.greenplum.connection.Greenplum.fetch>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use this method to execute some ``SELECT`` query which returns **small number or rows**, like reading
+Greenplum config, or reading data from some reference table.
+
+Method accepts :obj:`JDBCOptions <onetl.connection.db_connection.jdbc_mixin.options.JDBCOptions>`.
+
+Connection opened using this method should be then closed with :obj:`Greenplum.close <onetl.connection.db_connection.greenplum.connection.Greenplum.close>`.
+
+Syntax support
+^^^^^^^^^^^^^^
+
+This method supports **any** query syntax supported by Greenplum, like:
+
+* ``SELECT ... FROM ...``
+* ``WITH alias AS (...) SELECT ...``
+
+Queries like ``SHOW ...`` are not supported.
+
+It does not support multiple queries in the same operation, like ``SET ...; SELECT ...;``.
+
+Examples
+^^^^^^^^
+
+.. code-block:: python
+
+    from onetl.connection import Greenplum
+
+    greenplum = Greenplum(...)
+
+    df = greenplum.fetch(
+        "SELECT value FROM some.reference_table WHERE key = 'some_constant'",
+        options=Greenplum.JDBCOptions(query_timeout=10),
+    )
+    greenplum.close()
+    value = df.collect()[0][0]  # get value from first row and first column
+
+Use :obj:`Greenplum.execute <onetl.connection.db_connection.greenplum.connection.Greenplum.execute>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use this method to execute DDL and DML operations. Each method call runs operation in a separated transaction, and then commits it.
+
+Method accepts :obj:`JDBCOptions <onetl.connection.db_connection.jdbc_mixin.options.JDBCOptions>`.
+
+Connection opened using this method should be then closed with :obj:`Greenplum.close <onetl.connection.db_connection.greenplum.connection.Greenplum.close>`.
+
+Syntax support
+^^^^^^^^^^^^^^
+
+This method supports **any** query syntax supported by Greenplum, like:
+
+* ``CREATE TABLE ...``, ``CREATE VIEW ...``, and so on
+* ``ALTER ...``
+* ``INSERT INTO ... AS SELECT ...``
+* ``DROP TABLE ...``, ``DROP VIEW ...``, and so on
+* ``CALL procedure(arg1, arg2) ...``
+* ``SELECT func(arg1, arg2)`` or ``{call func(arg1, arg2)}`` - special syntax for calling functions
+* etc
+
+It does not support multiple queries in the same operation, like ``SET ...; CREATE TABLE ...;``.
+
+Examples
+^^^^^^^^
+
+.. code-block:: python
+
+    from onetl.connection import Greenplum
+
+    greenplum = Greenplum(...)
+
+    with greenplum:
+        greenplum.execute("DROP TABLE schema.table")
+        greenplum.execute(
+            """
+            CREATE TABLE schema.table AS (
+                id int,
+                key text,
+                value real
+            )
+            DISTRIBUTED BY id
+            """,
+            options=Greenplum.JDBCOptions(query_timeout=10),
+        )
+
 Interaction schema
 ------------------
 

--- a/docs/connection/db_connection/greenplum/index.rst
+++ b/docs/connection/db_connection/greenplum/index.rst
@@ -17,3 +17,9 @@ Greenplum
     read
     write
     execute
+
+.. toctree::
+    :maxdepth: 1
+    :caption: Troubleshooting
+
+    types

--- a/docs/connection/db_connection/greenplum/prerequisites.rst
+++ b/docs/connection/db_connection/greenplum/prerequisites.rst
@@ -24,7 +24,7 @@ Downloading VMware package
 --------------------------
 
 To use Greenplum connector you should download connector ``.jar`` file from
-`VMware website <https://network.tanzu.vmware.com/products/vmware-greenplum#/releases/1457167/file_groups/18338>`_
+`VMware website <https://network.tanzu.vmware.com/products/vmware-greenplum#/releases/1462218/file_groups/18524>`_
 and then pass it to Spark session.
 
 .. warning::
@@ -197,7 +197,7 @@ used for creating a connection:
 
 .. tabs::
 
-    .. code-tab:: sql Read + write
+    .. code-tab:: sql Read + Write
 
         -- get access to get tables metadata & cluster information
         GRANT SELECT ON information_schema.tables TO username;

--- a/docs/connection/db_connection/greenplum/types.rst
+++ b/docs/connection/db_connection/greenplum/types.rst
@@ -1,0 +1,386 @@
+.. _greenplum-types:
+
+Greenplum <-> Spark type mapping
+=================================
+
+Type detection & casting
+------------------------
+
+Spark's DataFrames always have a ``schema`` which is a list of columns with corresponding Spark types. All operations on a column are performed using column type.
+
+Reading from Greenplum
+~~~~~~~~~~~~~~~~~~~~~~~
+
+This is how Greenplum connector performs this:
+
+* Execute query ``SELECT * FROM table LIMIT 0`` [1]_.
+* For each column in query result get column name and Greenplum type.
+* Find corresponding ``Greenplum type (read)`` -> ``Spark type`` combination (see below) for each DataFrame column. If no combination is found, raise exception.
+* Use Spark column projection and predicate pushdown features to build a final query.
+* Create DataFrame from generated query with inferred schema.
+
+.. [1]
+    Yes, **all columns of a table**, not just selected ones.
+    This means that if source table **contains** columns with unsupported type, the entire table cannot be read.
+
+Writing to some existing Clickhuse table
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This is how Greenplum connector performs this:
+
+* Get names of columns in DataFrame.
+* Perform ``SELECT * FROM table LIMIT 0`` query.
+* For each column in query result get column name and Greenplum type.
+* Match table columns with DataFrame columns (by name, case insensitive).
+  If some column is present only in target table, but not in DataFrame (like ``DEFAULT`` or ``SERIAL`` column), and vice versa, raise an exception.
+  See `Write unsupported column type`_.
+* Find corresponding ``Spark type`` -> ``Greenplumtype (write)`` combination (see below) for each DataFrame column. If no combination is found, raise exception.
+* If ``Greenplumtype (write)`` match ``Greenplum type (read)``, no additional casts will be performed, DataFrame column will be written to Greenplum as is.
+* If ``Greenplumtype (write)`` does not match ``Greenplum type (read)``, DataFrame column will be casted to target column type **on Greenplum side**. For example, you can write column with text data to ``json`` column which Greenplum connector currently does not support.
+
+Create new table using Spark
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. warning::
+
+    ABSOLUTELY NOT RECOMMENDED!
+
+This is how Greenplum connector performs this:
+
+* Find corresponding ``Spark type`` -> ``Greenplum type (create)`` combination (see below) for each DataFrame column. If no combination is found, raise exception.
+* Generate DDL for creating table in Greenplum, like ``CREATE TABLE (col1 ...)``, and run it.
+* Write DataFrame to created table as is.
+
+More details `can be found here <https://docs.vmware.com/en/VMware-Greenplum-Connector-for-Apache-Spark/2.3/greenplum-connector-spark/write_to_gpdb.html>`_.
+
+But Greenplum connector support only limited number of types and almost no custom clauses (like ``PARTITION BY``).
+So instead of relying on Spark to create tables:
+
+.. dropdown:: See example
+
+    .. code:: python
+
+        writer = DBWriter(
+            connection=greenplum,
+            table="public.table",
+            options=Greenplum.WriteOptions(
+                if_exists="append",
+                # by default distribution is random
+                distributedBy="id",
+                # partitionBy is not supported
+            ),
+        )
+        writer.run(df)
+
+Always prefer creating table with desired DDL **BEFORE WRITING DATA**:
+
+.. dropdown:: See example
+
+    .. code:: python
+
+        greenplum.execute(
+            """
+            CREATE TABLE public.table AS (
+                id int32,
+                business_dt timestamp(6),
+                value json
+            )
+            PARTITION BY RANGE (business_dt)
+            DISTRIBUTED BY id
+            """,
+        )
+
+        writer = DBWriter(
+            connection=greenplum,
+            table="public.table",
+            options=Greenplum.WriteOptions(if_exists="append"),
+        )
+        writer.run(df)
+
+See Greenplum `CREATE TABLE <https://docs.vmware.com/en/VMware-Greenplum/7/greenplum-database/ref_guide-sql_commands-CREATE_TABLE.html>`_ documentation.
+
+Supported types
+---------------
+
+See `list of Greenplum types <https://docs.vmware.com/en/VMware-Greenplum-Connector-for-Apache-Spark/2.3/greenplum-connector-spark/reference-datatype_mapping.html>`_.
+
+Numeric types
+~~~~~~~~~~~~~
+
++----------------------------------+-----------------------------------+-------------------------------+-------------------------+
+| Greenplum type (read)            | Spark type                        | Greenplumtype (write)         | Greenplum type (create) |
++==================================+===================================+===============================+=========================+
+| ``decimal``                      | ``DecimalType(P=38, S=18)``       | ``decimal(P=38, S=18)``       | ``decimal`` (unbounded) |
++----------------------------------+-----------------------------------+-------------------------------+                         |
+| ``decimal(P=0..38)``             | ``DecimalType(P=0..38, S=0)``     | ``decimal(P=0..38, S=0)``     |                         |
++----------------------------------+-----------------------------------+-------------------------------+                         |
+| ``decimal(P=0..38, S=0..38)``    | ``DecimalType(P=0..38, S=0..38)`` | ``decimal(P=0..38, S=0..38)`` |                         |
++----------------------------------+-----------------------------------+-------------------------------+-------------------------+
+| ``decimal(P=39.., S=0..)``       | unsupported [2]_                  |                               |                         |
++----------------------------------+-----------------------------------+-------------------------------+-------------------------+
+| ``real``                         | ``FloatType()``                   | ``real``                      | ``real``                |
++----------------------------------+-----------------------------------+-------------------------------+-------------------------+
+| ``double precision``             | ``DoubleType()``                  | ``double precision``          | ``double precision``    |
++----------------------------------+-----------------------------------+-------------------------------+-------------------------+
+| ``-``                            | ``ByteType()``                    | unsupported                   | unsupported             |
++----------------------------------+-----------------------------------+-------------------------------+-------------------------+
+| ``smallint``                     | ``ShortType()``                   | ``smallint``                  | ``smallint``            |
++----------------------------------+-----------------------------------+-------------------------------+-------------------------+
+| ``integer``                      | ``IntegerType()``                 | ``integer``                   | ``integer``             |
++----------------------------------+-----------------------------------+-------------------------------+-------------------------+
+| ``bigint``                       | ``LongType()``                    | ``bigint``                    | ``bigint``              |
++----------------------------------+-----------------------------------+-------------------------------+-------------------------+
+| ``money``                        | unsupported                       |                               |                         |
++----------------------------------+                                   |                               |                         |
+| ``int4range``                    |                                   |                               |                         |
++----------------------------------+                                   |                               |                         |
+| ``int8range``                    |                                   |                               |                         |
++----------------------------------+                                   |                               |                         |
+| ``numrange``                     |                                   |                               |                         |
++----------------------------------+                                   |                               |                         |
+| ``int2vector``                   |                                   |                               |                         |
++----------------------------------+-----------------------------------+-------------------------------+-------------------------+
+
+.. [2]
+
+    Greenplum support decimal types with unlimited precision.
+
+    But Spark's ``DecimalType(P, S)`` supports maximum ``P=38`` (128 bit). It is impossible to read, write or operate with values of larger precision,
+    this leads to an exception.
+
+Temporal types
+~~~~~~~~~~~~~~
+
++------------------------------------+-------------------------+-----------------------+-------------------------+
+| Greenplum type (read)              | Spark type              | Greenplumtype (write) | Greenplum type (create) |
++====================================+=========================+=======================+=========================+
+| ``date``                           | ``DateType()``          | ``date``              | ``date``                |
++------------------------------------+-------------------------+-----------------------+-------------------------+
+| ``time``                           | ``TimestampType()``,    | ``timestamp``         | ``timestamp``           |
++------------------------------------+ time format quirks [3]_ |                       |                         |
+| ``time(0..6)``                     |                         |                       |                         |
++------------------------------------+                         |                       |                         |
+| ``time with time zone``            |                         |                       |                         |
++------------------------------------+                         |                       |                         |
+| ``time(0..6) with time zone``      |                         |                       |                         |
++------------------------------------+-------------------------+-----------------------+-------------------------+
+| ``timestamp``                      | ``TimestampType()``     | ``timestamp``         | ``timestamp``           |
++------------------------------------+                         |                       |                         |
+| ``timestamp(0..6)``                |                         |                       |                         |
++------------------------------------+                         |                       |                         |
+| ``timestamp with time zone``       |                         |                       |                         |
++------------------------------------+                         |                       |                         |
+| ``timestamp(0..6) with time zone`` |                         |                       |                         |
++------------------------------------+-------------------------+-----------------------+-------------------------+
+| ``interval`` or any precision      | unsupported             |                       |                         |
++------------------------------------+                         |                       |                         |
+| ``daterange``                      |                         |                       |                         |
++------------------------------------+                         |                       |                         |
+| ``tsrange``                        |                         |                       |                         |
++------------------------------------+                         |                       |                         |
+| ``tstzrange``                      |                         |                       |                         |
++------------------------------------+-------------------------+-----------------------+-------------------------+
+
+.. [3]
+
+    ``time`` type is the same as ``timestamp`` with date ``1970-01-01``. So instead of reading data from Postgres like ``23:59:59``
+    it is actually read ``1970-01-01 23:59:59``, and vice versa.
+
+String types
+~~~~~~~~~~~~
+
++-----------------------------+------------------+-----------------------+-------------------------+
+| Greenplum type (read)       | Spark type       | Greenplumtype (write) | Greenplum type (create) |
++=============================+==================+=======================+=========================+
+| ``character``               | ``StringType()`` | ``text``              | ``text``                |
++-----------------------------+                  |                       |                         |
+| ``character(N)``            |                  |                       |                         |
++-----------------------------+                  |                       |                         |
+| ``character varying``       |                  |                       |                         |
++-----------------------------+                  |                       |                         |
+| ``character varying(N)``    |                  |                       |                         |
++-----------------------------+                  |                       |                         |
+| ``text``                    |                  |                       |                         |
++-----------------------------+                  |                       |                         |
+| ``xml``                     |                  |                       |                         |
++-----------------------------+                  |                       |                         |
+| ``CREATE TYPE ... AS ENUM`` |                  |                       |                         |
++-----------------------------+------------------+-----------------------+-------------------------+
+| ``json``                    | unsupported      |                       |                         |
++-----------------------------+                  |                       |                         |
+| ``jsonb``                   |                  |                       |                         |
++-----------------------------+------------------+-----------------------+-------------------------+
+
+Binary types
+~~~~~~~~~~~~
+
++--------------------------+-------------------+-----------------------+-------------------------+
+| Greenplum type (read)    | Spark type        | Greenplumtype (write) | Greenplum type (create) |
++==========================+===================+=======================+=========================+
+| ``boolean``              | ``BooleanType()`` | ``boolean``           | ``boolean``             |
++--------------------------+-------------------+-----------------------+-------------------------+
+| ``bit``                  | unsupported       |                       |                         |
++--------------------------+                   |                       |                         |
+| ``bit(N)``               |                   |                       |                         |
++--------------------------+                   |                       |                         |
+| ``bit varying``          |                   |                       |                         |
++--------------------------+                   |                       |                         |
+| ``bit varying(N)``       |                   |                       |                         |
++--------------------------+-------------------+-----------------------+-------------------------+
+| ``bytea``                | unsupported [4]_  |                       |                         |
++--------------------------+-------------------+-----------------------+-------------------------+
+| ``-``                    | ``BinaryType()``  | ``bytea``             | ``bytea``               |
++--------------------------+-------------------+-----------------------+-------------------------+
+
+.. [4] Yes, that's weird.
+
+Struct types
+~~~~~~~~~~~~
+
++--------------------------------+------------------+-----------------------+-------------------------+
+| Greenplum type (read)          | Spark type       | Greenplumtype (write) | Greenplum type (create) |
++================================+==================+=======================+=========================+
+| ``T[]``                        | unsupported      |                       |                         |
++--------------------------------+------------------+-----------------------+-------------------------+
+| ``-``                          | ``ArrayType()``  | unsupported           |                         |
++--------------------------------+------------------+-----------------------+-------------------------+
+| ``CREATE TYPE sometype (...)`` | ``StringType()`` | ``text``              | ``text``                |
++--------------------------------+------------------+-----------------------+-------------------------+
+| ``-``                          | ``StructType()`` | unsupported           |                         |
++--------------------------------+------------------+                       |                         |
+| ``-``                          | ``MapType()``    |                       |                         |
++--------------------------------+------------------+-----------------------+-------------------------+
+
+Unsupported types
+-----------------
+
+Columns of these types cannot be read/written by Spark:
+    * ``cidr``
+    * ``inet``
+    * ``macaddr``
+    * ``macaddr8``
+    * ``circle``
+    * ``box``
+    * ``line``
+    * ``lseg``
+    * ``path``
+    * ``point``
+    * ``polygon``
+    * ``tsvector``
+    * ``tsquery``
+    * ``uuid``
+
+The is a way to avoid this - just cast unsupported types to ``text``. But the way this can be done is not a straightforward.
+
+Read unsupported column type
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Unfortunately, it is not possible to cast unsupported column to some supported type on ``DBReader`` side:
+
+.. code-block:: python
+
+    DBReader(
+        connection=greenplum,
+        # will fail
+        columns=["CAST(column AS text)"],
+    )
+
+This is related to Greenplum connector implementation. Instead of passing this ``CAST`` expression to ``SELECT`` query
+as is, it performs type cast on Spark side, so this syntax is not supported.
+
+But there is a workaround - create a view with casting unsupported column to ``text`` (or any other supported type).
+
+For example, you can use ``to_json`` Postgres function for convert column of any type to string representation.
+You can then parse this column on Spark side using `from_json <https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.from_json.html>`_:
+
+.. code:: python
+
+    from pyspark.sql.functions import from_json
+    from pyspark.sql.types import ArrayType, IntegerType
+
+    from onetl.connection import Greenplum
+    from onetl.db import DBReader
+
+    greenplum = Greenplum(...)
+
+    # create view with proper type cast
+    greenplum.execute(
+        """
+        CREATE VIEW schema.view_with_json_column AS
+        SELECT
+            id,
+            supported_column,
+            to_json(array_column) array_column_as_json,
+            gp_segment_id  -- ! important !
+        FROM
+            schema.table_with_unsupported_columns
+        """,
+    )
+
+    # create dataframe using this view
+    reader = DBReader(
+        connection=greenplum,
+        source="schema.view_with_json_column",
+    )
+    df = reader.run()
+
+    # Spark requires all columns to have some type, describe it
+    column_type = ArrayType(IntegerType())
+
+    # cast column content to proper Spark type
+    df = df.select(
+        df.id,
+        df.supported_column,
+        from_json(df.array_column_as_json, schema).alias("array_column"),
+    )
+
+Write unsupported column type
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+It is always possible to convert data on Spark side to string, and then write it to ``text`` column in Greenplum table.
+
+For example, you can convert data using `to_json <https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.to_json.html>`_ function.
+
+.. code:: python
+
+    from pyspark.sql.functions import to_json
+
+    from onetl.connection import Greenplum
+    from onetl.db import DBReader
+
+    greenplum = Greenplum(...)
+
+    greenplum.execute(
+        """
+        CREATE TABLE schema.target_table (
+            id int,
+            supported_column timestamp,
+            array_column_as_json jsonb, -- or text
+        )
+        DISTRIBUTED BY id
+        """,
+    )
+
+    write_df = df.select(
+        df.id,
+        df.supported_column,
+        to_json(df.array_column).alias("array_column_json"),
+    )
+
+    writer = DBWriter(
+        connection=greenplum,
+        target="schema.target_table",
+    )
+    writer.run(write_df)
+
+Then you can parse this column on Greenplum side:
+
+.. code-block:: sql
+
+    SELECT
+        id,
+        supported_column,
+        -- access first item of an array
+        array_column_as_json->0
+    FROM
+        schema.target_table

--- a/docs/connection/db_connection/greenplum/write.rst
+++ b/docs/connection/db_connection/greenplum/write.rst
@@ -1,10 +1,46 @@
 .. _greenplum-write:
 
-Writing to Greenplum
-=====================
+Writing to Greenplum using ``DBWriter``
+========================================
 
-For writing data to Greenplum, use :obj:`DBWriter <onetl.db.db_writer.db_writer.DBWriter>` with options below.
+For writing data to Greenplum, use :obj:`DBWriter <onetl.db.db_writer.db_writer.DBWriter>`
+with :obj:`GreenplumWriteOptions <onetl.connection.db_connection.greenplum.options.GreenplumWriteOptions>`.
 
+.. warning::
+
+    Please take into account :ref:`greenplum-types`.
+
+.. warning::
+
+    It is always recommended to create table explicitly using :obj:`Greenplum.execute <onetl.connection.db_connection.greenplum.connection.Greenplum.execute>`
+    instead of relying on Spark's table DDL generation.
+
+    This is because Spark's DDL generator can create columns with different types than it is expected.
+
+Examples
+--------
+
+.. code-block:: python
+
+    from onetl.connection import Greenplum
+    from onetl.db import DBWriter
+
+    greenplum = Greenplum(...)
+
+    df = ...  # data is here
+
+    writer = DBWriter(
+        connection=greenplum,
+        target="schema.table",
+        options=Greenplum.WriteOptions(
+            if_exists="append",
+            # by default distribution is random
+            distributedBy="id",
+            # partitionBy is not supported
+        ),
+    )
+
+    writer.run(df)
 
 Interaction schema
 ------------------
@@ -87,18 +123,8 @@ High-level schema is described in :ref:`greenplum-prerequisites`. You can find d
                 deactivate "Spark driver"
         @enduml
 
-Recommendations
----------------
-
-Mapping of Spark types to Greenplum types
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-See `official documentation <https://docs.vmware.com/en/VMware-Greenplum-Connector-for-Apache-Spark/2.3/greenplum-connector-spark/reference-datatype_mapping.html#spark-to-greenplum>`_
-for more details.
-onETL does not perform any additional casting of types while writing data.
-
-Options
--------
+Write options
+-------------
 
 .. currentmodule:: onetl.connection.db_connection.greenplum.options
 

--- a/onetl/connection/db_connection/greenplum/connection.py
+++ b/onetl/connection/db_connection/greenplum/connection.py
@@ -64,7 +64,7 @@ class Greenplum(JDBCMixin, DBConnection):
     """Greenplum connection. |support_hooks|
 
     Based on package ``io.pivotal:greenplum-spark:2.3.0``
-    (`VMware Greenplum connector for Spark <https://network.tanzu.vmware.com/products/vmware-greenplum#/releases/1462218/file_groups/18524>`_).
+    (`VMware Greenplum connector for Spark <https://docs.vmware.com/en/VMware-Greenplum-Connector-for-Apache-Spark/index.html>`_).
 
     .. warning::
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

<!-- Please give a short summary of the changes. -->

* Added [separated page](https://onetl--228.org.readthedocs.build/en/228/connection/db_connection/greenplum/types.html) with Greenplum <-> Spark types mapping, and recommendations related to type casts.
* Describe set of [DBReader features](https://onetl--228.org.readthedocs.build/en/228/connection/db_connection/greenplum/read.html) supported by Greenplum connector.
* Added more examples to reading & writing data to Greenplum, and using `fetch` and `execute` methods.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [ ] Tests pass on CI and coverage does not decrease
* [X] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
