### PR TITLE
[DOP-13851] - upgrade MySql packages

### DIFF
--- a/docs/changelog/next_release/253.feature.rst
+++ b/docs/changelog/next_release/253.feature.rst
@@ -1,0 +1,1 @@
+:class:`MySQL` connection now uses MySQL JDBC driver ``8.3.0``, upgraded from ``8.0.33``, and supports passing custom versions: ``MySQL.get_packages(package_version=...)``.

--- a/onetl/connection/db_connection/mysql/connection.py
+++ b/onetl/connection/db_connection/mysql/connection.py
@@ -6,6 +6,7 @@ import warnings
 from typing import ClassVar, Optional
 
 from onetl._util.classproperty import classproperty
+from onetl._util.version import Version
 from onetl.connection.db_connection.jdbc_connection import JDBCConnection
 from onetl.connection.db_connection.mysql.dialect import MySQLDialect
 from onetl.hooks import slot, support_hooks
@@ -104,28 +105,37 @@ class MySQL(JDBCConnection):
 
     @slot
     @classmethod
-    def get_packages(cls) -> list[str]:
+    def get_packages(cls, package_version: str | None = None) -> list[str]:
         """
-        Get package names to be downloaded by Spark. |support_hooks|
+        Get package names to be downloaded by Spark. Allows specifying a custom JDBC driver version for MySQL. |support_hooks|
+
+        Parameters
+        ----------
+        package_version : str, optional
+            Specifies the version of the MySQL JDBC driver to use. Defaults to ``8.3.0``.
 
         Examples
         --------
-
         .. code:: python
 
             from onetl.connection import MySQL
 
             MySQL.get_packages()
 
+            # specify a custom package version
+            MySQL.get_packages(package_version="8.2.0")
         """
-        return ["com.mysql:mysql-connector-j:8.0.33"]
+        default_version = "8.3.0"
+        version = Version(package_version or default_version).min_digits(3)
+
+        return [f"com.mysql:mysql-connector-j:{version}"]
 
     @classproperty
     def package(cls) -> str:
         """Get package name to be downloaded by Spark."""
         msg = "`MySQL.package` will be removed in 1.0.0, use `MySQL.get_packages()` instead"
         warnings.warn(msg, UserWarning, stacklevel=3)
-        return "com.mysql:mysql-connector-j:8.0.33"
+        return "com.mysql:mysql-connector-j:8.3.0"
 
     @property
     def jdbc_url(self):

--- a/tests/tests_unit/tests_db_connection_unit/test_mysql_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_mysql_unit.py
@@ -14,11 +14,35 @@ def test_mysql_class_attributes():
 def test_mysql_package():
     warning_msg = re.escape("will be removed in 1.0.0, use `MySQL.get_packages()` instead")
     with pytest.warns(UserWarning, match=warning_msg):
-        assert MySQL.package == "com.mysql:mysql-connector-j:8.0.33"
+        assert MySQL.package == "com.mysql:mysql-connector-j:8.3.0"
 
 
-def test_mysql_get_packages():
-    assert MySQL.get_packages() == ["com.mysql:mysql-connector-j:8.0.33"]
+@pytest.mark.parametrize(
+    "package_version, expected_packages",
+    [
+        (None, ["com.mysql:mysql-connector-j:8.3.0"]),
+        ("8.3.0", ["com.mysql:mysql-connector-j:8.3.0"]),
+        ("8.1.0", ["com.mysql:mysql-connector-j:8.1.0"]),
+        ("8.0.33", ["com.mysql:mysql-connector-j:8.0.33"]),
+    ],
+)
+def test_mysql_get_packages(package_version, expected_packages):
+    assert MySQL.get_packages(package_version=package_version) == expected_packages
+
+
+@pytest.mark.parametrize(
+    "package_version",
+    [
+        "8.3",
+        "abc",
+    ],
+)
+def test_mysql_get_packages_invalid_version(package_version):
+    with pytest.raises(
+        ValueError,
+        match=rf"Version '{package_version}' does not have enough numeric components for requested format \(expected at least 3\).",
+    ):
+        MySQL.get_packages(package_version=package_version)
 
 
 def test_mysql_missing_package(spark_no_packages):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

- `MySQL` connection now uses MySQL JDBC driver ``8.3.0``, upgraded from ``8.0.33``, and supports passing custom versions: ``MySQL.get_packages(package_version=...)``.
- Update following documentation and tests.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [ ] Tests pass on CI and coverage does not decrease
* [x] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
