### PR TITLE
[DOP-13779] Improve Teradata documentation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -398,7 +398,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./reports/coverage.xml
           fail_ci_if_error: true
-          plugin: 'noop'
+          plugin: noop
 
       - name: All done
         run: echo 1

--- a/docs/changelog/next_release/240.improvement.rst
+++ b/docs/changelog/next_release/240.improvement.rst
@@ -1,0 +1,4 @@
+Improve Teradata documentation:
+  * Add "Prerequisites" section describing different aspects of connecting to Teradata
+  * Separate documentation of ``DBReader`` and ``Teradata.sql``
+  * Add examples for ``Teradata.fetch`` and ``Teradata.execute``

--- a/docs/connection/db_connection/clickhouse/execute.rst
+++ b/docs/connection/db_connection/clickhouse/execute.rst
@@ -3,20 +3,30 @@
 Executing statements in Clickhouse
 ==================================
 
+.. warning::
+
+    Methods below **read all the rows** returned from DB **to Spark driver memory**, and then convert them to DataFrame.
+
+    Do **NOT** use them to read large amounts of data. Use :ref:`DBReader <clickhouse-read>` or :ref:`Clickhouse.sql <clickhouse-sql>` instead.
+
 How to
 ------
 
 There are 2 ways to execute some statement in Clickhouse
 
-Use :obj:`Clickhouse.fetch <onetl.connection.db_connection.clickhouse.connection.Clickhouse.fetch>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Use ``Clickhouse.fetch``
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 Use this method to execute some ``SELECT`` query which returns **small number or rows**, like reading
-Clickhouse config, or reading data from some reference table.
+Clickhouse config, or reading data from some reference table. Method returns Spark DataFrame.
 
 Method accepts :obj:`JDBCOptions <onetl.connection.db_connection.jdbc_mixin.options.JDBCOptions>`.
 
-Connection opened using this method should be then closed with :obj:`Clickhouse.close <onetl.connection.db_connection.clickhouse.connection.Clickhouse.close>`.
+Connection opened using this method should be then closed with ``connection.close()`` or ``with connection:``.
+
+.. warning::
+
+    Please take into account :ref:`clickhouse-types`.
 
 Syntax support
 ^^^^^^^^^^^^^^
@@ -45,23 +55,23 @@ Examples
     clickhouse.close()
     value = df.collect()[0][0]  # get value from first row and first column
 
-Use :obj:`Clickhouse.execute <onetl.connection.db_connection.clickhouse.connection.Clickhouse.execute>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Use ``Clickhouse.execute``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Use this method to execute DDL and DML operations. Each method call runs operation in a separated transaction, and then commits it.
 
 Method accepts :obj:`JDBCOptions <onetl.connection.db_connection.jdbc_mixin.options.JDBCOptions>`.
 
-Connection opened using this method should be then closed with :obj:`Clickhouse.close <onetl.connection.db_connection.clickhouse.connection.Clickhouse.close>`.
+Connection opened using this method should be then closed with ``connection.close()`` or ``with connection:``.
 
 Syntax support
 ^^^^^^^^^^^^^^
 
 This method supports **any** query syntax supported by Clickhouse, like:
 
-* ✅︎ ``CREATE TABLE ...``, ``CREATE VIEW ...``, and so on
+* ✅︎ ``CREATE TABLE ...``, ``CREATE VIEW ...``, ``DROP TABLE ...``, and so on
 * ✅︎ ``ALTER ...``
-* ✅︎ ``INSERT INTO ... AS SELECT ...``
+* ✅︎ ``INSERT INTO ... SELECT ...``, ``UPDATE ...``, ``DELETE ...``, and so on
 * ✅︎ ``DROP TABLE ...``, ``DROP VIEW ...``, and so on
 * ✅︎ other statements not mentioned here
 * ❌ ``SET ...; SELECT ...;`` - multiple statements not supported
@@ -76,6 +86,7 @@ Examples
     clickhouse = Clickhouse(...)
 
     with clickhouse:
+        # automatically close connection after exiting this context manager
         clickhouse.execute("DROP TABLE schema.table")
         clickhouse.execute(
             """
@@ -90,14 +101,15 @@ Examples
             options=Clickhouse.JDBCOptions(query_timeout=10),
         )
 
-References
-----------
+Notes
+------
 
-.. currentmodule:: onetl.connection.db_connection.clickhouse.connection
+These methods **read all the rows** returned from DB **to Spark driver memory**, and then convert them to DataFrame.
 
-.. automethod:: Clickhouse.fetch
-.. automethod:: Clickhouse.execute
-.. automethod:: Clickhouse.close
+So it should **NOT** be used to read large amounts of data. Use :ref:`DBReader <clickhouse-read>` or :ref:`Clickhouse.sql <clickhouse-sql>` instead.
+
+Options
+-------
 
 .. currentmodule:: onetl.connection.db_connection.jdbc_mixin.options
 

--- a/docs/connection/db_connection/clickhouse/read.rst
+++ b/docs/connection/db_connection/clickhouse/read.rst
@@ -3,12 +3,12 @@
 Reading from Clickhouse using ``DBReader``
 ==========================================
 
+:obj:`DBReader <onetl.db.db_reader.db_reader.DBReader>` supports :ref:`strategy` for incremental data reading,
+but does not support custom queries, like ``JOIN``.
+
 .. warning::
 
     Please take into account :ref:`clickhouse-types`
-
-:obj:`DBReader <onetl.db.db_reader.db_reader.DBReader>` supports :ref:`strategy` for incremental data reading,
-but does not support custom queries, like JOINs.
 
 Supported DBReader features
 ---------------------------
@@ -67,8 +67,23 @@ Incremental strategy:
     with IncrementalStrategy():
         df = reader.run()
 
-Read options
-------------
+Recommendations
+---------------
+
+Select only required columns
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Instead of passing ``"*"`` in ``DBReader(columns=[...])`` prefer passing exact column names. This reduces the amount of data passed from Clickhouse to Spark.
+
+Pay attention to ``where`` value
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Instead of filtering data on Spark side using ``df.filter(df.column == 'value')`` pass proper ``DBReader(where="column = 'value'")`` clause.
+This both reduces the amount of data send from Clickhouse to Spark, and may also improve performance of the query.
+Especially if there are indexes or partitions for columns used in ``where`` clause.
+
+Options
+-------
 
 .. currentmodule:: onetl.connection.db_connection.jdbc_connection.options
 

--- a/docs/connection/db_connection/clickhouse/write.rst
+++ b/docs/connection/db_connection/clickhouse/write.rst
@@ -11,7 +11,7 @@ For writing data to Clickhouse, use :obj:`DBWriter <onetl.db.db_writer.db_writer
 
 .. warning::
 
-    It is always recommended to create table explicitly using :obj:`Clickhouse.execute <onetl.connection.db_connection.clickhouse.connection.Clickhouse.execute>`
+    It is always recommended to create table explicitly using :ref:`Clickhouse.execute <clickhouse-execute>`
     instead of relying on Spark's table DDL generation.
 
     This is because Spark's DDL generator can create columns with different precision and types than it is expected,
@@ -42,8 +42,8 @@ Examples
     writer.run(df)
 
 
-Write options
--------------
+Options
+-------
 
 Method above accepts  :obj:`JDBCWriteOptions <onetl.connection.db_connection.jdbc.options.JDBCWriteOptions>`
 

--- a/docs/connection/db_connection/greenplum/write.rst
+++ b/docs/connection/db_connection/greenplum/write.rst
@@ -12,7 +12,7 @@ with :obj:`GreenplumWriteOptions <onetl.connection.db_connection.greenplum.optio
 
 .. warning::
 
-    It is always recommended to create table explicitly using :obj:`Greenplum.execute <onetl.connection.db_connection.greenplum.connection.Greenplum.execute>`
+    It is always recommended to create table explicitly using :ref:`Greenplum.execute <greenplum-execute>`
     instead of relying on Spark's table DDL generation.
 
     This is because Spark's DDL generator can create columns with different types than it is expected.
@@ -123,8 +123,8 @@ High-level schema is described in :ref:`greenplum-prerequisites`. You can find d
                 deactivate "Spark driver"
         @enduml
 
-Write options
--------------
+Options
+-------
 
 .. currentmodule:: onetl.connection.db_connection.greenplum.options
 

--- a/docs/connection/db_connection/mongodb/pipeline.rst
+++ b/docs/connection/db_connection/mongodb/pipeline.rst
@@ -3,12 +3,22 @@
 Reading from MongoDB using ``MongoDB.pipeline``
 ===============================================
 
+:obj:`MongoDB.sql <onetl.connection.db_connection.mongodb.connection.MongoDB.pipeline>` allows passing custom pipeline,
+but does not support incremental strategies.
+
 .. warning::
 
     Please take into account :ref:`mongodb-types`
 
-:obj:`MongoDB.sql <onetl.connection.db_connection.mongodb.connection.MongoDB.pipeline>` allows passing custom pipeline,
-but does not support incremental strategies.
+Recommendations
+---------------
+
+Pay attention to ``pipeline`` value
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Instead of filtering data on Spark side using ``df.filter(df.column == 'value')`` pass proper ``mongodb.pipeline(..., pipeline={"$match": {"column": {"$eq": "value"}}})`` value.
+This both reduces the amount of data send from MongoDB to Spark, and may also improve performance of the query.
+Especially if there are indexes for columns used in ``pipeline`` value.
 
 References
 ----------

--- a/docs/connection/db_connection/mongodb/read.rst
+++ b/docs/connection/db_connection/mongodb/read.rst
@@ -3,12 +3,12 @@
 Reading from MongoDB using ``DBReader``
 =======================================
 
+:obj:`DBReader <onetl.db.db_reader.db_reader.DBReader>` supports :ref:`strategy` for incremental data reading,
+but does not support custom pipelines, e.g. aggregation.
+
 .. warning::
 
     Please take into account :ref:`mongodb-types`
-
-:obj:`DBReader <onetl.db.db_reader.db_reader.DBReader>` supports :ref:`strategy` for incremental data reading,
-but does not support custom pipelines, e.g. aggregation.
 
 Supported DBReader features
 ---------------------------
@@ -119,6 +119,16 @@ Incremental strategy:
 
     with IncrementalStrategy():
         df = reader.run()
+
+Recommendations
+---------------
+
+Pay attention to ``where`` value
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Instead of filtering data on Spark side using ``df.filter(df.column == 'value')`` pass proper ``DBReader(where={"column": {"$eq": "value"}})`` clause.
+This both reduces the amount of data send from MongoDB to Spark, and may also improve performance of the query.
+Especially if there are indexes for columns used in ``where`` clause.
 
 Read options
 ------------

--- a/docs/connection/db_connection/mssql/execute.rst
+++ b/docs/connection/db_connection/mssql/execute.rst
@@ -3,20 +3,30 @@
 Executing statements in MSSQL
 =============================
 
+.. warning::
+
+    Methods below **read all the rows** returned from DB **to Spark driver memory**, and then convert them to DataFrame.
+
+    Do **NOT** use them to read large amounts of data. Use :ref:`DBReader <mssql-read>` or :ref:`MSSQL.sql <mssql-sql>` instead.
+
 How to
 ------
 
 There are 2 ways to execute some statement in MSSQL
 
-Use :obj:`MSSQL.fetch <onetl.connection.db_connection.mssql.connection.MSSQL.fetch>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Use ``MSSQL.fetch``
+~~~~~~~~~~~~~~~~~~~
 
 Use this method to execute some ``SELECT`` query which returns **small number or rows**, like reading
-MSSQL config, or reading data from some reference table.
+MSSQL config, or reading data from some reference table. Method returns Spark DataFrame.
 
 Method accepts :obj:`JDBCOptions <onetl.connection.db_connection.jdbc_mixin.options.JDBCOptions>`.
 
-Connection opened using this method should be then closed with :obj:`MSSQL.close <onetl.connection.db_connection.mssql.connection.MSSQL.close>`.
+Connection opened using this method should be then closed with ``connection.close()`` or ``with connection:``.
+
+.. warning::
+
+    Please take into account :ref:`mssql-types`.
 
 Syntax support
 ^^^^^^^^^^^^^^
@@ -44,14 +54,14 @@ Examples
     mssql.close()
     value = df.collect()[0][0]  # get value from first row and first column
 
-Use :obj:`MSSQL.execute <onetl.connection.db_connection.mssql.connection.MSSQL.execute>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Use ``MSSQL.execute``
+~~~~~~~~~~~~~~~~~~~~~
 
 Use this method to execute DDL and DML operations. Each method call runs operation in a separated transaction, and then commits it.
 
 Method accepts :obj:`JDBCOptions <onetl.connection.db_connection.jdbc_mixin.options.JDBCOptions>`.
 
-Connection opened using this method should be then closed with :obj:`MSSQL.close <onetl.connection.db_connection.mssql.connection.MSSQL.close>`.
+Connection opened using this method should be then closed with ``connection.close()`` or ``with connection:``.
 
 Syntax support
 ^^^^^^^^^^^^^^
@@ -77,6 +87,7 @@ Examples
     mssql = MSSQL(...)
 
     with mssql:
+        # automatically close connection after exiting this context manager
         mssql.execute("DROP TABLE schema.table")
         mssql.execute(
             """
@@ -89,15 +100,8 @@ Examples
             options=MSSQL.JDBCOptions(query_timeout=10),
         )
 
-
-References
-----------
-
-.. currentmodule:: onetl.connection.db_connection.mssql.connection
-
-.. automethod:: MSSQL.fetch
-.. automethod:: MSSQL.execute
-.. automethod:: MSSQL.close
+Options
+-------
 
 .. currentmodule:: onetl.connection.db_connection.jdbc_mixin.options
 

--- a/docs/connection/db_connection/mssql/read.rst
+++ b/docs/connection/db_connection/mssql/read.rst
@@ -3,12 +3,12 @@
 Reading from MSSQL using ``DBReader``
 ======================================
 
+:obj:`DBReader <onetl.db.db_reader.db_reader.DBReader>` supports :ref:`strategy` for incremental data reading,
+but does not support custom queries, like ``JOIN``.
+
 .. warning::
 
     Please take into account :ref:`mssql-types`
-
-:obj:`DBReader <onetl.db.db_reader.db_reader.DBReader>` supports :ref:`strategy` for incremental data reading,
-but does not support custom queries, like JOINs.
 
 Supported DBReader features
 ---------------------------
@@ -67,8 +67,23 @@ Incremental strategy:
     with IncrementalStrategy():
         df = reader.run()
 
-Read options
-------------
+Recommendations
+---------------
+
+Select only required columns
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Instead of passing ``"*"`` in ``DBReader(columns=[...])`` prefer passing exact column names. This reduces the amount of data passed from MSSQL to Spark.
+
+Pay attention to ``where`` value
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Instead of filtering data on Spark side using ``df.filter(df.column == 'value')`` pass proper ``DBReader(where="column = 'value'")`` clause.
+This both reduces the amount of data send from MSSQL to Spark, and may also improve performance of the query.
+Especially if there are indexes or partitions for columns used in ``where`` clause.
+
+Options
+-------
 
 .. currentmodule:: onetl.connection.db_connection.jdbc_connection.options
 

--- a/docs/connection/db_connection/mssql/sql.rst
+++ b/docs/connection/db_connection/mssql/sql.rst
@@ -3,14 +3,16 @@
 Reading from MSSQL using ``MSSQL.sql``
 ========================================
 
+``MSSQL.sql`` allows passing custom SQL query, but does not support incremental strategies.
+
 .. warning::
 
     Please take into account :ref:`mssql-types`
 
-:obj:`MSSQL.sql <onetl.connection.db_connection.mssql.connection.MSSQL.sql>` allows passing custom SQL query,
-but does not support incremental strategies.
+.. warning::
 
-Method also accepts :obj:`JDBCReadOptions <onetl.connection.db_connection.jdbc.options.JDBCReadOptions>`.
+    Statement is executed in **read-write** connection, so if you're calling some functions/procedures with DDL/DML statements inside,
+    they can change data in your database.
 
 Syntax support
 --------------
@@ -41,12 +43,26 @@ Examples
         WHERE
             key = 'something'
         """,
-        options=MSSQL.ReadOptions(partition_column="id", num_partitions=10),
+        options=MSSQL.ReadOptions(
+            partition_column="id",
+            num_partitions=10,
+            lower_bound=0,
+            upper_bound=1000,
+        ),
     )
 
-References
-----------
+Recommendations
+---------------
 
-.. currentmodule:: onetl.connection.db_connection.mssql.connection
+Select only required columns
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. automethod:: MSSQL.sql
+Instead of passing ``SELECT * FROM ...`` prefer passing exact column names ``SELECT col1, col2, ...``.
+This reduces the amount of data passed from MSSQL to Spark.
+
+Pay attention to ``where`` value
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Instead of filtering data on Spark side using ``df.filter(df.column == 'value')`` pass proper ``WHERE column = 'value'`` clause.
+This both reduces the amount of data send from MSSQL to Spark, and may also improve performance of the query.
+Especially if there are indexes or partitions for columns used in ``where`` clause.

--- a/docs/connection/db_connection/mssql/write.rst
+++ b/docs/connection/db_connection/mssql/write.rst
@@ -11,7 +11,7 @@ For writing data to MSSQL, use :obj:`DBWriter <onetl.db.db_writer.db_writer.DBWr
 
 .. warning::
 
-    It is always recommended to create table explicitly using :obj:`MSSQL.execute <onetl.connection.db_connection.mssql.connection.MSSQL.execute>`
+    It is always recommended to create table explicitly using :ref:`MSSQL.execute <mssql-execute>`
     instead of relying on Spark's table DDL generation.
 
     This is because Spark's DDL generator can create columns with different precision and types than it is expected,
@@ -37,9 +37,8 @@ Examples
 
     writer.run(df)
 
-
-Write options
--------------
+Options
+-------
 
 Method above accepts  :obj:`JDBCWriteOptions <onetl.connection.db_connection.jdbc.options.JDBCWriteOptions>`
 

--- a/docs/connection/db_connection/mysql/execute.rst
+++ b/docs/connection/db_connection/mysql/execute.rst
@@ -1,22 +1,32 @@
 .. _mysql-execute:
 
 Executing statements in MySQL
-==================================
+=============================
+
+.. warning::
+
+    Methods below **read all the rows** returned from DB **to Spark driver memory**, and then convert them to DataFrame.
+
+    Do **NOT** use them to read large amounts of data. Use :ref:`DBReader <mysql-read>` or :ref:`MySQL.sql <mysql-sql>` instead.
 
 How to
 ------
 
 There are 2 ways to execute some statement in MySQL
 
-Use :obj:`MySQL.fetch <onetl.connection.db_connection.mysql.connection.MySQL.fetch>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Use ``MySQL.fetch``
+~~~~~~~~~~~~~~~~~~~
 
 Use this method to execute some ``SELECT`` query which returns **small number or rows**, like reading
-MySQL config, or reading data from some reference table.
+MySQL config, or reading data from some reference table. Method returns Spark DataFrame.
 
 Method accepts :obj:`JDBCOptions <onetl.connection.db_connection.jdbc_mixin.options.JDBCOptions>`.
 
-Connection opened using this method should be then closed with :obj:`MySQL.close <onetl.connection.db_connection.mysql.connection.MySQL.close>`.
+Connection opened using this method should be then closed with ``connection.close()`` or ``with connection:``.
+
+.. warning::
+
+    Please take into account :ref:`mysql-types`.
 
 Syntax support
 ^^^^^^^^^^^^^^
@@ -45,23 +55,23 @@ Examples
     mysql.close()
     value = df.collect()[0][0]  # get value from first row and first column
 
-Use :obj:`MySQL.execute <onetl.connection.db_connection.mysql.connection.MySQL.execute>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Use ``MySQL.execute``
+~~~~~~~~~~~~~~~~~~~~~
 
 Use this method to execute DDL and DML operations. Each method call runs operation in a separated transaction, and then commits it.
 
 Method accepts :obj:`JDBCOptions <onetl.connection.db_connection.jdbc_mixin.options.JDBCOptions>`.
 
-Connection opened using this method should be then closed with :obj:`MySQL.close <onetl.connection.db_connection.mysql.connection.MySQL.close>`.
+Connection opened using this method should be then closed with ``connection.close()`` or ``with connection:``.
 
 Syntax support
 ^^^^^^^^^^^^^^
 
 This method supports **any** query syntax supported by MySQL, like:
 
-* ✅︎ ``CREATE TABLE ...``, ``CREATE VIEW ...``, and so on
+* ✅︎ ``CREATE TABLE ...``, ``CREATE VIEW ...``, ``DROP TABLE ...``, and so on
 * ✅︎ ``ALTER ...``
-* ✅︎ ``INSERT INTO ... AS SELECT ...``
+* ✅︎ ``INSERT INTO ... SELECT ...``, ``UPDATE ...``, ``DELETE ...``, and so on
 * ✅︎ ``DROP TABLE ...``, ``DROP VIEW ...``, and so on
 * ✅︎ ``CALL procedure(arg1, arg2) ...`` or ``{call procedure(arg1, arg2)}`` - special syntax for calling procedure
 * ✅︎ other statements not mentioned here
@@ -77,6 +87,7 @@ Examples
     mysql = MySQL(...)
 
     with mysql:
+        # automatically close connection after exiting this context manager
         mysql.execute("DROP TABLE schema.table")
         mysql.execute(
             """
@@ -90,14 +101,8 @@ Examples
             options=MySQL.JDBCOptions(query_timeout=10),
         )
 
-References
-----------
-
-.. currentmodule:: onetl.connection.db_connection.mysql.connection
-
-.. automethod:: MySQL.fetch
-.. automethod:: MySQL.execute
-.. automethod:: MySQL.close
+Options
+-------
 
 .. currentmodule:: onetl.connection.db_connection.jdbc_mixin.options
 

--- a/docs/connection/db_connection/mysql/read.rst
+++ b/docs/connection/db_connection/mysql/read.rst
@@ -3,12 +3,12 @@
 Reading from MySQL using ``DBReader``
 =====================================
 
+:obj:`DBReader <onetl.db.db_reader.db_reader.DBReader>` supports :ref:`strategy` for incremental data reading,
+but does not support custom queries, like ``JOIN``.
+
 .. warning::
 
     Please take into account :ref:`mysql-types`
-
-:obj:`DBReader <onetl.db.db_reader.db_reader.DBReader>` supports :ref:`strategy` for incremental data reading,
-but does not support custom queries, like JOINs.
 
 Supported DBReader features
 ---------------------------
@@ -69,8 +69,23 @@ Incremental strategy:
     with IncrementalStrategy():
         df = reader.run()
 
-Read options
-------------
+Recommendations
+---------------
+
+Select only required columns
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Instead of passing ``"*"`` in ``DBReader(columns=[...])`` prefer passing exact column names. This reduces the amount of data passed from Oracle to Spark.
+
+Pay attention to ``where`` value
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Instead of filtering data on Spark side using ``df.filter(df.column == 'value')`` pass proper ``DBReader(where="column = 'value'")`` clause.
+This both reduces the amount of data send from Oracle to Spark, and may also improve performance of the query.
+Especially if there are indexes for columns used in ``where`` clause.
+
+Options
+-------
 
 .. currentmodule:: onetl.connection.db_connection.jdbc_connection.options
 

--- a/docs/connection/db_connection/mysql/write.rst
+++ b/docs/connection/db_connection/mysql/write.rst
@@ -11,7 +11,7 @@ For writing data to MySQL, use :obj:`DBWriter <onetl.db.db_writer.db_writer.DBWr
 
 .. warning::
 
-    It is always recommended to create table explicitly using :obj:`MySQL.execute <onetl.connection.db_connection.mysql.connection.MySQL.execute>`
+    It is always recommended to create table explicitly using :ref:`MySQL.execute <mysql-execute>`
     instead of relying on Spark's table DDL generation.
 
     This is because Spark's DDL generator can create columns with different precision and types than it is expected,
@@ -41,9 +41,8 @@ Examples
 
     writer.run(df)
 
-
-Write options
--------------
+Options
+-------
 
 Method above accepts  :obj:`JDBCWriteOptions <onetl.connection.db_connection.jdbc.options.JDBCWriteOptions>`
 

--- a/docs/connection/db_connection/oracle/execute.rst
+++ b/docs/connection/db_connection/oracle/execute.rst
@@ -1,22 +1,32 @@
 .. _oracle-execute:
 
 Executing statements in Oracle
-==================================
+==============================
+
+.. warning::
+
+    Methods below **read all the rows** returned from DB **to Spark driver memory**, and then convert them to DataFrame.
+
+    Do **NOT** use them to read large amounts of data. Use :ref:`DBReader <oracle-read>` or :ref:`Oracle.sql <oracle-sql>` instead.
 
 How to
 ------
 
 There are 2 ways to execute some statement in Oracle
 
-Use :obj:`Oracle.fetch <onetl.connection.db_connection.oracle.connection.Oracle.fetch>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Use ``Oracle.fetch``
+~~~~~~~~~~~~~~~~~~~~
 
 Use this method to execute some ``SELECT`` query which returns **small number or rows**, like reading
-Oracle config, or reading data from some reference table.
+Oracle config, or reading data from some reference table. Method returns Spark DataFrame.
 
 Method accepts :obj:`JDBCOptions <onetl.connection.db_connection.jdbc_mixin.options.JDBCOptions>`.
 
-Connection opened using this method should be then closed with :obj:`Oracle.close <onetl.connection.db_connection.oracle.connection.Oracle.close>`.
+Connection opened using this method should be then closed with ``connection.close()`` or ``with connection:``.
+
+.. warning::
+
+    Please take into account :ref:`oracle-types`.
 
 Syntax support
 ^^^^^^^^^^^^^^
@@ -45,14 +55,14 @@ Examples
     oracle.close()
     value = df.collect()[0][0]  # get value from first row and first column
 
-Use :obj:`Oracle.execute <onetl.connection.db_connection.oracle.connection.Oracle.execute>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Use ``Oracle.execute``
+~~~~~~~~~~~~~~~~~~~~~~
 
 Use this method to execute DDL and DML operations. Each method call runs operation in a separated transaction, and then commits it.
 
 Method accepts :obj:`JDBCOptions <onetl.connection.db_connection.jdbc_mixin.options.JDBCOptions>`.
 
-Connection opened using this method should be then closed with :obj:`Oracle.close <onetl.connection.db_connection.oracle.connection.Oracle.close>`.
+Connection opened using this method should be then closed with ``connection.close()`` or ``with connection:``.
 
 Syntax support
 ^^^^^^^^^^^^^^
@@ -61,7 +71,7 @@ This method supports **any** query syntax supported by Oracle, like:
 
 * ✅︎ ``CREATE TABLE ...``, ``CREATE VIEW ...``
 * ✅︎ ``ALTER ...``
-* ✅︎ ``INSERT INTO ... AS SELECT ...``
+* ✅︎ ``INSERT INTO ... SELECT ...``, ``UPDATE ...``, ``DELETE ...``, and so on
 * ✅︎ ``DROP TABLE ...``, ``DROP VIEW ...``, and so on
 * ✅︎ ``CALL procedure(arg1, arg2) ...`` or ``{call procedure(arg1, arg2)}`` - special syntax for calling procedure
 * ✅︎ ``DECLARE ... BEGIN ... END`` - execute PL/SQL statement
@@ -78,6 +88,7 @@ Examples
     oracle = Oracle(...)
 
     with oracle:
+        # automatically close connection after exiting this context manager
         oracle.execute("DROP TABLE schema.table")
         oracle.execute(
             """
@@ -90,15 +101,8 @@ Examples
             options=Oracle.JDBCOptions(query_timeout=10),
         )
 
-
-References
-----------
-
-.. currentmodule:: onetl.connection.db_connection.oracle.connection
-
-.. automethod:: Oracle.fetch
-.. automethod:: Oracle.execute
-.. automethod:: Oracle.close
+Options
+-------
 
 .. currentmodule:: onetl.connection.db_connection.jdbc_mixin.options
 

--- a/docs/connection/db_connection/oracle/read.rst
+++ b/docs/connection/db_connection/oracle/read.rst
@@ -3,12 +3,12 @@
 Reading from Oracle using ``DBReader``
 ======================================
 
+:obj:`DBReader <onetl.db.db_reader.db_reader.DBReader>` supports :ref:`strategy` for incremental data reading,
+but does not support custom queries, like ``JOIN``.
+
 .. warning::
 
     Please take into account :ref:`oracle-types`
-
-:obj:`DBReader <onetl.db.db_reader.db_reader.DBReader>` supports :ref:`strategy` for incremental data reading,
-but does not support custom queries, like JOINs.
 
 Supported DBReader features
 ---------------------------
@@ -69,8 +69,23 @@ Incremental strategy:
     with IncrementalStrategy():
         df = reader.run()
 
-Read options
-------------
+Recommendations
+---------------
+
+Select only required columns
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Instead of passing ``"*"`` in ``DBReader(columns=[...])`` prefer passing exact column names. This reduces the amount of data passed from Oracle to Spark.
+
+Pay attention to ``where`` value
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Instead of filtering data on Spark side using ``df.filter(df.column == 'value')`` pass proper ``DBReader(where="column = 'value'")`` clause.
+This both reduces the amount of data send from Oracle to Spark, and may also improve performance of the query.
+Especially if there are indexes or partitions for columns used in ``where`` clause.
+
+Options
+-------
 
 .. currentmodule:: onetl.connection.db_connection.jdbc_connection.options
 

--- a/docs/connection/db_connection/oracle/sql.rst
+++ b/docs/connection/db_connection/oracle/sql.rst
@@ -3,14 +3,16 @@
 Reading from Oracle using ``Oracle.sql``
 ========================================
 
+``Oracle.sql`` allows passing custom SQL query, but does not support incremental strategies.
+
 .. warning::
 
     Please take into account :ref:`oracle-types`
 
-:obj:`Oracle.sql <onetl.connection.db_connection.oracle.connection.Oracle.sql>` allows passing custom SQL query,
-but does not support incremental strategies.
+.. warning::
 
-Method also accepts :obj:`JDBCReadOptions <onetl.connection.db_connection.jdbc.options.JDBCReadOptions>`.
+    Statement is executed in **read-write** connection, so if you're calling some functions/procedures with DDL/DML statements inside,
+    they can change data in your database.
 
 Syntax support
 --------------
@@ -42,12 +44,26 @@ Examples
         WHERE
             key = 'something'
         """,
-        options=Oracle.ReadOptions(partition_column="id", num_partitions=10),
+        options=Oracle.ReadOptions(
+            partition_column="id",
+            num_partitions=10,
+            lower_bound=0,
+            upper_bound=1000,
+        ),
     )
 
-References
-----------
+Recommendations
+---------------
 
-.. currentmodule:: onetl.connection.db_connection.oracle.connection
+Select only required columns
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. automethod:: Oracle.sql
+Instead of passing ``SELECT * FROM ...`` prefer passing exact column names ``SELECT col1, col2, ...``.
+This reduces the amount of data passed from Oracle to Spark.
+
+Pay attention to ``where`` value
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Instead of filtering data on Spark side using ``df.filter(df.column == 'value')`` pass proper ``WHERE column = 'value'`` clause.
+This both reduces the amount of data send from Oracle to Spark, and may also improve performance of the query.
+Especially if there are indexes or partitions for columns used in ``where`` clause.

--- a/docs/connection/db_connection/oracle/write.rst
+++ b/docs/connection/db_connection/oracle/write.rst
@@ -11,7 +11,7 @@ For writing data to Oracle, use :obj:`DBWriter <onetl.db.db_writer.db_writer.DBW
 
 .. warning::
 
-    It is always recommended to create table explicitly using :obj:`Oracle.execute <onetl.connection.db_connection.oracle.connection.Oracle.execute>`
+    It is always recommended to create table explicitly using :ref:`Oracle.execute <oracle-execute>`
     instead of relying on Spark's table DDL generation.
 
     This is because Spark's DDL generator can create columns with different precision and types than it is expected,
@@ -37,9 +37,8 @@ Examples
 
     writer.run(df)
 
-
-Write options
--------------
+Options
+-------
 
 Method above accepts  :obj:`JDBCWriteOptions <onetl.connection.db_connection.jdbc.options.JDBCWriteOptions>`
 

--- a/docs/connection/db_connection/postgres/execute.rst
+++ b/docs/connection/db_connection/postgres/execute.rst
@@ -3,20 +3,30 @@
 Executing statements in Postgres
 ================================
 
+.. warning::
+
+    Methods below **read all the rows** returned from DB **to Spark driver memory**, and then convert them to DataFrame.
+
+    Do **NOT** use them to read large amounts of data. Use :ref:`DBReader <postgres-read>` or :ref:`Postgres.sql <postgres-sql>` instead.
+
 How to
 ------
 
 There are 2 ways to execute some statement in Postgres
 
-Use :obj:`Postgres.fetch <onetl.connection.db_connection.postgres.connection.Postgres.fetch>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Use ``Postgres.fetch``
+~~~~~~~~~~~~~~~~~~~~~~
 
 Use this method to execute some ``SELECT`` query which returns **small number or rows**, like reading
-Postgres config, or reading data from some reference table.
+Postgres config, or reading data from some reference table. Method returns Spark DataFrame.
 
 Method accepts :obj:`JDBCOptions <onetl.connection.db_connection.jdbc_mixin.options.JDBCOptions>`.
 
-Connection opened using this method should be then closed with :obj:`Postgres.close <onetl.connection.db_connection.postgres.connection.Postgres.close>`.
+Connection opened using this method should be then closed with ``connection.close()`` or ``with connection:``.
+
+.. warning::
+
+    Please take into account :ref:`postgres-types`.
 
 Syntax support
 ^^^^^^^^^^^^^^
@@ -43,23 +53,23 @@ Examples
     postgres.close()
     value = df.collect()[0][0]  # get value from first row and first column
 
-Use :obj:`Postgres.execute <onetl.connection.db_connection.postgres.connection.Postgres.execute>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Use ``Postgres.execute``
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 Use this method to execute DDL and DML operations. Each method call runs operation in a separated transaction, and then commits it.
 
 Method accepts :obj:`JDBCOptions <onetl.connection.db_connection.jdbc_mixin.options.JDBCOptions>`.
 
-Connection opened using this method should be then closed with :obj:`Postgres.close <onetl.connection.db_connection.postgres.connection.Postgres.close>`.
+Connection opened using this method should be then closed with ``connection.close()`` or ``with connection:``.
 
 Syntax support
 ^^^^^^^^^^^^^^
 
 This method supports **any** query syntax supported by Postgres, like:
 
-* ✅︎ ``CREATE TABLE ...``, ``CREATE VIEW ...``, and so on
+* ✅︎ ``CREATE TABLE ...``, ``CREATE VIEW ...``, ``DROP TABLE ...``, and so on
 * ✅︎ ``ALTER ...``
-* ✅︎ ``INSERT INTO ... AS SELECT ...``
+* ✅︎ ``INSERT INTO ... SELECT ...``, ``UPDATE ...``, ``DELETE ...``, and so on
 * ✅︎ ``DROP TABLE ...``, ``DROP VIEW ...``, and so on
 * ✅︎ ``CALL procedure(arg1, arg2) ...``
 * ✅︎ ``SELECT func(arg1, arg2)`` or ``{call func(arg1, arg2)}`` - special syntax for calling functions
@@ -76,6 +86,7 @@ Examples
     postgres = Postgres(...)
 
     with postgres:
+        # automatically close connection after exiting this context manager
         postgres.execute("DROP TABLE schema.table")
         postgres.execute(
             """
@@ -88,15 +99,8 @@ Examples
             options=Postgres.JDBCOptions(query_timeout=10),
         )
 
-
-References
-----------
-
-.. currentmodule:: onetl.connection.db_connection.postgres.connection
-
-.. automethod:: Postgres.fetch
-.. automethod:: Postgres.execute
-.. automethod:: Postgres.close
+Options
+-------
 
 .. currentmodule:: onetl.connection.db_connection.jdbc_mixin.options
 

--- a/docs/connection/db_connection/postgres/read.rst
+++ b/docs/connection/db_connection/postgres/read.rst
@@ -3,12 +3,12 @@
 Reading from Postgres using ``DBReader``
 ========================================
 
+:obj:`DBReader <onetl.db.db_reader.db_reader.DBReader>` supports :ref:`strategy` for incremental data reading,
+but does not support custom queries, like ``JOIN``.
+
 .. warning::
 
     Please take into account :ref:`postgres-types`
-
-:obj:`DBReader <onetl.db.db_reader.db_reader.DBReader>` supports :ref:`strategy` for incremental data reading,
-but does not support custom queries, like JOINs.
 
 Supported DBReader features
 ---------------------------
@@ -67,8 +67,23 @@ Incremental strategy:
     with IncrementalStrategy():
         df = reader.run()
 
-Read options
-------------
+Recommendations
+---------------
+
+Select only required columns
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Instead of passing ``"*"`` in ``DBReader(columns=[...])`` prefer passing exact column names. This reduces the amount of data passed from Postgres to Spark.
+
+Pay attention to ``where`` value
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Instead of filtering data on Spark side using ``df.filter(df.column == 'value')`` pass proper ``DBReader(where="column = 'value'")`` clause.
+This both reduces the amount of data send from Postgres to Spark, and may also improve performance of the query.
+Especially if there are indexes or partitions for columns used in ``where`` clause.
+
+Options
+-------
 
 .. currentmodule:: onetl.connection.db_connection.jdbc_connection.options
 

--- a/docs/connection/db_connection/postgres/sql.rst
+++ b/docs/connection/db_connection/postgres/sql.rst
@@ -3,14 +3,16 @@
 Reading from Postgres using ``Postgres.sql``
 ============================================
 
+``Postgres.sql`` allows passing custom SQL query, but does not support incremental strategies.
+
 .. warning::
 
     Please take into account :ref:`postgres-types`
 
-:obj:`Postgres.sql <onetl.connection.db_connection.postgres.connection.Postgres.sql>` allows passing custom SQL query,
-but does not support incremental strategies.
+.. warning::
 
-Method also accepts :obj:`JDBCReadOptions <onetl.connection.db_connection.jdbc.options.JDBCReadOptions>`.
+    Statement is executed in **read-write** connection, so if you're calling some functions/procedures with DDL/DML statements inside,
+    they can change data in your database.
 
 Syntax support
 --------------
@@ -41,12 +43,26 @@ Examples
         WHERE
             key = 'something'
         """,
-        options=Postgres.ReadOptions(partition_column="id", num_partitions=10),
+        options=Postgres.ReadOptions(
+            partition_column="id",
+            num_partitions=10,
+            lower_bound=0,
+            upper_bound=1000,
+        ),
     )
 
-References
-----------
+Recommendations
+---------------
 
-.. currentmodule:: onetl.connection.db_connection.postgres.connection
+Select only required columns
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. automethod:: Postgres.sql
+Instead of passing ``SELECT * FROM ...`` prefer passing exact column names ``SELECT col1, col2, ...``.
+This reduces the amount of data passed from Postgres to Spark.
+
+Pay attention to ``where`` value
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Instead of filtering data on Spark side using ``df.filter(df.column == 'value')`` pass proper ``WHERE column = 'value'`` clause.
+This both reduces the amount of data send from Postgres to Spark, and may also improve performance of the query.
+Especially if there are indexes or partitions for columns used in ``where`` clause.

--- a/docs/connection/db_connection/postgres/write.rst
+++ b/docs/connection/db_connection/postgres/write.rst
@@ -11,7 +11,7 @@ For writing data to Postgres, use :obj:`DBWriter <onetl.db.db_writer.db_writer.D
 
 .. warning::
 
-    It is always recommended to create table explicitly using :obj:`Postgres.execute <onetl.connection.db_connection.postgres.connection.Postgres.execute>`
+    It is always recommended to create table explicitly using :ref:`Postgres.execute <postgres-execute>`
     instead of relying on Spark's table DDL generation.
 
     This is because Spark's DDL generator can create columns with different precision and types than it is expected,
@@ -37,9 +37,8 @@ Examples
 
     writer.run(df)
 
-
-Write options
--------------
+Options
+-------
 
 Method above accepts  :obj:`JDBCWriteOptions <onetl.connection.db_connection.jdbc.options.JDBCWriteOptions>`
 

--- a/docs/connection/db_connection/teradata/execute.rst
+++ b/docs/connection/db_connection/teradata/execute.rst
@@ -3,11 +3,103 @@
 Executing statements in Teradata
 ================================
 
-.. currentmodule:: onetl.connection.db_connection.teradata.connection
+.. warning::
 
-.. automethod:: Teradata.fetch
-.. automethod:: Teradata.execute
-.. automethod:: Teradata.close
+    Methods below **read all the rows** returned from DB **to Spark driver memory**, and then convert them to DataFrame.
+
+    Do **NOT** use them to read large amounts of data. Use :ref:`DBReader <teradata-read>` or :ref:`Teradata.sql <teradata-sql>` instead.
+
+How to
+------
+
+There are 2 ways to execute some statement in Teradata
+
+Use ``Teradata.fetch``
+~~~~~~~~~~~~~~~~~~~~~~
+
+Use this method to execute some ``SELECT`` query which returns **small number or rows**, like reading
+Teradata config, or reading data from some reference table. Method returns Spark DataFrame.
+
+Method accepts :obj:`JDBCOptions <onetl.connection.db_connection.jdbc_mixin.options.JDBCOptions>`.
+
+Connection opened using this method should be then closed with ``connection.close()`` or ``with connection:``.
+
+Syntax support
+^^^^^^^^^^^^^^
+
+This method supports **any** query syntax supported by Teradata, like:
+
+* ✅︎ ``SELECT ... FROM ...``
+* ✅︎ ``WITH alias AS (...) SELECT ...``
+* ✅︎ ``SHOW ...``
+* ❌ ``SET ...; SELECT ...;`` - multiple statements not supported
+
+Examples
+^^^^^^^^
+
+.. code-block:: python
+
+    from onetl.connection import Teradata
+
+    teradata = Teradata(...)
+
+    df = teradata.fetch(
+        "SELECT value FROM some.reference_table WHERE key = 'some_constant'",
+        options=Teradata.JDBCOptions(query_timeout=10),
+    )
+    teradata.close()
+    value = df.collect()[0][0]  # get value from first row and first column
+
+Use ``Teradata.execute``
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use this method to execute DDL and DML operations. Each method call runs operation in a separated transaction, and then commits it.
+
+Method accepts :obj:`JDBCOptions <onetl.connection.db_connection.jdbc_mixin.options.JDBCOptions>`.
+
+Connection opened using this method should be then closed with ``connection.close()`` or ``with connection:``.
+
+Syntax support
+^^^^^^^^^^^^^^
+
+This method supports **any** query syntax supported by Teradata, like:
+
+* ✅︎ ``CREATE TABLE ...``, ``CREATE VIEW ...``, ``DROP TABLE ...``, and so on
+* ✅︎ ``ALTER ...``
+* ✅︎ ``INSERT INTO ... SELECT ...``, ``UPDATE ...``, ``DELETE ...``, and so on
+* ✅︎ ``DROP TABLE ...``, ``DROP VIEW ...``, and so on
+* ✅︎ ``CALL procedure(arg1, arg2) ...`` or ``{call procedure(arg1, arg2)}`` - special syntax for calling procedure
+* ✅︎ ``EXECUTE macro(arg1, arg2)``
+* ✅︎ ``EXECUTE FUNCTION ...``
+* ✅︎ other statements not mentioned here
+* ❌ ``SET ...; SELECT ...;`` - multiple statements not supported
+
+Examples
+^^^^^^^^
+
+.. code-block:: python
+
+    from onetl.connection import Teradata
+
+    teradata = Teradata(...)
+
+    with teradata:
+        # automatically close connection after exiting this context manager
+        teradata.execute("DROP TABLE database.table")
+        teradata.execute(
+            """
+            CREATE MULTISET TABLE database.table AS (
+                id BIGINT,
+                key VARCHAR,
+                value REAL
+            )
+            NO PRIMARY INDEX
+            """,
+            options=Teradata.JDBCOptions(query_timeout=10),
+        )
+
+Options
+-------
 
 .. currentmodule:: onetl.connection.db_connection.jdbc_mixin.options
 

--- a/docs/connection/db_connection/teradata/index.rst
+++ b/docs/connection/db_connection/teradata/index.rst
@@ -7,6 +7,7 @@ Teradata
     :maxdepth: 1
     :caption: Connection
 
+    prerequisites
     connection
 
 .. toctree::
@@ -14,5 +15,6 @@ Teradata
     :caption: Operations
 
     read
+    sql
     write
     execute

--- a/docs/connection/db_connection/teradata/prerequisites.rst
+++ b/docs/connection/db_connection/teradata/prerequisites.rst
@@ -1,0 +1,60 @@
+.. _teradata-prerequisites:
+
+Prerequisites
+=============
+
+Version Compatibility
+---------------------
+
+* Teradata server versions: 16.10 - 20.0
+* Spark versions: 2.3.x - 3.5.x
+* Java versions: 8 - 20
+
+See `official documentation <https://teradata-docs.s3.amazonaws.com/doc/connectivity/jdbc/reference/current/platformMatrix.html>`_.
+
+Installing PySpark
+------------------
+
+To use Teradata connector you should have PySpark installed (or injected to ``sys.path``)
+BEFORE creating the connector instance.
+
+See :ref:`install-spark` installation instruction for more details.
+
+Connecting to Teradata
+-----------------------
+
+Connection host
+~~~~~~~~~~~~~~~
+
+It is possible to connect to Teradata by using either DNS name Parsing Engine (PE) host, or it's IP address.
+
+Connection port
+~~~~~~~~~~~~~~~
+
+Connection is usually performed to port ``1025``. Port may differ for different Teradata instances.
+Please ask your Teradata administrator to provide required information.
+
+Required grants
+~~~~~~~~~~~~~~~
+
+Ask your Teradata cluster administrator to set following grants for a user,
+used for creating a connection:
+
+.. tabs::
+
+    .. code-tab:: sql Read + Write
+
+        -- allow creating tables in the target schema
+        GRANT CREATE TABLE ON database TO username;
+
+        -- allow read & write access to specific table
+        GRANT SELECT, INSERT ON database.mytable TO username;
+
+    .. code-tab:: sql Read only
+
+        -- allow read access to specific table
+        GRANT SELECT ON database.mytable TO username;
+
+See:
+    * `Teradata access rights <https://www.dwhpro.com/teradata-access-rights/>`_
+    * `GRANT documentation <https://teradata.github.io/presto/docs/0.167-t/sql/grant.html>`_

--- a/docs/connection/db_connection/teradata/read.rst
+++ b/docs/connection/db_connection/teradata/read.rst
@@ -1,18 +1,119 @@
 .. _teradata-read:
 
-Reading from Teradata
-=====================
+Reading from Teradata using ``DBReader``
+========================================
 
-There are 2 ways of distributed data reading from Teradata:
+:obj:`DBReader <onetl.db.db_reader.db_reader.DBReader>` supports :ref:`strategy` for incremental data reading,
+but does not support custom queries, like ``JOIN``.
 
-* Using :obj:`DBReader <onetl.db.db_reader.db_reader.DBReader>` with different :ref:`strategy`
-* Using :obj:`Teradata.sql <onetl.connection.db_connection.teradata.connection.Teradata.sql>`
+Supported DBReader features
+---------------------------
 
-Both methods accept :obj:`JDBCReadOptions <onetl.connection.db_connection.jdbc.options.JDBCReadOptions>`
+* ✅︎ ``columns``
+* ✅︎ ``where``
+* ✅︎ ``hwm``, supported strategies:
+* * ✅︎ :ref:`snapshot-strategy`
+* * ✅︎ :ref:`incremental-strategy`
+* * ✅︎ :ref:`snapshot-batch-strategy`
+* * ✅︎ :ref:`incremental-batch-strategy`
+* ❌ ``hint`` (is not supported by Teradata)
+* ❌ ``df_schema``
+* ✅︎ ``options`` (see :obj:`JDBCReadOptions <onetl.connection.db_connection.jdbc.options.JDBCReadOptions>`)
 
-.. currentmodule:: onetl.connection.db_connection.teradata.connection
+Examples
+--------
 
-.. automethod:: Teradata.sql
+Snapshot strategy:
+
+.. code-block:: python
+
+    from onetl.connection import Teradata
+    from onetl.db import DBReader
+
+    teradata = Teradata(...)
+
+    reader = DBReader(
+        connection=teradata,
+        source="database.table",
+        columns=["id", "key", "CAST(value AS VARCHAR) value", "updated_dt"],
+        where="key = 'something'",
+        options=Teradata.ReadOptions(
+            partition_column="id",
+            num_partitions=10,
+            partitioning_mode="hash",
+        ),
+    )
+    df = reader.run()
+
+Incremental strategy:
+
+.. code-block:: python
+
+    from onetl.connection import Teradata
+    from onetl.db import DBReader
+    from onetl.strategy import IncrementalStrategy
+
+    teradata = Teradata(...)
+
+    reader = DBReader(
+        connection=teradata,
+        source="database.table",
+        columns=["id", "key", "CAST(value AS VARCHAR) value", "updated_dt"],
+        where="key = 'something'",
+        hwm=DBReader.AutoDetectHWM(name="teradata_hwm", expression="updated_dt"),
+        options=Teradata.ReadOptions(
+            partition_column="id",
+            num_partitions=10,
+            partitioning_mode="hash",
+        ),
+    )
+
+    with IncrementalStrategy():
+        df = reader.run()
+
+Recommendations
+---------------
+
+Select only required columns
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Instead of passing ``"*"`` in ``DBReader(columns=[...])`` prefer passing exact column names. This reduces the amount of data passed from Teradata to Spark.
+
+Pay attention to ``where`` value
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Instead of filtering data on Spark side using ``df.filter(df.column == 'value')`` pass proper ``DBReader(where="column = 'value'")`` clause.
+This both reduces the amount of data send from Teradata to Spark, and may also improve performance of the query.
+Especially if there are indexes or partitions for columns used in ``where`` clause.
+
+Read data in parallel
+~~~~~~~~~~~~~~~~~~~~~
+
+``DBReader`` can read data in multiple parallel connections by passing ``Teradata.ReadOptions(num_partitions=..., partition_column=...)``.
+
+In the example above, Spark opens 10 parallel connections, and data is evenly distributed between all these connections using expression
+``HASHAMP(HASHBUCKET(HASHROW({partition_column}))) MOD {num_partitions}``.
+This allows sending each Spark worker only some piece of data, reducing resource consumption.
+``partition_column`` here can be table column of any type.
+
+It is also possible to use ``partitioning_mode="mod"`` or ``partitioning_mode="range"``, but in this case
+``partition_column`` have to be an integer, should not contain ``NULL``, and values to be uniformly distributed.
+It is also less performant than ``partitioning_mode="hash"`` due to Teradata ``HASHAMP`` implementation.
+
+Do **NOT** use ``TYPE=FASTEXPORT``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Teradata supports several `different connection types <https://teradata-docs.s3.amazonaws.com/doc/connectivity/jdbc/reference/current/jdbcug_chapter_2.html#BABFGFAF>`_:
+    * ``TYPE=DEFAULT`` - perform plain ``SELECT`` queries
+    * ``TYPE=FASTEXPORT`` - uses special FastExport protocol for select queries
+
+But ``TYPE=FASTEXPORT`` uses exclusive lock on the source table, so it is impossible to use multiple Spark workers parallel data read.
+This leads to sending all the data to just one Spark worker, which is slow and takes a lot of RAM.
+
+Prefer using ``partitioning_mode="hash"`` from example above.
+
+Options
+-------
 
 .. currentmodule:: onetl.connection.db_connection.jdbc_connection.options
 

--- a/docs/connection/db_connection/teradata/write.rst
+++ b/docs/connection/db_connection/teradata/write.rst
@@ -1,9 +1,116 @@
 .. _teradata-write:
 
-Writing to Teradata
-===================
+Writing to Teradata using ``DBWriter``
+======================================
 
-For writing data to Teradata, use :obj:`DBWriter <onetl.db.db_writer.db_writer.DBWriter>` with options below.
+For writing data to Teradata, use :obj:`DBWriter <onetl.db.db_writer.db_writer.DBWriter>`.
+
+.. warning::
+
+    It is always recommended to create table explicitly using :ref:`Teradata.execute <teradata-execute>`
+    instead of relying on Spark's table DDL generation.
+
+    This is because Spark's DDL generator can create columns with different precision and types than it is expected,
+    causing precision loss or other issues.
+
+Examples
+--------
+
+.. code-block:: python
+
+    from onetl.connection import Teradata
+    from onetl.db import DBWriter
+
+    teradata = Teradata(
+        ...,
+        extra={"TYPE": "FASTLOAD", "TMODE": "TERA"},
+    )
+
+    df = ...  # data is here
+
+    writer = DBWriter(
+        connection=teradata,
+        target="database.table",
+        options=Teradata.WriteOptions(
+            if_exists="append",
+            # avoid creating SET table, use MULTISET
+            createTableOptions="NO PRIMARY INDEX",
+        ),
+    )
+
+    writer.run(df.repartition(1))
+
+Recommendations
+---------------
+
+Number of connections
+~~~~~~~~~~~~~~~~~~~~~
+
+Teradata is not MVCC based, so write operations take exclusive lock on the entire table.
+So **it is impossible to write data to Teradata table in multiple parallel connections**, no exceptions.
+
+The only way to write to Teradata without making deadlocks is write dataframe with exactly 1 partition.
+
+It can be implemented using ``df.repartition(1)``:
+
+.. code-block:: python
+
+    # do NOT use df.coalesce(1) as it can freeze
+    writer.run(df.repartition(1))
+
+This moves all the data to just one Spark worker, so it may consume a lot of RAM. It is usually require to increase ``spark.executor.memory`` to handle this.
+
+Another way is to write all dataframe partitions one-by-one:
+
+.. code-block:: python
+
+    from pyspark.sql.functions import spark_partition_id
+
+    # get list of all partitions in the dataframe
+    partitions = sorted(df.select(spark_partition_id()).distinct().collect())
+
+    for partition in partitions:
+        # get only part of data within this exact partition
+        part_df = df.where(**partition.asDict()).coalesce(1)
+
+        writer.run(part_df)
+
+This require even data distribution for all partitions to avoid data skew and spikes of RAM consuming.
+
+Choosing connection type
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Teradata supports several `different connection types <https://teradata-docs.s3.amazonaws.com/doc/connectivity/jdbc/reference/current/jdbcug_chapter_2.html#BABFGFAF>`_:
+    * ``TYPE=DEFAULT`` - perform plain ``INSERT`` queries
+    * ``TYPE=FASTLOAD`` - uses special FastLoad protocol for insert queries
+
+It is always recommended to use ``TYPE=FASTLOAD`` because:
+    * It provides higher performance
+    * It properly handles inserting ``NULL`` values (``TYPE=DEFAULT`` raises an exception)
+
+But it can be used only during write, not read.
+
+Choosing transaction mode
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Teradata supports `2 different transaction modes <https://teradata-docs.s3.amazonaws.com/doc/connectivity/jdbc/reference/current/jdbcug_chapter_2.html#TMODESEC>`_:
+    * ``TMODE=ANSI``
+    * ``TMODE=TERA``
+
+Choosing one of the modes can alter connector behavior. For example:
+    * Inserting data which exceeds table column length, like insert ``CHAR(25)`` to column with type ``CHAR(24)``:
+    * * ``TMODE=ANSI`` - raises exception
+    * * ``TMODE=TERA`` - truncates input string to 24 symbols
+    * Creating table using Spark:
+    * * ``TMODE=ANSI`` - creates ``MULTISET`` table
+    * * ``TMODE=TERA`` - creates ``SET`` table with ``PRIMARY KEY`` is a first column in dataframe.
+        This can lead to slower insert time, because each row will be checked against a unique index.
+        Fortunately, this can be disabled by passing custom ``createTableOptions``.
+
+Options
+-------
+
+Method above accepts  :obj:`JDBCWriteOptions <onetl.connection.db_connection.jdbc.options.JDBCWriteOptions>`
 
 .. currentmodule:: onetl.connection.db_connection.jdbc_connection.options
 

--- a/onetl/connection/db_connection/hive/options.py
+++ b/onetl/connection/db_connection/hive/options.py
@@ -82,8 +82,8 @@ class HiveWriteOptions(GenericOptions):
 
         options = Hive.WriteOptions(
             if_exists="append",
-            partitionBy="reg_id",
-            someNewOption="value",
+            partition_by="reg_id",
+            customOption="value",
         )
     """
 

--- a/onetl/connection/db_connection/jdbc_connection/connection.py
+++ b/onetl/connection/db_connection/jdbc_connection/connection.py
@@ -68,61 +68,21 @@ class JDBCConnection(JDBCMixin, DBConnection):
 
         Same as ``spark.read.jdbc(query)``.
 
-        .. note::
-
-            This method does not support :ref:`strategy`,
-            use :obj:`DBReader <onetl.db.db_reader.db_reader.DBReader>` instead
-
-        .. note::
-
-            Statement is executed in read-write connection,
-            so if you're calling some functions/procedures with DDL/DML statements inside,
-            they can change data in your database.
-
-            Unfortunately, Spark does no provide any option to change this behavior.
-
         Parameters
         ----------
         query : str
 
             SQL query to be executed.
 
-            Only ``SELECT ... FROM ...`` form is supported.
-
-            Some databases also supports ``WITH ... AS (...) SELECT ... FROM ...`` form.
-
-            Queries like ``SHOW ...`` are not supported.
-
-            .. warning::
-
-                The exact syntax **depends on RDBMS** is being used.
-
         options : dict, :obj:`~ReadOptions`, default: ``None``
 
-            Spark options to be used while fetching data, like ``fetchsize`` or ``partitionColumn``
+            Spark options to be used while fetching data.
 
         Returns
         -------
         df : pyspark.sql.dataframe.DataFrame
 
             Spark dataframe
-
-        Examples
-        --------
-
-        Read data from a table:
-
-        .. code:: python
-
-            df = connection.sql("SELECT * FROM mytable")
-
-        Read data from a table with options:
-
-        .. code:: python
-
-            # reads data from table in batches, 10000 rows per batch
-            df = connection.sql("SELECT * FROM mytable", {"fetchsize": 10000})
-            assert df.count()
 
         """
 

--- a/onetl/connection/db_connection/jdbc_connection/options.py
+++ b/onetl/connection/db_connection/jdbc_connection/options.py
@@ -123,11 +123,11 @@ class JDBCReadOptions(JDBCOptions):
     .. code:: python
 
         options = JDBC.ReadOptions(
-            partitionColumn="reg_id",
-            numPartitions=10,
-            lowerBound=0,
-            upperBound=1000,
-            someNewOption="value",
+            partition_column="reg_id",
+            num_partitions=10,
+            lower_bound=0,
+            upper_bound=1000,
+            customOption="value",
         )
     """
 
@@ -390,7 +390,7 @@ class JDBCWriteOptions(JDBCOptions):
 
     .. code:: python
 
-        options = JDBC.WriteOptions(if_exists="append", batchsize=20_000, someNewOption="value")
+        options = JDBC.WriteOptions(if_exists="append", batchsize=20_000, customOption="value")
     """
 
     class Config:

--- a/onetl/connection/db_connection/teradata/connection.py
+++ b/onetl/connection/db_connection/teradata/connection.py
@@ -32,29 +32,9 @@ class Teradata(JDBCConnection):
     Based on package ``com.teradata.jdbc:terajdbc:17.20.00.15``
     (`official Teradata JDBC driver <https://downloads.teradata.com/download/connectivity/jdbc-driver>`_).
 
-    .. dropdown:: Version compatibility
-
-        * Teradata server versions: 16.10 - 20.0
-        * Spark versions: 2.3.x - 3.5.x
-        * Java versions: 8 - 20
-
-        See `official documentation <https://teradata-docs.s3.amazonaws.com/doc/connectivity/jdbc/reference/current/platformMatrix.html>`_.
-
     .. warning::
 
-        To use Teradata connector you should have PySpark installed (or injected to ``sys.path``)
-        BEFORE creating the connector instance.
-
-        You can install PySpark as follows:
-
-        .. code:: bash
-
-            pip install onetl[spark]  # latest PySpark version
-
-            # or
-            pip install onetl pyspark=3.5.0  # pass specific PySpark version
-
-        See :ref:`install-spark` installation instruction for more details.
+        Before using this connector please take into account :ref:`teradata-prerequisites`
 
     Parameters
     ----------
@@ -92,10 +72,10 @@ class Teradata(JDBCConnection):
             By default, these options are added to extra:
 
                 * ``CHARSET = "UTF8"``
-                * ``COLUMN_NAME = "ON"``
-                * ``FLATTEN = "ON"``
+                * ``COLUMN_NAME = "ON"`` - allow reading column title from a table
+                * ``FLATTEN = "ON"`` - improves error messages
                 * ``MAYBENULL = "ON"``
-                * ``STRICT_NAMES = "OFF"``
+                * ``STRICT_NAMES = "OFF"`` - ignore Spark options passed to JDBC URL
 
             It is possible to override default values, for example set ``extra={"FLATTEN": "OFF"}``
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

<!-- Please give a short summary of the changes. -->

* Sync Teradata documentation structure and content with other databases, like Clickhouse, Oracle, Postgres - see #233, #234, #229
* Add `Recommendations` to reading documentation of each connector
* Remove examples from `JDBC.fetch`, `JDBC.execute`, `JDBC.sql` documentation, because now there are separated examples for each JDBC database.

See https://onetl--240.org.readthedocs.build/en/240/connection/db_connection/teradata/index.html

For now, there is no page with type compatibility between Teradata and Spark, it may be added in the future.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [ ] Tests pass on CI and coverage does not decrease
* [X] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
