### PR TITLE
[DOP-14492] - Teradata supports passing custom versions

### DIFF
--- a/docs/changelog/next_release/256.feature.rst
+++ b/docs/changelog/next_release/256.feature.rst
@@ -1,0 +1,1 @@
+:class:`Teradata` connection now supports passing custom versions: ``Teradata.get_packages(package_version=...)``.

--- a/onetl/connection/db_connection/teradata/connection.py
+++ b/onetl/connection/db_connection/teradata/connection.py
@@ -6,6 +6,7 @@ import warnings
 from typing import ClassVar, Optional
 
 from onetl._util.classproperty import classproperty
+from onetl._util.version import Version
 from onetl.connection.db_connection.jdbc_connection import JDBCConnection
 from onetl.connection.db_connection.teradata.dialect import TeradataDialect
 from onetl.hooks import slot
@@ -124,21 +125,33 @@ class Teradata(JDBCConnection):
 
     @slot
     @classmethod
-    def get_packages(cls) -> list[str]:
+    def get_packages(
+        cls,
+        package_version: str | None = None,
+    ) -> list[str]:
         """
-        Get package names to be downloaded by Spark. |support_hooks|
+        Get package names to be downloaded by Spark. Allows specifying custom JDBC driver versions for Teradata. |support_hooks|
+
+        Parameters
+        ----------
+        package_version : str, optional
+            Specifies the version of the Teradata JDBC driver to use. Defaults to ``17.20.00.15``.
 
         Examples
         --------
-
         .. code:: python
 
             from onetl.connection import Teradata
 
             Teradata.get_packages()
 
+            # specify custom driver version
+            Teradata.get_packages(package_version="20.00.00.18")
         """
-        return ["com.teradata.jdbc:terajdbc:17.20.00.15"]
+        default_package_version = "17.20.00.15"
+        version = Version(package_version or default_package_version).min_digits(4)
+
+        return [f"com.teradata.jdbc:terajdbc:{version}"]
 
     @classproperty
     def package(cls) -> str:

--- a/tests/tests_unit/tests_db_connection_unit/test_teradata_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_teradata_unit.py
@@ -17,8 +17,31 @@ def test_teradata_package():
         assert Teradata.package == "com.teradata.jdbc:terajdbc:17.20.00.15"
 
 
-def test_teradata_get_packages():
-    assert Teradata.get_packages() == ["com.teradata.jdbc:terajdbc:17.20.00.15"]
+@pytest.mark.parametrize(
+    "package_version, expected_package",
+    [
+        (None, ["com.teradata.jdbc:terajdbc:17.20.00.15"]),
+        ("17.20.00.15", ["com.teradata.jdbc:terajdbc:17.20.00.15"]),
+        ("16.20.00.13", ["com.teradata.jdbc:terajdbc:16.20.00.13"]),
+    ],
+)
+def test_teradata_get_packages_valid_versions(package_version, expected_package):
+    assert Teradata.get_packages(package_version=package_version) == expected_package
+
+
+@pytest.mark.parametrize(
+    "package_version",
+    [
+        "20.00.13",
+        "abc",
+    ],
+)
+def test_teradata_get_packages_invalid_version(package_version):
+    with pytest.raises(
+        ValueError,
+        match=rf"Version '{package_version}' does not have enough numeric components for requested format \(expected at least 4\).",
+    ):
+        Teradata.get_packages(package_version=package_version)
 
 
 def test_teradata_missing_package(spark_no_packages):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

- `Teradata` connection now uses Teradata JDBC driver ``20.00.00.19``, upgraded from ``17.20.00.15``, and supports passing custom versions: ``Teradata.get_packages(package_version=...)``.
- Update following documentation and tests.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [x] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
