### PR TITLE
[DOP-13739] Return back handling DBReader(columns="string")

### DIFF
--- a/docs/changelog/next_release/238.bugfix.rst
+++ b/docs/changelog/next_release/238.bugfix.rst
@@ -1,0 +1,2 @@
+Return back handling of ``DBReader(columns="string")``. This was a valid syntax up to v0.10 release, but it was removed because
+most of users neved used it. It looks that we were wrong, returning this behavior back, but with deprecation warning.

--- a/onetl/base/base_db_connection.py
+++ b/onetl/base/base_db_connection.py
@@ -35,7 +35,7 @@ class BaseDBDialect(ABC):
         """
 
     @abstractmethod
-    def validate_columns(self, columns: list[str] | None) -> list[str] | None:
+    def validate_columns(self, columns: str | list[str] | None) -> list[str] | None:
         """Check if ``columns`` value is valid.
 
         Raises

--- a/onetl/connection/db_connection/dialect_mixins/support_columns_list.py
+++ b/onetl/connection/db_connection/dialect_mixins/support_columns_list.py
@@ -2,15 +2,24 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from typing import Any
+import warnings
 
 
 class SupportColumns:
     def validate_columns(
         self,
-        columns: Any,
+        columns: str | list[str] | None,
     ) -> list[str] | None:
         if columns is None:
             return ["*"]
+
+        if isinstance(columns, str):
+            warnings.warn(
+                f"Passing DBReader(columns={columns!r}) is deprecated since v0.10.0 and will be removed in v1.0.0. "
+                f"Use DBReader(columns=[{columns!r}] instead",
+                category=UserWarning,
+                stacklevel=3,
+            )
+            return [columns]
 
         return list(columns)

--- a/onetl/db/db_reader/db_reader.py
+++ b/onetl/db/db_reader/db_reader.py
@@ -107,6 +107,11 @@ class DBReader(FrozenModel):
             It is recommended to pass column names explicitly to avoid selecting too many columns,
             and to avoid adding unexpected columns to dataframe if source DDL is changed.
 
+        .. deprecated:: 0.10.0
+
+            Syntax ``DBReader(columns="col1, col2")`` (string instead of list) is not supported,
+            and will be removed in v1.0.0
+
     where : Any, default: ``None``
         Custom ``where`` for SQL query or MongoDB pipeline.
 
@@ -384,8 +389,8 @@ class DBReader(FrozenModel):
         connection: BaseDBConnection = values["connection"]
         return connection.dialect.validate_name(source)
 
-    @validator("columns", always=True)  # noqa: WPS231
-    def validate_columns(cls, value: list[str] | None, values: dict) -> list[str] | None:
+    @validator("columns", always=True, pre=True)
+    def validate_columns(cls, value: str | list[str] | None, values: dict) -> list[str] | None:
         connection: BaseDBConnection = values["connection"]
         return connection.dialect.validate_columns(value)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

<!-- Please give a short summary of the changes. -->

Allow passing string to `DBReader(columns=...)` as it was allowed in v0.9.x and below. But this is a deprecated syntax, so user will see a warning.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [X] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
