### PR TITLE
[DOP-13845] -  implement Avro.parse_column, Avro.serialize_column

### DIFF
--- a/docs/changelog/next_release/265.feature.rst
+++ b/docs/changelog/next_release/265.feature.rst
@@ -1,0 +1,1 @@
+Add ``Avro.parse_column`` and ``Avro.serialize_column`` methods to enhance the handling of Avro binary data within Spark. These methods allow for direct parsing of binary Avro data into structured Spark DataFrame columns and serialization of Spark DataFrame columns back into Avro binary format.

--- a/docs/file_df/file_formats/avro.rst
+++ b/docs/file_df/file_formats/avro.rst
@@ -6,4 +6,4 @@ Avro
 .. currentmodule:: onetl.file.format.avro
 
 .. autoclass:: Avro
-    :members: get_packages
+    :members: get_packages, parse_column, serialize_column

--- a/onetl/file/format/avro.py
+++ b/onetl/file/format/avro.py
@@ -216,6 +216,7 @@ class Avro(ReadWriteFileFormat):
         .. code:: python
 
             from pyspark.sql import SparkSession
+
             from onetl.file.format import Avro
 
             spark = SparkSession.builder.appName("AvroParsingExample").getOrCreate()
@@ -276,7 +277,7 @@ class Avro(ReadWriteFileFormat):
         .. code:: python
 
             from pyspark.sql import SparkSession
-            from pyspark.sql.functions import col
+
             from onetl.file.format import Avro
 
             spark = SparkSession.builder.appName("AvroSerializationExample").getOrCreate()

--- a/requirements/tests/base.txt
+++ b/requirements/tests/base.txt
@@ -4,3 +4,5 @@ pytest<8
 pytest-lazy-fixture
 pytest-mock
 pytest-rerunfailures
+requests
+responses


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

- Add ``Avro.parse_column`` and ``Avro.serialize_column`` methods to enhance the handling of Avro binary data within Spark. 
- Add following tests and documentation. 
## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [ ] Tests pass on CI and coverage does not decrease
* [x] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
