### PR TITLE
[DOP-13681] Allow empty pipeline in MongoDB.pipeline

### DIFF
--- a/docs/changelog/next_release/237.feature.rst
+++ b/docs/changelog/next_release/237.feature.rst
@@ -1,0 +1,1 @@
+Allow calling ``MongoDB.pipeline(...)`` with passing just collection name, without explicit aggregation pipeline.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

<!-- Please give a short summary of the changes. -->

Sometimes it is handy to just fetch some data from MongoDB to see infered schema. But `MongoDB.pipeline` requires to pass `pipeline={...}` argument, so users have to pass here some nonsense to bypass this.

Now this argument is optional.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [X] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [ ] My PR is ready to review.
