### PR TITLE
[DOP-13840] - add JSON.parse_column and JSON.serialize_column methods

### DIFF
--- a/docs/changelog/next_release/257.feature.rst
+++ b/docs/changelog/next_release/257.feature.rst
@@ -1,0 +1,1 @@
+Add ``JSON.parse_column`` and ``JSON.serialize_column`` methods to facilitate direct parsing of JSON strings into Spark DataFrame columns and serialization of structured DataFrame columns back into JSON strings.

--- a/docs/connection/db_connection/clickhouse/types.rst
+++ b/docs/connection/db_connection/clickhouse/types.rst
@@ -336,12 +336,16 @@ Explicit type cast
 ~~~~~~~~~~~~
 
 Use ``CAST`` or ``toJSONString`` to get column data as string in JSON format,
-and then cast string column in resulting dataframe to proper type using `from_json <https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.from_json.html>`_:
 
-.. code:: python
+For parsing JSON columns in ClickHouse, :obj:`JSON.parse_column <onetl.file.format.json.JSON.parse_column>` method.
 
-    from pyspark.sql.functions import from_json
+.. code-block:: python
+
     from pyspark.sql.types import ArrayType, IntegerType
+
+    from onetl.file.format import JSON
+    from onetl.connection import ClickHouse
+    from onetl.db import DBReader
 
     reader = DBReader(
         connection=clickhouse,
@@ -357,16 +361,22 @@ and then cast string column in resulting dataframe to proper type using `from_js
 
     df = df.select(
         df.id,
-        from_json(df.array_column, column_type).alias("array_column"),
+        JSON().parse_column("array_column", column_type),
     )
 
 ``DBWriter``
 ~~~~~~~~~~~~
 
-Convert dataframe column to JSON using `to_json <https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.to_json.html>`_,
-and write it as ``String`` column in Clickhouse:
+For writing JSON data to ClickHouse, use the :obj:`JSON.serialize_column <onetl.file.format.json.JSON.serialize_column>` method to convert a DataFrame column to JSON format efficiently and write it as a ``String`` column in Clickhouse.
 
-.. code:: python
+
+.. code-block:: python
+
+    from onetl.file.format import JSON
+    from onetl.connection import ClickHouse
+    from onetl.db import DBWriter
+
+    clickhouse = ClickHouse(...)
 
     clickhouse.execute(
         """
@@ -379,11 +389,9 @@ and write it as ``String`` column in Clickhouse:
         """,
     )
 
-    from pyspark.sql.functions import to_json
-
     df = df.select(
         df.id,
-        to_json(df.array_column).alias("array_column_json"),
+        JSON().serialize_column(df.array_column).alias("array_column_json"),
     )
 
     writer.run(df)

--- a/docs/file_df/file_formats/json.rst
+++ b/docs/file_df/file_formats/json.rst
@@ -6,4 +6,4 @@ JSON
 .. currentmodule:: onetl.file.format.json
 
 .. autoclass:: JSON
-    :members: __init__
+    :members: __init__, parse_column, serialize_column

--- a/onetl/file/format/json.py
+++ b/onetl/file/format/json.py
@@ -2,15 +2,17 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
-from pyspark.sql import Column, SparkSession
-from pyspark.sql.functions import col, from_json, to_json
-from pyspark.sql.types import ArrayType, MapType, StructType
 from typing_extensions import Literal
 
 from onetl.file.format.file_format import ReadOnlyFileFormat
 from onetl.hooks import slot, support_hooks
+
+if TYPE_CHECKING:
+    from pyspark.sql import Column, SparkSession
+    from pyspark.sql.types import ArrayType, MapType, StructType
+
 
 READ_WRITE_OPTIONS = frozenset(
     (
@@ -105,7 +107,7 @@ class JSON(ReadOnlyFileFormat):
 
     def parse_column(self, column: str | Column, schema: StructType | ArrayType | MapType) -> Column:
         """
-        Parses a JSON string column to a structured Spark SQL column based on the provided schema.
+        Parses a JSON string column to a structured Spark SQL column using Spark's `from_json <https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.from_json.html>`_ function, based on the provided schema.
 
         Parameters
         ----------
@@ -128,17 +130,18 @@ class JSON(ReadOnlyFileFormat):
             from pyspark.sql.types import StructType, StructField, IntegerType, StringType
 
             spark = SparkSession.builder.appName("JSONParsingExample").getOrCreate()
-            json_formatter = JSON()
+            json = JSON()
             df = spark.createDataFrame([(1, '{"id":123, "name":"John"}')], ["id", "json_string"])
             schema = StructType(
                 [StructField("id", IntegerType()), StructField("name", StringType())]
             )
 
-            parsed_df = df.withColumn(
-                "parsed_json", json_formatter.parse_column("json_string", schema)
-            )
+            parsed_df = df.withColumn("parsed_json", json.parse_column("json_string", schema))
             parsed_df.show()
         """
+        from pyspark.sql import Column, SparkSession  # noqa:  WPS442
+        from pyspark.sql.functions import col, from_json
+
         self.check_if_supported(SparkSession._instantiatedSession)  # noqa:  WPS437
 
         if isinstance(column, Column):
@@ -150,7 +153,7 @@ class JSON(ReadOnlyFileFormat):
 
     def serialize_column(self, column: str | Column) -> Column:
         """
-        Serializes a structured Spark SQL column into a JSON string column.
+        Serializes a structured Spark SQL column into a JSON string column using Spark's `to_json <https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.to_json.html>`_ function.
 
         Parameters
         ----------
@@ -170,15 +173,16 @@ class JSON(ReadOnlyFileFormat):
             from pyspark.sql.functions import struct
 
             spark = SparkSession.builder.appName("JSONSerializationExample").getOrCreate()
-            json_formatter = JSON()
+            json = JSON()
             df = spark.createDataFrame([(123, "John")], ["id", "name"])
             df = df.withColumn("combined", struct("id", "name"))
 
-            serialized_df = df.withColumn(
-                "json_string", json_formatter.serialize_column("combined")
-            )
+            serialized_df = df.withColumn("json_string", json.serialize_column("combined"))
             serialized_df.show()
         """
+        from pyspark.sql import Column, SparkSession  # noqa:  WPS442
+        from pyspark.sql.functions import col, to_json
+
         self.check_if_supported(SparkSession._instantiatedSession)  # noqa:  WPS437
 
         if isinstance(column, Column):

--- a/onetl/file/format/json.py
+++ b/onetl/file/format/json.py
@@ -2,16 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar
+from typing import ClassVar
 
+from pyspark.sql import Column, SparkSession
+from pyspark.sql.functions import col, from_json, to_json
+from pyspark.sql.types import ArrayType, MapType, StructType
 from typing_extensions import Literal
 
 from onetl.file.format.file_format import ReadOnlyFileFormat
 from onetl.hooks import slot, support_hooks
-
-if TYPE_CHECKING:
-    from pyspark.sql import SparkSession
-
 
 READ_WRITE_OPTIONS = frozenset(
     (
@@ -103,3 +102,88 @@ class JSON(ReadOnlyFileFormat):
     def check_if_supported(self, spark: SparkSession) -> None:
         # always available
         pass
+
+    def parse_column(self, column: str | Column, schema: StructType | ArrayType | MapType) -> Column:
+        """
+        Parses a JSON string column to a structured Spark SQL column based on the provided schema.
+
+        Parameters
+        ----------
+        column : str | Column
+            The name of the column or the Column object containing JSON strings to parse.
+
+        schema : StructType | ArrayType | MapType
+            The schema to apply when parsing the JSON data. This defines the structure of the output DataFrame column.
+
+        Returns
+        -------
+        Column
+            A new Column object with data parsed from JSON string to the specified structure.
+
+        Examples
+        --------
+        .. code:: python
+
+            from pyspark.sql import SparkSession
+            from pyspark.sql.types import StructType, StructField, IntegerType, StringType
+
+            spark = SparkSession.builder.appName("JSONParsingExample").getOrCreate()
+            json_formatter = JSON()
+            df = spark.createDataFrame([(1, '{"id":123, "name":"John"}')], ["id", "json_string"])
+            schema = StructType(
+                [StructField("id", IntegerType()), StructField("name", StringType())]
+            )
+
+            parsed_df = df.withColumn(
+                "parsed_json", json_formatter.parse_column("json_string", schema)
+            )
+            parsed_df.show()
+        """
+        self.check_if_supported(SparkSession._instantiatedSession)  # noqa:  WPS437
+
+        if isinstance(column, Column):
+            column_name, column = column._jc.toString(), column.cast("string")  # noqa:  WPS437
+        else:
+            column_name, column = column, col(column).cast("string")
+
+        return from_json(column, schema, self.dict()).alias(column_name)
+
+    def serialize_column(self, column: str | Column) -> Column:
+        """
+        Serializes a structured Spark SQL column into a JSON string column.
+
+        Parameters
+        ----------
+        column : str | Column
+            The name of the column or the Column object containing the data to serialize to JSON.
+
+        Returns
+        -------
+        Column
+            A new Column object with data serialized from Spark SQL structures to JSON string.
+
+        Examples
+        --------
+        .. code:: python
+
+            from pyspark.sql import SparkSession
+            from pyspark.sql.functions import struct
+
+            spark = SparkSession.builder.appName("JSONSerializationExample").getOrCreate()
+            json_formatter = JSON()
+            df = spark.createDataFrame([(123, "John")], ["id", "name"])
+            df = df.withColumn("combined", struct("id", "name"))
+
+            serialized_df = df.withColumn(
+                "json_string", json_formatter.serialize_column("combined")
+            )
+            serialized_df.show()
+        """
+        self.check_if_supported(SparkSession._instantiatedSession)  # noqa:  WPS437
+
+        if isinstance(column, Column):
+            column_name = column._jc.toString()  # noqa:  WPS437
+        else:
+            column_name, column = column, col(column)
+
+        return to_json(column, self.dict()).alias(column_name)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

- Add ``JSON.parse_column`` and ``JSON.serialize_column`` methods to facilitate direct parsing of JSON strings into Spark DataFrame columns and serialization of structured DataFrame columns back into JSON strings.
- Update following tests and documentation

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [ ] Tests pass on CI and coverage does not decrease
* [x] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
