### PR TITLE
[DOP-13853] - upgrade MongoDB packages

### DIFF
--- a/docs/changelog/next_release/255.feature.rst
+++ b/docs/changelog/next_release/255.feature.rst
@@ -1,1 +1,1 @@
-:class:`MongoDB` connection now uses MongoDB Spark connector ``10.2.2``, upgraded from ``10.1.1``, and supports passing custom versions: ``MongoDB.get_packages(scala_version=..., connector_version=...)``.
+:class:`MongoDB` connection now uses MongoDB Spark connector ``10.2.2``, upgraded from ``10.1.1``, and supports passing custom versions: ``MongoDB.get_packages(scala_version=..., package_version=...)``.

--- a/docs/changelog/next_release/255.feature.rst
+++ b/docs/changelog/next_release/255.feature.rst
@@ -1,0 +1,1 @@
+:class:`MongoDB` connection now uses MongoDB Spark connector ``10.2.2``, upgraded from ``10.1.1``, and supports passing custom versions: ``MongoDB.get_packages(scala_version=..., connector_version=...)``.

--- a/onetl/connection/db_connection/mongodb/connection.py
+++ b/onetl/connection/db_connection/mongodb/connection.py
@@ -133,7 +133,7 @@ class MongoDB(DBConnection):
         cls,
         scala_version: str | None = None,
         spark_version: str | None = None,
-        connector_version: str | None = None,
+        package_version: str | None = None,
     ) -> list[str]:
         """
         Get package names to be downloaded by Spark. Allows specifying custom MongoDB Spark connector versions. |support_hooks|
@@ -148,7 +148,7 @@ class MongoDB(DBConnection):
         spark_version : str, optional
             Spark version in format ``major.minor``. Used only if ``scala_version=None``.
 
-        connector_version : str, optional
+        package_version : str, optional
             Specifies the version of the MongoDB Spark connector to use. Defaults to ``10.2.2``.
 
         Examples
@@ -160,10 +160,10 @@ class MongoDB(DBConnection):
             MongoDB.get_packages(scala_version="2.12")
 
             # specify custom connector version
-            MongoDB.get_packages(scala_version="2.12", connector_version="10.2.2")
+            MongoDB.get_packages(scala_version="2.12", package_version="10.2.2")
         """
 
-        default_connector_version = "10.2.2"
+        default_package_version = "10.2.2"
 
         if scala_version:
             scala_ver = Version(scala_version).min_digits(2)
@@ -175,10 +175,10 @@ class MongoDB(DBConnection):
         else:
             raise ValueError("You should pass either `scala_version` or `spark_version`")
 
-        connector_ver = Version(connector_version or default_connector_version).min_digits(2)
+        connector_ver = Version(package_version or default_package_version).min_digits(2)
 
-        if scala_ver < Version("2.12") or scala_ver > Version("2.13"):
-            raise ValueError(f"Scala version must be 2.12 - 2.13, got {scala_ver.format('{0}.{1}')}")
+        if scala_ver < Version("2.12"):
+            raise ValueError(f"Scala version must be at least 2.12, got {scala_ver}")
 
         return [f"org.mongodb.spark:mongo-spark-connector_{scala_ver.format('{0}.{1}')}:{connector_ver}"]
 

--- a/onetl/connection/db_connection/mongodb/connection.py
+++ b/onetl/connection/db_connection/mongodb/connection.py
@@ -131,15 +131,12 @@ class MongoDB(DBConnection):
     @classmethod
     def get_packages(
         cls,
-        scala_version: str | Version | None = None,
-        spark_version: str | Version | None = None,
+        scala_version: str | None = None,
+        spark_version: str | None = None,
+        connector_version: str | None = None,
     ) -> list[str]:
         """
-        Get package names to be downloaded by Spark. |support_hooks|
-
-        .. warning::
-
-            You should pass at least one parameter.
+        Get package names to be downloaded by Spark. Allows specifying custom MongoDB Spark connector versions. |support_hooks|
 
         Parameters
         ----------
@@ -149,23 +146,25 @@ class MongoDB(DBConnection):
             If ``None``, ``spark_version`` is used to determine Scala version.
 
         spark_version : str, optional
-            Spark version in format ``major.minor``.
+            Spark version in format ``major.minor``. Used only if ``scala_version=None``.
 
-            Used only if ``scala_version=None``.
+        connector_version : str, optional
+            Specifies the version of the MongoDB Spark connector to use. Defaults to ``10.2.2``.
 
         Examples
         --------
-
         .. code:: python
 
             from onetl.connection import MongoDB
 
             MongoDB.get_packages(scala_version="2.12")
-            MongoDB.get_packages(spark_version="3.4")
 
+            # specify custom connector version
+            MongoDB.get_packages(scala_version="2.12", connector_version="10.2.2")
         """
 
-        # Connector version is fixed, so we can perform checks for Scala/Spark version
+        default_connector_version = "10.2.2"
+
         if scala_version:
             scala_ver = Version(scala_version).min_digits(2)
         elif spark_version:
@@ -176,11 +175,12 @@ class MongoDB(DBConnection):
         else:
             raise ValueError("You should pass either `scala_version` or `spark_version`")
 
+        connector_ver = Version(connector_version or default_connector_version).min_digits(2)
+
         if scala_ver < Version("2.12") or scala_ver > Version("2.13"):
             raise ValueError(f"Scala version must be 2.12 - 2.13, got {scala_ver.format('{0}.{1}')}")
 
-        # https://mvnrepository.com/artifact/org.mongodb.spark/mongo-spark-connector
-        return [f"org.mongodb.spark:mongo-spark-connector_{scala_ver.format('{0}.{1}')}:10.1.1"]
+        return [f"org.mongodb.spark:mongo-spark-connector_{scala_ver.format('{0}.{1}')}:{connector_ver}"]
 
     @classproperty
     def package_spark_3_2(cls) -> str:
@@ -190,7 +190,7 @@ class MongoDB(DBConnection):
             "use `MongoDB.get_packages(spark_version='3.2')` instead"
         )
         warnings.warn(msg, UserWarning, stacklevel=3)
-        return "org.mongodb.spark:mongo-spark-connector_2.12:10.1.1"
+        return "org.mongodb.spark:mongo-spark-connector_2.12:10.2.2"
 
     @classproperty
     def package_spark_3_3(cls) -> str:
@@ -200,7 +200,7 @@ class MongoDB(DBConnection):
             "use `MongoDB.get_packages(spark_version='3.3')` instead"
         )
         warnings.warn(msg, UserWarning, stacklevel=3)
-        return "org.mongodb.spark:mongo-spark-connector_2.12:10.1.1"
+        return "org.mongodb.spark:mongo-spark-connector_2.12:10.2.2"
 
     @classproperty
     def package_spark_3_4(cls) -> str:
@@ -210,7 +210,7 @@ class MongoDB(DBConnection):
             "use `MongoDB.get_packages(spark_version='3.4')` instead"
         )
         warnings.warn(msg, UserWarning, stacklevel=3)
-        return "org.mongodb.spark:mongo-spark-connector_2.12:10.1.1"
+        return "org.mongodb.spark:mongo-spark-connector_2.12:10.2.2"
 
     @slot
     def pipeline(

--- a/tests/tests_unit/tests_db_connection_unit/test_mongodb_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_mongodb_unit.py
@@ -38,18 +38,17 @@ def test_mongodb_get_packages_spark_version_not_supported(spark_version):
 @pytest.mark.parametrize(
     "scala_version",
     [
+        "2.9.2",
         "2.11",
-        "2.14",
-        "3.0",
     ],
 )
 def test_mongodb_get_packages_scala_version_not_supported(scala_version):
-    with pytest.raises(ValueError, match=f"Scala version must be 2.12 - 2.13, got {scala_version}"):
+    with pytest.raises(ValueError, match=f"Scala version must be at least 2.12, got {scala_version}"):
         MongoDB.get_packages(scala_version=scala_version)
 
 
 @pytest.mark.parametrize(
-    "spark_version, scala_version, connector_version, package",
+    "spark_version, scala_version, package_version, package",
     [
         (None, "2.12", "10.2.2", "org.mongodb.spark:mongo-spark-connector_2.12:10.2.2"),
         (None, "2.13", "10.2.2", "org.mongodb.spark:mongo-spark-connector_2.13:10.2.2"),
@@ -63,27 +62,27 @@ def test_mongodb_get_packages_scala_version_not_supported(scala_version):
         ("3.2.4", "2.12.1", "10.2.2", "org.mongodb.spark:mongo-spark-connector_2.12:10.2.2"),
     ],
 )
-def test_mongodb_get_packages(spark_version, scala_version, connector_version, package):
+def test_mongodb_get_packages(spark_version, scala_version, package_version, package):
     assert MongoDB.get_packages(
         spark_version=spark_version,
         scala_version=scala_version,
-        connector_version=connector_version,
+        package_version=package_version,
     ) == [package]
 
 
 @pytest.mark.parametrize(
-    "connector_version",
+    "package_version",
     [
         "10",
         "abc",
     ],
 )
-def test_mongodb_get_packages_invalid_connector_version(connector_version):
+def test_mongodb_get_packages_invalid_package_version(package_version):
     with pytest.raises(
         ValueError,
-        match=rf"Version '{connector_version}' does not have enough numeric components for requested format \(expected at least 2\).",
+        match=rf"Version '{package_version}' does not have enough numeric components for requested format \(expected at least 2\).",
     ):
-        MongoDB.get_packages(scala_version="2.12", connector_version=connector_version)
+        MongoDB.get_packages(scala_version="2.12", package_version=package_version)
 
 
 def test_mongodb_missing_package(spark_no_packages):

--- a/tests/tests_unit/tests_db_connection_unit/test_mongodb_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_mongodb_unit.py
@@ -12,9 +12,9 @@ pytestmark = [pytest.mark.mongodb, pytest.mark.db_connection, pytest.mark.connec
 def test_mongodb_package():
     warning_msg = re.escape("will be removed in 1.0.0, use `MongoDB.get_packages(spark_version=")
     with pytest.warns(UserWarning, match=warning_msg):
-        assert MongoDB.package_spark_3_2 == "org.mongodb.spark:mongo-spark-connector_2.12:10.1.1"
-        assert MongoDB.package_spark_3_3 == "org.mongodb.spark:mongo-spark-connector_2.12:10.1.1"
-        assert MongoDB.package_spark_3_4 == "org.mongodb.spark:mongo-spark-connector_2.12:10.1.1"
+        assert MongoDB.package_spark_3_2 == "org.mongodb.spark:mongo-spark-connector_2.12:10.2.2"
+        assert MongoDB.package_spark_3_3 == "org.mongodb.spark:mongo-spark-connector_2.12:10.2.2"
+        assert MongoDB.package_spark_3_4 == "org.mongodb.spark:mongo-spark-connector_2.12:10.2.2"
 
 
 def test_mongodb_get_packages_no_input():
@@ -49,24 +49,41 @@ def test_mongodb_get_packages_scala_version_not_supported(scala_version):
 
 
 @pytest.mark.parametrize(
-    "spark_version, scala_version, package",
+    "spark_version, scala_version, connector_version, package",
     [
-        # use Scala version directly
-        (None, "2.12", "org.mongodb.spark:mongo-spark-connector_2.12:10.1.1"),
-        (None, "2.13", "org.mongodb.spark:mongo-spark-connector_2.13:10.1.1"),
-        # Detect Scala version by Spark version
-        ("3.2", None, "org.mongodb.spark:mongo-spark-connector_2.12:10.1.1"),
-        ("3.3", None, "org.mongodb.spark:mongo-spark-connector_2.12:10.1.1"),
-        ("3.4", None, "org.mongodb.spark:mongo-spark-connector_2.12:10.1.1"),
-        # Override Scala version detected automatically
-        ("3.2", "2.12", "org.mongodb.spark:mongo-spark-connector_2.12:10.1.1"),
-        ("3.4", "2.13", "org.mongodb.spark:mongo-spark-connector_2.13:10.1.1"),
-        # Scala version contain three digits when only two needed
-        ("3.2.4", "2.12.1", "org.mongodb.spark:mongo-spark-connector_2.12:10.1.1"),
+        (None, "2.12", "10.2.2", "org.mongodb.spark:mongo-spark-connector_2.12:10.2.2"),
+        (None, "2.13", "10.2.2", "org.mongodb.spark:mongo-spark-connector_2.13:10.2.2"),
+        ("3.2", None, "10.2.2", "org.mongodb.spark:mongo-spark-connector_2.12:10.2.2"),
+        ("3.3", None, "10.2.2", "org.mongodb.spark:mongo-spark-connector_2.12:10.2.2"),
+        ("3.4", None, "10.2.2", "org.mongodb.spark:mongo-spark-connector_2.12:10.2.2"),
+        ("3.2", "2.12", "10.1.1", "org.mongodb.spark:mongo-spark-connector_2.12:10.1.1"),
+        ("3.4", "2.13", "10.1.1", "org.mongodb.spark:mongo-spark-connector_2.13:10.1.1"),
+        ("3.2", "2.12", "10.2.1", "org.mongodb.spark:mongo-spark-connector_2.12:10.2.1"),
+        ("3.2", "2.12", "10.2.0", "org.mongodb.spark:mongo-spark-connector_2.12:10.2.0"),
+        ("3.2.4", "2.12.1", "10.2.2", "org.mongodb.spark:mongo-spark-connector_2.12:10.2.2"),
     ],
 )
-def test_mongodb_get_packages(spark_version, scala_version, package):
-    assert MongoDB.get_packages(spark_version=spark_version, scala_version=scala_version) == [package]
+def test_mongodb_get_packages(spark_version, scala_version, connector_version, package):
+    assert MongoDB.get_packages(
+        spark_version=spark_version,
+        scala_version=scala_version,
+        connector_version=connector_version,
+    ) == [package]
+
+
+@pytest.mark.parametrize(
+    "connector_version",
+    [
+        "10",
+        "abc",
+    ],
+)
+def test_mongodb_get_packages_invalid_connector_version(connector_version):
+    with pytest.raises(
+        ValueError,
+        match=rf"Version '{connector_version}' does not have enough numeric components for requested format \(expected at least 2\).",
+    ):
+        MongoDB.get_packages(scala_version="2.12", connector_version=connector_version)
 
 
 def test_mongodb_missing_package(spark_no_packages):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

- `MongoDB` connection now uses MongoDB Spark connector ``10.2.2``, upgraded from ``10.1.1``, and supports passing custom versions: ``MongoDB.get_packages(scala_version=..., connector_version=...)``.
- Update following documentation and tests.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [ ] Tests pass on CI and coverage does not decrease
* [x] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
