### PR TITLE
[DOP-14061] Replace asserts in documentation with doctest style

### DIFF
--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Run tests
         run: |
           ./run_tests.sh -m 'not connection'
-          ./run_tests.sh onetl/_util
+          ./run_tests.sh onetl/_util onetl/_internal.py onetl/hooks onetl/file/filter onetl/file/limit onetl/hwm/store/hwm_class_registry.py
 
       - name: Upload coverage results
         uses: actions/upload-artifact@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.12
+  python: python3.11
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/docs/changelog/next_release/273.improvement.rst
+++ b/docs/changelog/next_release/273.improvement.rst
@@ -1,0 +1,1 @@
+Replace all ``assert`` in documentation with doctest syntax. This should make documentation more readable.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,6 +70,12 @@ autodoc_pydantic_model_show_validator_members = False
 autodoc_pydantic_field_list_validators = False
 sphinx_tabs_disable_tab_closing = True
 
+# prevent >>>, ... and doctest outputs from copying
+copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
+copybutton_prompt_is_regexp = True
+copybutton_copy_empty_lines = False
+copybutton_only_copy_prompt_lines = True
+
 towncrier_draft_autoversion_mode = "draft"
 towncrier_draft_include_empty = False
 towncrier_draft_working_directory = PROJECT_ROOT_DIR

--- a/onetl/_util/classproperty.py
+++ b/onetl/_util/classproperty.py
@@ -15,7 +15,8 @@ class classproperty(property):  # noqa: N801
     ...    def attribute(cls):
     ...        return 123
     >>> # no call
-    >>> assert My.attribute == 123
+    >>> My.attribute
+    123
     """
 
     def __init__(self, f):

--- a/onetl/base/base_file_connection.py
+++ b/onetl/base/base_file_connection.py
@@ -35,11 +35,12 @@ class BaseFileConnection(BaseConnection):
         Examples
         --------
 
-        .. code:: python
-
-            assert connection.path_exists("/path/to/file.csv")
-            assert connection.path_exists("/path/to/dir")
-            assert not connection.path_exists("/path/to/missing")
+        >>> connection.path_exists("/path/to/file.csv")
+        True
+        >>> connection.path_exists("/path/to/dir")
+        True
+        >>> connection.path_exists("/path/to/missing")
+        False
         """
 
     @abstractmethod
@@ -64,10 +65,10 @@ class BaseFileConnection(BaseConnection):
         Examples
         --------
 
-        .. code:: python
-
-            assert connection.is_file("/path/to/dir/file.csv")
-            assert not connection.is_file("/path/to/dir")
+        >>> connection.is_file("/path/to/dir/file.csv")
+        True
+        >>> connection.is_file("/path/to/dir")
+        False
         """
 
     @abstractmethod
@@ -92,10 +93,10 @@ class BaseFileConnection(BaseConnection):
         Examples
         --------
 
-        .. code:: python
-
-            assert connection.is_dir("/path/to/dir")
-            assert not connection.is_dir("/path/to/dir/file.csv")
+        >>> connection.is_dir("/path/to/dir")
+        True
+        >>> connection.is_dir("/path/to/dir/file.csv")
+        False
         """
 
     @abstractmethod
@@ -119,11 +120,11 @@ class BaseFileConnection(BaseConnection):
         Examples
         --------
 
-        .. code:: python
-
-            stat = connection.get_stat("/path/to/file.csv")
-            assert stat.st_size > 0
-            assert stat.st_uid == 12345  # owner id
+        >>> stat = connection.get_stat("/path/to/file.csv")
+        >>> stat.st_size  # in bytes
+        1024
+        >>> stat.st_uid  # owner id or name
+        12345
         """
 
     @abstractmethod
@@ -151,11 +152,11 @@ class BaseFileConnection(BaseConnection):
         Examples
         --------
 
-        .. code:: python
-
-            dir_path = connection.resolve_dir("/path/to/dir")
-            assert os.fspath(dir_path) == "/path/to/dir"
-            assert dir_path.stat.st_uid == 12345  # owner id
+        >>> dir_path = connection.resolve_dir("/path/to/dir")
+        >>> os.fspath(dir_path)
+        '/path/to/dir'
+        >>> dir_path.stat.st_uid  # owner id
+        12345
         """
 
     @abstractmethod
@@ -183,11 +184,11 @@ class BaseFileConnection(BaseConnection):
         Examples
         --------
 
-        .. code:: python
-
-            file_path = connection.resolve_file("/path/to/dir/file.csv")
-            assert os.fspath(file_path) == "/path/to/dir/file.csv"
-            assert file_path.stat.st_uid == 12345  # owner id
+        >>> file_path = connection.resolve_file("/path/to/dir/file.csv")
+        >>> os.fspath(file_path)
+        '/path/to/dir/file.csv'
+        >>> file_path.stat.st_uid  # owner id
+        12345
         """
 
     @abstractmethod
@@ -212,9 +213,9 @@ class BaseFileConnection(BaseConnection):
         Examples
         --------
 
-        .. code:: python
-
-            dir_path = connection.create_dir("/path/to/dir")
+        >>> dir_path = connection.create_dir("/path/to/dir")
+        >>> os.fspath(dir_path)
+        '/path/to/dir'
         """
 
     @abstractmethod
@@ -245,12 +246,12 @@ class BaseFileConnection(BaseConnection):
         Examples
         --------
 
-        .. code:: python
-
-            assert connection.remove_file("/path/to/file.csv")
-            assert not connection.path_exists("/path/to/dir/file.csv")
-
-            assert not connection.remove_file("/path/to/file.csv")  # already deleted
+        >>> connection.remove_file("/path/to/file.csv")
+        True
+        >>> connection.path_exists("/path/to/dir/file.csv")
+        False
+        >>> connection.remove_file("/path/to/file.csv")  # already deleted, no error
+        False
         """
 
     @abstractmethod
@@ -280,13 +281,14 @@ class BaseFileConnection(BaseConnection):
         Examples
         --------
 
-        .. code:: python
-
-            assert connection.remove_dir("/path/to/dir")
-            assert not connection.path_exists("/path/to/dir/file.csv")
-            assert not connection.path_exists("/path/to/dir")
-
-            assert not connection.remove_dir("/path/to/dir")  # already deleted
+        >>> connection.remove_dir("/path/to/dir")
+        True
+        >>> connection.path_exists("/path/to/dir")
+        False
+        >>> connection.path_exists("/path/to/dir/file.csv")
+        False
+        >>> connection.remove_dir("/path/to/dir")  # already deleted, no error
+        False
         """
 
     @abstractmethod
@@ -332,11 +334,13 @@ class BaseFileConnection(BaseConnection):
         Examples
         --------
 
-        .. code:: python
-
-            new_file = connection.rename_file("/path/to/file1.csv", "/path/to/file2.csv")
-            assert connection.path_exists("/path/to/file2.csv")
-            assert not connection.path_exists("/path/to/file1.csv")
+        >>> new_file = connection.rename_file("/path/to/file1.csv", "/path/to/file2.csv")
+        >>> os.fspath(new_file)
+        '/path/to/file2.csv'
+        >>> connection.path_exists("/path/to/file2.csv")
+        True
+        >>> connection.path_exists("/path/to/file1.csv")
+        False
         """
 
     @abstractmethod
@@ -376,11 +380,11 @@ class BaseFileConnection(BaseConnection):
         Examples
         --------
 
-        .. code:: python
-
-            dir_content = connection.list_dir("/path/to/dir")
-            assert os.fspath(dir_content[0]) == "/path/to/dir/file.csv"
-            assert connection.path_exists("/path/to/dir/file.csv")
+        >>> dir_content = connection.list_dir("/path/to/dir")
+        >>> os.fspath(dir_content[0])
+        '/path/to/dir/file.csv'
+        >>> connection.path_exists("/path/to/dir/file.csv")
+        True
         """
 
     @abstractmethod
@@ -428,13 +432,16 @@ class BaseFileConnection(BaseConnection):
         Examples
         --------
 
-        .. code:: python
-
-            for root, dirs, files in connection.walk("/path/to/dir"):
-                assert os.fspath(root) == "/path/to/dir"
-                assert dirs == []
-                assert os.fspath(files[0]) == "/path/to/dir/file.csv"
-                assert connection.path_exists("/path/to/dir/file.csv")
+        >>> for root, dirs, files in connection.walk("/path/to/dir"):
+        ...    break
+        >>> os.fspath(root)
+        '/path/to/dir'
+        >>> dirs
+        []
+        >>> os.fspath(files[0])
+        '/path/to/dir/file.csv'
+        >>> connection.path_exists("/path/to/dir/file.csv")
+        True
         """
 
     @abstractmethod
@@ -483,14 +490,18 @@ class BaseFileConnection(BaseConnection):
         Examples
         --------
 
-        .. code:: python
-
-            local_file = connection.download_file(
-                remote_file_path="/path/to/source.csv", local_file_path="/path/to/target.csv"
-            )
-            assert local_file.exists()
-            assert os.fspath(local_file) == "/path/to/target.csv"
-            assert local_file.stat().st_size == connection.get_stat("/path/to/source.csv").st_size
+        >>> local_file = connection.download_file(
+        ...     remote_file_path="/path/to/source.csv",
+        ...     local_file_path="/path/to/target.csv",
+        ... )
+        >>> os.fspath(local_file)
+        '/path/to/target.csv'
+        >>> local_file.exists()
+        True
+        >>> local_file.stat().st_size  # in bytes
+        1024
+        >>> connection.get_stat("/path/to/source.csv").st_size  # same size
+        1024
         """
 
     @abstractmethod
@@ -539,14 +550,18 @@ class BaseFileConnection(BaseConnection):
         Examples
         --------
 
-        .. code:: python
-
-            remote_file = connection.upload(
-                local_file_path="/path/to/source.csv",
-                remote_file_path="/path/to/target.csv",
-            )
-            assert connection.path_exists("/path/to/target.csv")
-            assert remote_file.stat().st_size == os.stat("/path/to/source.csv").st_size
+        >>> remote_file = connection.upload(
+        ...     local_file_path="/path/to/source.csv",
+        ...     remote_file_path="/path/to/target.csv",
+        ... )
+        >>> os.fspath(remote_file)
+        '/path/to/target.csv'
+        >>> connection.path_exists("/path/to/target.csv")
+        True
+        >>> remote_file.stat().st_size  # in bytes
+        1024
+        >>> os.stat("/path/to/source.csv").st_size  # same as source
+        1024
         """
 
     @abstractmethod
@@ -577,10 +592,8 @@ class BaseFileConnection(BaseConnection):
         Examples
         --------
 
-        .. code:: python
-
-            content = connection.read_text("/path/to/dir/file.csv")
-            assert content == "some;header\n1;2"
+        >>> connection.read_text("/path/to/dir/file.csv")
+        'some;header\n1;2'
         """
 
     @abstractmethod
@@ -608,10 +621,8 @@ class BaseFileConnection(BaseConnection):
         Examples
         --------
 
-        .. code:: python
-
-            content = connection.read_bytes("/path/to/dir/file.csv")
-            assert content == b"0xdeadbeef"
+        >>> connection.read_bytes("/path/to/dir/file.csv")
+        b'0xdeadbeef'
         """
 
     @abstractmethod
@@ -654,10 +665,11 @@ class BaseFileConnection(BaseConnection):
         Examples
         --------
 
-        .. code:: python
-
-            file_path = connection.write_text("/path/to/dir/file.csv", "some;header\n1;2")
-            assert file_path.stat.st_size > 0
+        >>> file_path = connection.write_text("/path/to/dir/file.csv", "some;header\n1;2")
+        >>> os.fspath(file_path)
+        '/path/to/dir/file.csv'
+        >>> file_path.stat.st_size  # in bytes
+        1024
         """
 
     @abstractmethod
@@ -692,10 +704,11 @@ class BaseFileConnection(BaseConnection):
         Examples
         --------
 
-        .. code:: python
-
-            file_path = connection.write_bytes("/path/to/dir/file.csv", b"0xdeadbeef")
-            assert file_path.stat.st_size > 0
+        >>> file_path = connection.write_bytes("/path/to/dir/file.csv", b"0xdeadbeef")
+        >>> os.fspath(file_path)
+        '/path/to/dir/file.csv'
+        >>> file_path.stat.st_size  # in bytes
+        1024
         """
 
     @property

--- a/onetl/base/base_file_filter.py
+++ b/onetl/base/base_file_filter.py
@@ -25,11 +25,12 @@ class BaseFileFilter(ABC):
         Examples
         --------
 
-        .. code:: python
+        from onetl.impl import LocalPath
 
-            from onetl.impl import LocalPath
-
-            assert filter.match(LocalPath("/path/to/file.csv"))
-            assert not filter.match(LocalPath("/path/to/excluded.csv"))
-            assert filter.match(LocalPath("/path/to/file.csv"))
+        >>> filter.match(LocalPath("/path/to/file.csv"))
+        True
+        >>> filter.match(LocalPath("/path/to/excluded.csv"))
+        False
+        >>> filter.match(LocalPath("/path/to/file.csv"))
+        True
         """

--- a/onetl/base/base_file_limit.py
+++ b/onetl/base/base_file_limit.py
@@ -33,12 +33,11 @@ class BaseFileLimit(ABC):
         Examples
         --------
 
-        .. code:: python
-
-            assert limit.is_reached
-
-            new_limit = limit.reset()
-            assert not new_limit.is_reached
+        >>> limit.is_reached
+        True
+        >>> new_limit = limit.reset()
+        >>> new_limit.is_reached
+        False
         """
 
     @abstractmethod
@@ -58,21 +57,18 @@ class BaseFileLimit(ABC):
         Examples
         --------
 
-        .. code:: python
-
-            from onetl.impl import LocalPath
-
-            assert not limit.stops_at(LocalPath("/path/to/file.csv"))
-            # do this multiple times
-            ...
-
-            # stopped on some input
-            assert limit.stops_at(LocalPath("/path/to/another.csv"))
-
-            # at this point, .stops_at() and .is_reached will always return True,
-            # even on inputs that returned False before.
-            # it will be in the same state until .reset() is called
-            assert limit.stops_at(LocalPath("/path/to/file.csv"))
+        >>> from onetl.impl import LocalPath
+        >>> # limit is not reached yet
+        >>> limit.stops_at(LocalPath("/path/to/file.csv"))
+        False
+        >>> # after limit is reached
+        >>> limit.stops_at(LocalPath("/path/to/another.csv"))
+        True
+        >>> # at this point, .stops_at() and .is_reached will always return True,
+        >>> # even on inputs that returned False before.
+        >>> # it will be in the same state until .reset() is called
+        >>> limit.stops_at(LocalPath("/path/to/file.csv"))
+        True
         """
 
     @property
@@ -88,15 +84,16 @@ class BaseFileLimit(ABC):
         Examples
         --------
 
-        .. code:: python
-
-            from onetl.impl import LocalPath
-
-            assert not limit.is_reached
-
-            assert not limit.stops_at(LocalPath("/path/to/file.csv"))
-            assert not limit.is_reached
-
-            assert limit.stops_at(LocalPath("/path/to/file.csv"))
-            assert limit.is_reached
+        >>> from onetl.impl import LocalPath
+        >>> limit.is_reached
+        False
+        >>> limit.stops_at(LocalPath("/path/to/file.csv"))
+        False
+        >>> limit.is_reached
+        False
+        >>> # after limit is reached
+        >>> limit.stops_at(LocalPath("/path/to/file.csv"))
+        True
+        >>> limit.is_reached
+        True
         """

--- a/onetl/connection/db_connection/jdbc_mixin/connection.py
+++ b/onetl/connection/db_connection/jdbc_mixin/connection.py
@@ -107,7 +107,6 @@ class JDBCMixin(FrozenModel):
         .. code:: python
 
             df = connection.fetch("SELECT * FROM mytable LIMIT 10")
-            assert df.count()
             connection.close()
 
             # or

--- a/onetl/connection/file_connection/file_connection.py
+++ b/onetl/connection/file_connection/file_connection.py
@@ -87,7 +87,6 @@ class FileConnection(BaseFileConnection, FrozenModel):
         .. code:: python
 
             content = connection.list_dir("/mydir")
-            assert content
             connection.close()
 
             # or
@@ -603,19 +602,19 @@ class FileConnection(BaseFileConnection, FrozenModel):
 
         Get an entry name:
 
-        .. code:: python
-
-            for entry in connection._scan_entries(path="/a/path/to/the/directory"):
-                assert entry == {
-                    "created": "2023-12-08T18:33:39Z",
-                    "owner": None,
-                    "size": "23",
-                    "modified": "2023-12-08 18:33:20",
-                    "isdir": False,
-                    "path": "/path/to/the/file.txt",
-                }
-
-                assert entry._extract_name_from_entry(entry) == "file.txt"
+        >>> for entry in connection._scan_entries(path="/a/path/to/the/directory"):
+        ...     break
+        >>> entry
+        {
+            'created': '2023-12-08T18:33:39Z',
+            'owner': None,
+            'size': 23,
+            'modified': '2023-12-08 18:33:20',
+            'isdir': False,
+            'path': '/path/to/the/directory/file.txt',
+        }
+        >>> entry._extract_name_from_entry(entry)
+        'file.txt'
         """
 
     @abstractmethod
@@ -643,10 +642,19 @@ class FileConnection(BaseFileConnection, FrozenModel):
 
         Show if the entry is a directory:
 
-        .. code:: python
-
-            for component in connection._scan_entries(path="/a/path/to/the/directory"):
-                assert connection._is_dir_entry(root="/a/path/to/the/directory", entry) == True
+        >>> for entry in connection._scan_entries(path="/a/path/to/the/directory"):
+        ...     break
+        >>> entry
+        {
+            'created': '2023-12-08T18:33:39Z',
+            'owner': None,
+            'size': 0,
+            'modified': '2023-12-08 18:33:20',
+            'isdir': True,
+            'path': '/path/to/the/directory',
+        }
+        >>> connection._is_dir_entry(root="/a/path/to/the/directory", entry)
+        True
         """
 
     @abstractmethod
@@ -674,10 +682,19 @@ class FileConnection(BaseFileConnection, FrozenModel):
 
         Show if the entry is a file:
 
-        .. code:: python
-
-            for entry in connection._scan_entries(path="/a/path/to/the/directory"):
-                assert connection._is_file_entry(root="/a/path/to/the/directory", entry) == True
+        >>> for entry in connection._scan_entries(path="/a/path/to/the/directory"):
+        ...     break
+        >>> entry
+        {
+            'created': '2023-12-08T18:33:39Z',
+            'owner': None,
+            'size': 23,
+            'modified': '2023-12-08 18:33:20',
+            'isdir': False,
+            'path': '/path/to/the/directory/file.txt',
+        }
+        >>> connection._is_file_entry(root="/a/path/to/the/directory", entry)
+        True
         """
 
     @abstractmethod
@@ -708,15 +725,25 @@ class FileConnection(BaseFileConnection, FrozenModel):
 
         Get statistics object from the entry:
 
-        .. code:: python
-
-            for entry in connection._scan_entries(path="/a/path/to/the/directory"):
-                stat = connection._extract_stat_from_entry(root="/a/path/to/the/directory", entry)
-
-                assert stat == RemotePathStat(
-                    st_size=23, st_mtime=1670517693.0, st_mode=None, st_uid=None, st_gid=None
-                )
-
+        >>> for entry in connection._scan_entries(path="/a/path/to/the/directory"):
+        ...     break
+        >>> entry
+        {
+            'created': '2023-12-08T18:33:39Z',
+            'owner': None,
+            'size': 23,
+            'modified': '2023-12-08 18:33:20',
+            'isdir': False,
+            'path': '/path/to/the/directory/file.txt',
+        }
+        >>> connection._extract_stat_from_entry(root="/a/path/to/the/directory", entry)
+        RemotePathStat(
+            st_size=23,
+            st_mtime=1670517693.0,
+            st_mode=None,
+            st_uid=None,
+            st_gid=None,
+        )
         """
 
     def _log_parameters(self):

--- a/onetl/connection/file_connection/mixins/rename_dir_mixin.py
+++ b/onetl/connection/file_connection/mixins/rename_dir_mixin.py
@@ -52,11 +52,13 @@ class RenameDirMixin(BaseFileConnection):
         Examples
         --------
 
-        .. code:: python
-
-            new_file = connection.rename_dir("/path/to/dir1", "/path/to/dir2")
-            assert connection.path_exists("/path/to/dir1")
-            assert not connection.path_exists("/path/to/dir2")
+        >>> new_dir = connection.rename_dir("/path/to/dir1", "/path/to/dir2")
+        >>> os.fspath(new_dir)
+        '/path/to/dir2'
+        >>> connection.path_exists("/path/to/dir1")
+        False
+        >>> connection.path_exists("/path/to/dir2")
+        True
         """
 
         log.debug("|%s| Renaming directory '%s' to '%s'", self.__class__.__name__, source_dir_path, target_dir_path)

--- a/onetl/file/file_downloader/file_downloader.py
+++ b/onetl/file/file_downloader/file_downloader.py
@@ -249,7 +249,7 @@ class FileDownloader(FrozenModel):
 
         Returns
         -------
-        downloaded_files : :obj:`DownloadResult <onetl.file.file_downloader.download_result.DownloadResult>`
+        :obj:`DownloadResult <onetl.file.file_downloader.download_result.DownloadResult>`
 
             Download result object
 
@@ -266,76 +266,76 @@ class FileDownloader(FrozenModel):
         Examples
         --------
 
-        Download files from ``source_path`` to ``local_path``
+        Download files from ``source_path`` to ``local_path``:
 
-        .. code:: python
-
-            from onetl.impl import RemoteFile, LocalPath
-            from onetl.file import FileDownloader
-
-            downloader = FileDownloader(source_path="/remote", local_path="/local", ...)
-            downloaded_files = downloader.run()
-
-            assert downloaded_files.successful == {
+        >>> from onetl.file import FileDownloader
+        >>> downloader = FileDownloader(source_path="/remote", local_path="/local", ...)
+        >>> download_result = downloader.run()
+        >>> download_result
+        DownloadResult(
+            successful=FileSet([
                 LocalPath("/local/file1.txt"),
                 LocalPath("/local/file2.txt"),
-                LocalPath("/local/nested/path/file3.txt"),  # directory structure is preserved
-            }
-            assert downloaded_files.failed == {FailedRemoteFile("/remote/failed.file")}
-            assert downloaded_files.skipped == {RemoteFile("/remote/already.exists")}
-            assert downloaded_files.missing == {RemotePath("/remote/missing.file")}
+                # directory structure is preserved
+                LocalPath("/local/nested/path/file3.txt"),
+            ]),
+            failed=FileSet([
+                FailedRemoteFile("/remote/failed.file"),
+            ]),
+            skipped=FileSet([
+                RemoteFile("/remote/already.exists"),
+            ]),
+            missing=FileSet([
+                RemotePath("/remote/missing.file"),
+            ]),
+        )
 
-        Download only certain files from ``source_path``
+        Download only certain files from ``source_path``:
 
-        .. code:: python
-
-            from onetl.impl import RemoteFile, LocalPath
-            from onetl.file import FileDownloader
-
-            downloader = FileDownloader(source_path="/remote", local_path="/local", ...)
-
-            # paths could be relative or absolute, but all should be in "/remote"
-            downloaded_files = downloader.run(
-                [
-                    "/remote/file1.txt",
-                    "/remote/nested/path/file3.txt",
-                    # excluding "/remote/file2.txt"
-                ]
-            )
-
-            assert downloaded_files.successful == {
+        >>> from onetl.file import FileDownloader
+        >>> downloader = FileDownloader(source_path="/remote", local_path="/local", ...)
+        >>> # paths could be relative or absolute, but all should be in "/remote"
+        >>> download_result = downloader.run(
+        ...     [
+        ...         "/remote/file1.txt",
+        ...         "/remote/nested/path/file3.txt",
+        ...         # excluding "/remote/file2.txt"
+        ...     ]
+        ... )
+        >>> download_result
+        DownloadResult(
+            successful=FileSet([
                 LocalPath("/local/file1.txt"),
-                LocalPath("/local/nested/path/file3.txt"),  # directory structure is preserved
-            }
-            assert not downloaded_files.failed
-            assert not downloaded_files.skipped
-            assert not downloaded_files.missing
+                # directory structure is preserved
+                LocalPath("/local/nested/path/file3.txt"),
+            ]),
+            failed=FileSet([]),
+            skipped=FileSet([]),
+            missing=FileSet([]),
+        )
 
-        Download certain files from any folder
+        Download certain files from any folder:
 
-        .. code:: python
-
-            from onetl.impl import RemoteFile, LocalPath
-            from onetl.file import FileDownloader
-
-            downloader = FileDownloader(local_path="/local", ...)  # no source_path set
-
-            # only absolute paths
-            downloaded_files = downloader.run(
-                [
-                    "/remote/file1.txt",
-                    "/any/nested/path/file2.txt",
-                ]
-            )
-
-            assert downloaded_files.successful == {
+        >>> from onetl.file import FileDownloader
+        >>> downloader = FileDownloader(local_path="/local", ...)  # no source_path set
+        >>> # only absolute paths
+        >>> download_result = downloader.run(
+        ...     [
+        ...         "/remote/file1.txt",
+        ...         "/any/nested/path/file2.txt",
+        ...     ]
+        ... )
+        >>> download_result
+        DownloadResult(
+            successful=FileSet([
                 LocalPath("/local/file1.txt"),
-                LocalPath("/local/file2.txt"),
                 # directory structure is NOT preserved without source_path
-            }
-            assert not downloaded_files.failed
-            assert not downloaded_files.skipped
-            assert not downloaded_files.missing
+                LocalPath("/local/file2.txt"),
+            ]),
+            failed=FileSet([]),
+            skipped=FileSet([]),
+            missing=FileSet([]),
+        )
         """
 
         entity_boundary_log(log, f"{self.__class__.__name__}.run() starts")
@@ -417,22 +417,16 @@ class FileDownloader(FrozenModel):
         Examples
         --------
 
-        View files
+        View files:
 
-        .. code:: python
-
-            from onetl.impl import RemoteFile
-            from onetl.file import FileDownloader
-
-            downloader = FileDownloader(source_path="/remote", ...)
-
-            view_files = downloader.view_files()
-
-            assert view_files == {
-                RemoteFile("/remote/file1.txt"),
-                RemoteFile("/remote/file3.txt"),
-                RemoteFile("/remote/nested/file3.txt"),
-            }
+        >>> from onetl.file import FileDownloader
+        >>> downloader = FileDownloader(source_path="/remote", ...)
+        >>> downloader.view_files()
+        FileSet([
+            RemoteFile("/remote/file1.txt"),
+            RemoteFile("/remote/file3.txt"),
+            RemoteFile("/remote/nested/file3.txt"),
+        ])
         """
 
         if not self.source_path:

--- a/onetl/file/file_downloader/result.py
+++ b/onetl/file/file_downloader/result.py
@@ -25,34 +25,33 @@ class DownloadResult(FileResult):
     Examples
     --------
 
-    Download files
-
-    .. code:: python
-
-        from onetl.impl import LocalPath, RemoteFile, FailedLocalFile
-        from onetl.file import FileDownloader, DownloadResult
-
-        downloader = FileDownloader(local_path="/local", ...)
-
-        downloaded_files = downloader.run(
-            [
-                "/remote/file1",
-                "/remote/file2",
-                "/failed/file",
-                "/existing/file",
-                "/missing/file",
-            ]
-        )
-
-        assert downloaded_files == DownloadResult(
-            successful={
-                LocalPath("/local/file1"),
-                LocalPath("/local/file2"),
-            },
-            failed={FailedLocalFile("/failed/file")},
-            skipped={RemoteFile("/existing/file")},
-            missing={RemotePath("/missing/file")},
-        )
+    >>> from onetl.file import FileDownloader
+    >>> downloader = FileDownloader(local_path="/local", ...)
+    >>> download_result = downloader.run(
+    ...     [
+    ...         "/remote/file1",
+    ...         "/remote/file2",
+    ...         "/failed/file",
+    ...         "/existing/file",
+    ...         "/missing/file",
+    ...     ]
+    ... )
+    >>> download_result
+    DownloadResult(
+        successful=FileSet([
+            LocalPath("/local/file1"),
+            LocalPath("/local/file2"),
+        ]),
+        failed=FileSet([
+            FailedLocalFile("/failed/file")
+        ]),
+        skipped=FileSet([
+            RemoteFile("/existing/file")
+        ]),
+        missing=FileSet([
+            RemotePath("/missing/file")
+        ]),
+    )
     """
 
     successful: FileSet[LocalPath] = Field(default_factory=FileSet)

--- a/onetl/file/file_mover/file_mover.py
+++ b/onetl/file/file_mover/file_mover.py
@@ -177,7 +177,7 @@ class FileMover(FrozenModel):
 
         Returns
         -------
-        moved_files : :obj:`MoveResult <onetl.file.file_mover.move_result.MoveResult>`
+        :obj:`MoveResult <onetl.file.file_mover.move_result.MoveResult>`
 
             Move result object
 
@@ -194,76 +194,76 @@ class FileMover(FrozenModel):
         Examples
         --------
 
-        Move files from ``source_path``
+        Move files from ``source_path``:
 
-        .. code:: python
-
-            from onetl.impl import RemoteFile, RemotePath
-            from onetl.file import FileMover
-
-            mover = FileMover(source_path="/source", target_path="/target", ...)
-            moved_files = mover.run()
-
-            assert moved_files.successful == {
+        >>> from onetl.file import FileMover
+        >>> mover = FileMover(source_path="/source", target_path="/target", ...)
+        >>> move_result = mover.run()
+        >>> move_result
+        MoveResult(
+            successful=FileSet([
                 RemoteFile("/target/file1.txt"),
                 RemoteFile("/target/file2.txt"),
-                RemoteFile("/target/nested/path/file3.txt"),  # directory structure is preserved
-            }
-            assert moved_files.failed == {FailedRemoteFile("/source/failed.file")}
-            assert moved_files.skipped == {RemoteFile("/source/already.exists")}
-            assert moved_files.missing == {RemotePath("/source/missing.file")}
+                # directory structure is preserved
+                RemoteFile("/target/nested/path/file3.txt"),
+            ]),
+            failed=FileSet([
+                FailedRemoteFile("/source/failed.file"),
+            ]),
+            skipped=FileSet([
+                RemoteFile("/source/already.exists"),
+            ]),
+            missing=FileSet([
+                RemotePath("/source/missing.file"),
+            ]),
+        )
 
-        Move only certain files from ``source_path``
+        Move only certain files from ``source_path``:
 
-        .. code:: python
-
-            from onetl.impl import RemoteFile
-            from onetl.file import FileMover
-
-            mover = FileMover(source_path="/source", target_path="/target", ...)
-
-            # paths could be relative or absolute, but all should be in "/source"
-            moved_files = mover.run(
-                [
-                    "/source/file1.txt",
-                    "/source/nested/path/file3.txt",
-                    # excluding "/source/file2.txt"
-                ]
-            )
-
-            assert moved_files.successful == {
+        >>> from onetl.file import FileMover
+        >>> mover = FileMover(source_path="/source", target_path="/target", ...)
+        >>> # paths could be relative or absolute, but all should be in "/source"
+        >>> move_result = mover.run(
+        ...     [
+        ...         "/source/file1.txt",
+        ...         "/source/nested/path/file3.txt",
+        ...         # excluding "/source/file2.txt"
+        ...     ]
+        ... )
+        >>> move_result
+        MoveResult(
+            successful=FileSet([
                 RemoteFile("/target/file1.txt"),
-                RemoteFile("/target/nested/path/file3.txt"),  # directory structure is preserved
-            }
-            assert not moved_files.failed
-            assert not moved_files.skipped
-            assert not moved_files.missing
+                # directory structure is preserved
+                RemoteFile("/target/nested/path/file3.txt"),
+            ]),
+            failed=FileSet([]),
+            skipped=FileSet([]),
+            missing=FileSet([]),
+        )
 
-        Move certain files from any folder
+        Move certain files from any folder:
 
-        .. code:: python
-
-            from onetl.impl import RemoteFile
-            from onetl.file import FileMover
-
-            mover = FileMover(target_path="/target", ...)  # no source_path set
-
-            # only absolute paths
-            moved_files = mover.run(
-                [
-                    "/remote/file1.txt",
-                    "/any/nested/path/file3.txt",
-                ]
-            )
-
-            assert moved_files.successful == {
+        >>> from onetl.file import FileMover
+        >>> mover = FileMover(target_path="/target", ...)  # no source_path set
+        >>> # only absolute paths
+        >>> move_result = mover.run(
+        ...     [
+        ...         "/remote/file1.txt",
+        ...         "/any/nested/path/file3.txt",
+        ...     ]
+        ... )
+        >>> move_result
+        MoveResult(
+            successful=FileSet([
                 RemoteFile("/target/file1.txt"),
-                RemoteFile("/target/file3.txt"),
                 # directory structure is NOT preserved without source_path
-            }
-            assert not moved_files.failed
-            assert not moved_files.skipped
-            assert not moved_files.missing
+                RemoteFile("/target/file3.txt"),
+            ]),
+            failed=FileSet([]),
+            skipped=FileSet([]),
+            missing=FileSet([]),
+        )
         """
 
         entity_boundary_log(log, f"{self.__class__.__name__}.run() starts")
@@ -327,22 +327,16 @@ class FileMover(FrozenModel):
         Examples
         --------
 
-        View files
+        View files:
 
-        .. code:: python
-
-            from onetl.impl import RemoteFile
-            from onetl.file import FileMover
-
-            mover = FileMover(source_path="/remote", ...)
-
-            view_files = mover.view_files()
-
-            assert view_files == {
-                RemoteFile("/remote/file1.txt"),
-                RemoteFile("/remote/file3.txt"),
-                RemoteFile("/remote/nested/path/file3.txt"),
-            }
+        >>> from onetl.file import FileMover
+        >>> mover = FileMover(source_path="/remote", ...)
+        >>> mover.view_files()
+        FileSet([
+            RemoteFile("/remote/file1.txt"),
+            RemoteFile("/remote/file2.txt"),
+            RemoteFile("/remote/nested/path/file3.txt"),
+        ])
         """
 
         if not self.source_path:

--- a/onetl/file/file_mover/result.py
+++ b/onetl/file/file_mover/result.py
@@ -25,34 +25,33 @@ class MoveResult(FileResult):
     Examples
     --------
 
-    Move files
-
-    .. code:: python
-
-        from onetl.impl import RemotePath, RemoteFile, FailedLocalFile
-        from onetl.file import FileMover, MoveResult
-
-        mover = FileMover(local_path="/local", ...)
-
-        moved_files = mover.run(
-            [
-                "/source/file1",
-                "/source/file2",
-                "/failed/file",
-                "/existing/file",
-                "/missing/file",
-            ]
-        )
-
-        assert moved_files == MoveResult(
-            successful={
-                RemoteFile("/target/file1"),
-                RemoteFile("/target/file2"),
-            },
-            failed={FailedLocalFile("/failed/file")},
-            skipped={RemoteFile("/existing/file")},
-            missing={RemotePath("/missing/file")},
-        )
+    >>> from onetl.file import FileMover
+    >>> mover = FileMover(local_path="/local", ...)
+    >>> move_result = mover.run(
+    ...     [
+    ...         "/source/file1",
+    ...         "/source/file2",
+    ...         "/failed/file",
+    ...         "/existing/file",
+    ...         "/missing/file",
+    ...     ]
+    ... )
+    >>> move_result
+    MoveResult(
+        successful=FileSet([
+            RemoteFile("/target/file1"),
+            RemoteFile("/target/file2"),
+        ]),
+        failed=FileSet([
+            FailedLocalFile("/failed/file")
+        ]),
+        skipped=FileSet([
+            RemoteFile("/existing/file")
+        ]),
+        missing=FileSet([
+            RemotePath("/missing/file")
+        ]),
+    )
     """
 
     successful: FileSet[RemoteFile] = Field(default_factory=FileSet)

--- a/onetl/file/file_result.py
+++ b/onetl/file/file_result.py
@@ -61,16 +61,13 @@ class FileResult(BaseModel):
         Examples
         --------
 
-        .. code:: python
-
-            from onetl.impl import LocalPath
-            from onet.file.file_result import FileResult
-
-            file_result = FileResult(
-                successful={LocalPath("/some/file"), LocalPath("/some/another.file")},
-            )
-
-            assert file_result.successful_count == 2
+        >>> from onetl.impl import LocalPath
+        >>> from onetl.file.file_result import FileResult
+        >>> file_result = FileResult(
+        ...     successful={LocalPath("/some/file"), LocalPath("/some/another.file")},
+        ... )
+        >>> file_result.successful_count
+        2
         """
 
         return len(self.successful)
@@ -83,16 +80,13 @@ class FileResult(BaseModel):
         Examples
         --------
 
-        .. code:: python
-
-            from onetl.impl import RemoteFile
-            from onet.file.file_result import FileResult
-
-            file_result = FileResult(
-                failed={RemoteFile("/some/file"), RemoteFile("/some/another.file")},
-            )
-
-            assert file_result.failed_count == 2
+        >>> from onetl.impl import RemoteFile
+        >>> from onetl.file.file_result import FileResult
+        >>> file_result = FileResult(
+        ...     failed={RemoteFile("/some/file"), RemoteFile("/some/another.file")},
+        ... )
+        >>> file_result.failed_count
+        2
         """
 
         return len(self.failed)
@@ -105,16 +99,13 @@ class FileResult(BaseModel):
         Examples
         --------
 
-        .. code:: python
-
-            from onetl.impl import LocalPath
-            from onet.file.file_result import FileResult
-
-            file_result = FileResult(
-                skipped={LocalPath("/some/file"), LocalPath("/some/another.file")},
-            )
-
-            assert file_result.skipped_count == 2
+        >>> from onetl.impl import LocalPath
+        >>> from onetl.file.file_result import FileResult
+        >>> file_result = FileResult(
+        ...     skipped={LocalPath("/some/file"), LocalPath("/some/another.file")},
+        ... )
+        >>> file_result.skipped_count
+        2
         """
 
         return len(self.skipped)
@@ -127,16 +118,13 @@ class FileResult(BaseModel):
         Examples
         --------
 
-        .. code:: python
-
-            from onetl.impl import LocalPath
-            from onet.file.file_result import FileResult
-
-            file_result = FileResult(
-                missing={LocalPath("/some/file"), LocalPath("/some/another.file")},
-            )
-
-            assert file_result.missing_count == 2
+        >>> from onetl.impl import LocalPath
+        >>> from onetl.file.file_result import FileResult
+        >>> file_result = FileResult(
+        ...     missing={LocalPath("/some/file"), LocalPath("/some/another.file")},
+        ... )
+        >>> file_result.missing_count
+        2
         """
 
         return len(self.missing)
@@ -149,19 +137,16 @@ class FileResult(BaseModel):
         Examples
         --------
 
-        .. code:: python
-
-            from onetl.impl import RemoteFile, LocalPath
-            from onet.file.file_result import FileResult
-
-            file_result = FileResult(
-                successful={LocalPath("/local/file"), LocalPath("/local/another.file")},
-                failed={RemoteFile("/remote/file"), RemoteFile("/remote/another.file")},
-                skipped={LocalPath("/skipped/file")},
-                missing={LocalPath("/missing/file")},
-            )
-
-            assert file_result.total_count == 6
+        >>> from onetl.impl import RemoteFile
+        >>> from onetl.file.file_result import FileResult
+        >>> file_result = FileResult(
+        ...     successful={LocalPath("/local/file"), LocalPath("/local/another.file")},
+        ...     failed={RemoteFile("/remote/file"), RemoteFile("/remote/another.file")},
+        ...     skipped={LocalPath("/skipped/file")},
+        ...     missing={LocalPath("/missing/file")},
+        ... )
+        >>> file_result.total_count
+        6
         """
 
         return self.successful_count + self.failed_count + self.missing_count + self.skipped_count
@@ -174,16 +159,13 @@ class FileResult(BaseModel):
         Examples
         --------
 
-        .. code:: python
-
-            from onetl.impl import LocalPath
-            from onet.file.file_result import FileResult
-
-            file_result = FileResult(
-                successful={LocalPath("/some/file"), LocalPath("/some/another.file")},
-            )
-
-            assert file_result.successful_size == 1_000_000  # in bytes
+        >>> from onetl.impl import LocalPath
+        >>> from onetl.file.file_result import FileResult
+        >>> file_result = FileResult(
+        ...     successful={LocalPath("/some/file"), LocalPath("/some/another.file")},
+        ... )
+        >>> file_result.successful_size  # in bytes
+        1024
         """
 
         return self.successful.total_size
@@ -196,16 +178,16 @@ class FileResult(BaseModel):
         Examples
         --------
 
-        .. code:: python
-
-            from onetl.impl import RemoteFile
-            from onet.file.file_result import FileResult
-
-            file_result = FileResult(
-                failed={RemoteFile("/some/file"), RemoteFile("/some/another.file")},
-            )
-
-            assert file_result.failed_size == 1_000_000  # in bytes
+        >>> from onetl.impl import RemoteFile, RemotePathStat
+        >>> from onetl.file.file_result import FileResult
+        >>> file_result = FileResult(
+        ...     failed={
+        ...         RemoteFile("/some/file", stats=RemotePathStat(st_size=1024)),
+        ...         RemoteFile("/some/another.file"), stats=RemotePathStat(st_size=1024)),
+        ...     },
+        ... )
+        >>> file_result.failed_size  # in bytes
+        2048
         """
 
         return self.failed.total_size
@@ -218,16 +200,13 @@ class FileResult(BaseModel):
         Examples
         --------
 
-        .. code:: python
-
-            from onetl.impl import LocalPath
-            from onet.file.file_result import FileResult
-
-            file_result = FileResult(
-                skipped={LocalPath("/some/file"), LocalPath("/some/another.file")},
-            )
-
-            assert file_result.skipped_size == 1_000_000  # in bytes
+        >>> from onetl.impl import LocalPath
+        >>> from onetl.file.file_result import FileResult
+        >>> file_result = FileResult(
+        ...     skipped={LocalPath("/some/file"), LocalPath("/some/another.file")},
+        ... )
+        >>> file_result.skipped_size  # in bytes
+        1024
         """
 
         return self.skipped.total_size
@@ -240,19 +219,19 @@ class FileResult(BaseModel):
         Examples
         --------
 
-        .. code:: python
-
-            from onetl.impl import RemoteFile, LocalPath
-            from onet.file.file_result import FileResult
-
-            file_result = FileResult(
-                successful={LocalPath("/local/file"), LocalPath("/local/another.file")},
-                failed={RemoteFile("/remote/file"), RemoteFile("/remote/another.file")},
-                skipped={LocalPath("/skipped/file")},
-                missing={LocalPath("/missing/file")},
-            )
-
-            assert file_result.total_size == 10_000_000  # in bytes
+        >>> from onetl.impl import RemoteFile, RemotePathStat, LocalPath
+        >>> from onetl.file.file_result import FileResult
+        >>> file_result = FileResult(
+        ...     successful={LocalPath("/local/file"), LocalPath("/local/another.file")},
+        ...     failed={
+        ...         RemoteFile("/remote/file", stats=RemotePathStat(st_size=1024)),
+        ...         RemoteFile("/remote/another.file", stats=RemotePathStat(st_size=1024))
+        ...     },
+        ...     skipped={LocalPath("/skipped/file")},
+        ...     missing={LocalPath("/missing/file")},
+        ... )
+        >>> file_result.total_size  # in bytes
+        4096
         """
 
         return self.successful_size + self.failed_size + self.skipped_size
@@ -270,33 +249,31 @@ class FileResult(BaseModel):
         Examples
         --------
 
-        .. code:: python
-
-            from onetl.impl import RemoteFile, LocalPath
-            from onet.file.file_result import FileResult
-
-            files_with_exception = [
-                FailedRemoteFile(
-                    path="/remote/file1",
-                    exception=NotAFileError("'/remote/file1' is not a file"),
-                ),
-                FailedRemoteFile(
-                    path="/remote/file2",
-                    exception=FileMissingError("'/remote/file2' does not exist"),
-                ),
-            ]
-
-            file_result = FileResult(failed=files_with_exception)
-
-            file_result.raise_if_failed()
-            # will raise FailedFilesError('''
-            #    Failed 2 files (10MB):
-            #        '/remote/file1' (1 MB)
-            #           NotAFileError("'/remote/file1' is not a file")
-            #
-            #        '/remote/file2' (9 MB)
-            #           FileMissingError("'/remote/file2' does not exist")
-            # ''')
+        >>> from onetl.impl import FailedRemoteFile, RemotePathStat
+        >>> from onetl.exception import NotAFileError, FileMissingError
+        >>> from onetl.file.file_result import FileResult
+        >>> files_with_exception = [
+        ...     FailedRemoteFile(
+        ...         path="/remote/file1",
+        ...         stats=RemotePathStat(st_size=0),
+        ...         exception=NotAFileError("'/remote/file1' is not a file"),
+        ...     ),
+        ...     FailedRemoteFile(
+        ...         path="/remote/file2",
+        ...         stats=RemotePathStat(st_size=0),
+        ...         exception=PermissionError("'/remote/file2': [Errno 13] Permission denied"),
+        ...     ),
+        ... ]
+        >>> file_result = FileResult(failed=files_with_exception)
+        >>> file_result.raise_if_failed()
+        Traceback (most recent call last)
+        ...
+        onetl.exception.FailedFilesError: Failed 2 files (size='0 bytes'):
+            '/remote/file1' (size='0 bytes')
+                NotAFileError("'/remote/file1' is not a file")
+        <BLANKLINE>
+            '/remote/file2' (size='0 Bytes')
+                PermissionError("'/remote/file2': [Errno 13] Permission denied")
         """
 
         if self.failed:
@@ -315,24 +292,20 @@ class FileResult(BaseModel):
         Examples
         --------
 
-        .. code:: python
-
-            from onetl.impl import RemoteFile, LocalPath
-            from onet.file.file_result import FileResult
-
-            file_result = FileResult(
-                missing={
-                    LocalPath("/missing/file1"),
-                    LocalPath("/missing/file2"),
-                },
-            )
-
-            file_result.raise_if_missing()
-            # will raise MissingFilesError('''
-            #    Missing 2 files:
-            #        '/missing/file1'
-            #        '/missing/file2'
-            # ''')
+        >>> from onetl.impl import LocalPath
+        >>> from onetl.file.file_result import FileResult
+        >>> file_result = FileResult(
+        ...     missing={
+        ...         LocalPath("/missing/file1"),
+        ...         LocalPath("/missing/file2"),
+        ...     },
+        ... )
+        >>> file_result.raise_if_missing()
+        Traceback (most recent call last):
+            ...
+        onetl.exception.MissingFilesError: Missing 2 files:
+            '/missing/file1'
+            '/missing/file2'
         """
 
         if self.missing:
@@ -351,21 +324,20 @@ class FileResult(BaseModel):
         Examples
         --------
 
-        .. code:: python
-
-            from onetl.impl import RemoteFile, LocalPath
-            from onet.file.file_result import FileResult
-
-            file_result = FileResult(
-                skipped={LocalPath("/skipped/file1"), LocalPath("/skipped/file2")},
-            )
-
-            file_result.raise_if_skipped()
-            # will raise SkippedFilesError('''
-            #    Skipped 2 files (15 kB):
-            #        '/skipped/file1' (10kB)
-            #        '/skipped/file2' (5 kB)
-            # ''')
+        >>> from onetl.impl import LocalPath
+        >>> from onetl.file.file_result import FileResult
+        >>> file_result = FileResult(
+        ...     skipped={
+        ...         LocalPath("/skipped/file1"),
+        ...         LocalPath("/skipped/file2"),
+        ...     },
+        ... )
+        >>> file_result.raise_if_skipped()
+        Traceback (most recent call last):
+            ...
+        onetl.exception.SkippedFilesError: Skipped 2 files (15 kB):
+            '/skipped/file1' (10kB)
+            '/skipped/file2' (5 kB)
         """
 
         if self.skipped:
@@ -384,25 +356,22 @@ class FileResult(BaseModel):
         Examples
         --------
 
-        .. code:: python
-
-            from onetl.impl import RemoteFile, LocalPath
-            from onet.file.file_result import FileResult
-
-            file_result = FileResult(
-                successful={
-                    LocalPath("/local/empty1.file"),
-                    LocalPath("/local/empty2.file"),
-                    LocalPath("/local/normal.file"),
-                },
-            )
-
-            file_result.raise_if_contains_zero_size()
-            # will raise ZeroFileSizeError('''
-            #    2 files out of 3 have zero size:
-            #        '/local/empty1.file'
-            #        '/local/empty2.file'
-            # ''')
+        >>> from onetl.exception import ZeroFileSizeError
+        >>> from onetl.impl import LocalPath
+        >>> from onetl.file.file_result import FileResult
+        >>> file_result = FileResult(
+        ...     successful={
+        ...         LocalPath("/local/empty1.file"),
+        ...         LocalPath("/local/empty2.file"),
+        ...         LocalPath("/local/normal.file"),
+        ...     },
+        ... )
+        >>> file_result.raise_if_contains_zero_size()
+        Traceback (most recent call last):
+            ...
+        onetl.exception.ZeroFileSizeError: 2 files out of 3 have zero size:
+            '/local/empty1.file'
+            '/local/empty2.file'
         """
 
         self.successful.raise_if_contains_zero_size()
@@ -415,18 +384,16 @@ class FileResult(BaseModel):
         Examples
         --------
 
-        .. code:: python
-
-            from onetl.impl import LocalPath
-            from onet.file.file_result import FileResult
-
-            file_result1 = FileResult()
-            assert file_result1.is_empty
-
-            file_result2 = FileResult(
-                successful={LocalPath("/local/file"), LocalPath("/local/another.file")},
-            )
-            assert not file_result2.is_empty
+        >>> from onetl.impl import LocalPath
+        >>> from onetl.file.file_result import FileResult
+        >>> file_result1 = FileResult()
+        >>> file_result1.is_empty
+        True
+        >>> file_result2 = FileResult(
+        ...     successful={LocalPath("/local/file"), LocalPath("/local/another.file")},
+        ... )
+        >>> file_result2.is_empty
+        False
         """
 
         return not self.failed and not self.successful and not self.skipped
@@ -444,15 +411,12 @@ class FileResult(BaseModel):
         Examples
         --------
 
-        .. code:: python
-
-            from onetl.impl import RemoteFile, LocalPath
-            from onet.file.file_result import FileResult
-
-            file_result = FileResult()
-
-            file_result.raise_if_empty()
-            # will raise EmptyFilesError("There are no files in the result")
+        >>> from onetl.file.file_result import FileResult
+        >>> file_result = FileResult()
+        >>> file_result.raise_if_empty()
+        Traceback (most recent call last):
+            ...
+        onetl.exception.EmptyFilesError: There are no files in the result
         """
 
         if self.is_empty:
@@ -460,71 +424,66 @@ class FileResult(BaseModel):
 
     @property
     def details(self) -> str:
-        '''
+        """
         Return detailed information about files in the result object
 
         Examples
         --------
 
-        .. code:: python
+        >>> from onetl.impl import FailedRemoteFile, LocalPath, RemoteFile, RemotePathStat
+        >>> from onetl.exception import NotAFileError
+        >>> from onetl.file.file_result import FileResult
+        >>> file_result1 = FileResult(
+        ...     successful={
+        ...         RemoteFile("/local/file", stats=RemotePathStat(st_size=1024)),
+        ...         RemoteFile("/local/another.file", stats=RemotePathStat(st_size=1024)),
+        ...     },
+        ...     failed={
+        ...         FailedRemoteFile(
+        ...             path="/remote/file1",
+        ...             stats=RemotePathStat(st_size=0),
+        ...             exception=NotAFileError("'/remote/file1' is not a file"),
+        ...         ),
+        ...         FailedRemoteFile(
+        ...             path="/remote/file2",
+        ...             stats=RemotePathStat(st_size=0),
+        ...             exception=PermissionError("'/remote/file2': [Errno 13] Permission denied"),
+        ...         ),
+        ...     },
+        ...     skipped={LocalPath("/skipped/file1"), LocalPath("/skipped/file2")},
+        ...     missing={LocalPath("/missing/file1"), LocalPath("/missing/file2")},
+        ... )
+        >>> print(file_result1.details)
+        Total: 8 files (size='2.0 kB')
+        <BLANKLINE>
+        Successful 2 files (size='2.0 kB'):
+            '/local/another.file' (size='1.0 kB')
+            '/local/file' (size='1.0 kB')
+        <BLANKLINE>
+        Failed 2 files (size='0 Bytes'):
+            '/remote/file2' (size='0 Bytes')
+                PermissionError("'/remote/file2': [Errno 13] Permission denied")
+            '/remote/file1' (size='0 Bytes')
+                NotAFileError("'/remote/file1' is not a file")
+        <BLANKLINE>
+        Skipped 2 files (size='0 Bytes'):
+            '/skipped/file1'
+            '/skipped/file2'
+        <BLANKLINE>
+        Missing 2 files:
+            '/missing/file2'
+            '/missing/file1'
 
-            from onetl.impl import RemoteFile, LocalPath
-            from onet.file.file_result import FileResult
-
-            file_result1 = FileResult(
-                successful={LocalPath("/local/file"), LocalPath("/local/another.file")},
-                failed={
-                    FailedRemoteFile(
-                        path="/remote/file1",
-                        exception=NotAFileError("'/remote/file1' is not a file"),
-                    ),
-                    FailedRemoteFile(
-                        path="/remote/file2",
-                        exception=FileMissingError("'/remote/file2' does not exist"),
-                    ),
-                },
-                skipped={LocalPath("/skipped/file1"), LocalPath("/skipped/file2")},
-                missing={LocalPath("/missing/file1"), LocalPath("/missing/file2")},
-            )
-
-            details1 = """
-                Total: 8 files (10.4 MB)
-
-                Successful 2 files (30.7 kB):
-                    '/successful1' (10.2 kB)
-                    '/successful2' (20.5 kB)
-
-                Failed 2 files (10MB):
-                    '/remote/file1' (1 MB)
-                        NotAFileError("'/remote/file1' is not a file")
-
-                    '/remote/file2' (9 MB)
-                        FileMissingError("'/remote/file2' does not exist")
-
-                Skipped 2 files (15 kB):
-                    '/skipped/file1' (10kB)
-                    '/skipped/file2' (5 kB)
-
-                Missing 2 files:
-                    '/missing/file1'
-                    '/missing/file2'
-            """
-
-            assert file_result1.details == details1
-
-            file_result2 = FileResult()
-            details2 = """
-                No successful files
-
-                No failed files
-
-                No skipped files
-
-                No missing files
-            """
-
-            assert file_result2.details == details2
-        '''
+        >>> file_result2 = FileResult()
+        >>> print(file_result2.details)
+        No successful files
+        <BLANKLINE>
+        No failed files
+        <BLANKLINE>
+        No skipped files
+        <BLANKLINE>
+        No missing files
+        """
 
         result = []
 
@@ -540,41 +499,50 @@ class FileResult(BaseModel):
 
     @property
     def summary(self) -> str:
-        '''
+        """
         Return short summary about files in the result object
 
         Examples
         --------
 
-        .. code:: python
+        >>> from onetl.impl import FailedRemoteFile, LocalPath, RemoteFile, RemotePathStat
+        >>> from onetl.exception import NotAFileError
+        >>> from onetl.file.file_result import FileResult
+        >>> file_result1 = FileResult(
+        ...     successful={
+        ...         RemoteFile("/local/file", stats=RemotePathStat(st_size=1024)),
+        ...         RemoteFile("/local/another.file", stats=RemotePathStat(st_size=1024)),
+        ...     },
+        ...     failed={
+        ...         FailedRemoteFile(
+        ...             path="/remote/file1",
+        ...             stats=RemotePathStat(st_size=0),
+        ...             exception=NotAFileError("'/remote/file1' is not a file"),
+        ...         ),
+        ...         FailedRemoteFile(
+        ...             path="/remote/file2",
+        ...             stats=RemotePathStat(st_size=0),
+        ...             exception=PermissionError("'/remote/file2': [Errno 13] Permission denied"),
+        ...         ),
+        ...     },
+        ...     skipped={LocalPath("/skipped/file1"), LocalPath("/skipped/file2")},
+        ...     missing={LocalPath("/missing/file1"), LocalPath("/missing/file2")},
+        ... )
+        >>> print(file_result1.summary)
+        Total: 8 files (size='2.0 kB')
+        <BLANKLINE>
+        Successful: 2 files (size='2.0 kB')
+        <BLANKLINE>
+        Failed: 2 files (size='0 Bytes')
+        <BLANKLINE>
+        Skipped: 2 files (size='0 Bytes')
+        <BLANKLINE>
+        Missing: 2 files
 
-            from onetl.impl import RemoteFile, LocalPath
-            from onet.file.file_result import FileResult
-
-            file_result1 = FileResult(
-                successful={LocalPath("/local/file"), LocalPath("/local/another.file")},
-                failed={RemoteFile("/remote/file"), RemoteFile("/remote/another.file")},
-                skipped={LocalPath("/skipped/file")},
-                missing={LocalPath("/missing/file")},
-            )
-
-            result = """
-                Total: 8 files (10.4 MB)
-
-                Successful: 2 files (30.7 kB)
-
-                Failed: 2 files (10MB)
-
-                Skipped: 2 files (15 kB)
-
-                Missing: 2 files
-            """
-
-            assert file_result1.summary == result
-
-            file_result2 = FileResult()
-            assert file_result1.summary == "No files"
-        '''
+        >>> file_result2 = FileResult()
+        >>> print(file_result2.summary)
+        No files
+        """
         return self._total_message
 
     def __str__(self):

--- a/onetl/file/file_set.py
+++ b/onetl/file/file_set.py
@@ -33,14 +33,11 @@ class FileSet(OrderedSet[T], Generic[T]):
         Examples
         --------
 
-        .. code:: python
-
-            from onetl.impl import LocalPath
-            from onet.file.file_set import FileSet
-
-            file_set = FileSet({LocalPath("/some/file"), LocalPath("/some/another.file")})
-
-            assert path_set.total_size == 1_000_000  # in bytes
+        >>> from onetl.impl import LocalPath
+        >>> from onet.file.file_set import FileSet
+        >>> file_set = FileSet({LocalPath("/some/file"), LocalPath("/some/another.file")})
+        >>> path_set.total_size  # in bytes
+        1024
         """
 
         return sum(
@@ -60,14 +57,12 @@ class FileSet(OrderedSet[T], Generic[T]):
         Examples
         --------
 
-        .. code:: python
-
-            from onet.file.file_set import FileSet
-
-            file_set = FileSet()
-
-            file_set.raise_if_empty()
-            # will raise EmptyFilesError("There are no files in the set")
+        >>> from onet.file.file_set import FileSet
+        >>> file_set = FileSet()
+        >>> file_set.raise_if_empty()
+        Traceback (most recent call last):
+            ...
+        onetl.exception.EmptyFilesError: There are no files in the set
         """
 
         if not self:
@@ -86,23 +81,19 @@ class FileSet(OrderedSet[T], Generic[T]):
         Examples
         --------
 
-        .. code:: python
-
-            from onetl.impl import RemoteFile, LocalPath
-            from onet.file.file_set import FileSet
-
-            file_set = FileSet(
-                LocalPath("/local/empty1.file"),
-                LocalPath("/local/empty2.file"),
-                LocalPath("/local/normal.file"),
-            )
-
-            file_set.raise_if_contains_zero_size()
-            # will raise ZeroFileSizeError('''
-            #    2 files out of 3 have zero size:
-            #        '/local/empty1.file'
-            #        '/local/empty2.file'
-            # ''')
+        >>> from onetl.impl import RemoteFile, LocalPath
+        >>> from onet.file.file_set import FileSet
+        >>> file_set = FileSet(
+        ...     LocalPath("/local/empty1.file"),
+        ...     LocalPath("/local/empty2.file"),
+        ...     LocalPath("/local/normal.file"),
+        ... )
+        >>> file_set.raise_if_contains_zero_size()
+        Traceback (most recent call last):
+            ...
+        onetl.exception.ZeroFileSizeError: 2 files out of 3 have zero size:
+            '/local/empty1.file'
+            '/local/empty2.file'
         """
 
         lines = []
@@ -132,21 +123,19 @@ class FileSet(OrderedSet[T], Generic[T]):
         Examples
         --------
 
-        .. code:: python
-
-            from onetl.impl import LocalPath
-            from onet.file.file_set import FileSet
-
-            path_set1 = FileSet(
-                [
-                    LocalPath("/local/file"),
-                    LocalPath("/local/another.file"),
-                ]
-            )
-
-            assert path_set1.summary == "2 files (30.7 kB)"
-
-            assert FileSet().summary == "No files"
+        >>> from onetl.impl import LocalPath
+        >>> from onet.file.file_set import FileSet
+        >>> path_set1 = FileSet(
+        ...     [
+        ...         LocalPath("/local/file"),
+        ...         LocalPath("/local/another.file"),
+        ...     ]
+        ... )
+        >>> print(path_set1.summary)
+        2 files (30.7 kB)
+        >>> path_set2 = FileSet()
+        >>> print(path_set2.summary)
+        No files
         """
 
         if not self:
@@ -156,35 +145,30 @@ class FileSet(OrderedSet[T], Generic[T]):
         return f"{file_number_str} (size='{naturalsize(self.total_size)}')"
 
     @property
-    def details(self) -> str:
-        '''
+    def details(self) -> str:  # noqa: WPS473
+        """
         Return detailed information about files in the set
 
         Examples
         --------
 
-        .. code:: python
+        >>> from onetl.impl import LocalPath
+        >>> from onet.file.file_set import FileSet
+        >>> path_set1 = FileSet(
+        ...     [
+        ...         LocalPath("/local/file"),
+        ...         LocalPath("/local/another.file"),
+        ...     ]
+        ... )
+        >>> print(path_set1.details)
+        2 files (30.7 kB):
+            '/local/file' (10.2 kB)
+            '/local/another.file' (20.5 kB)
 
-            from onetl.impl import LocalPath
-            from onet.file.file_set import FileSet
-
-            path_set1 = FileSet(
-                [
-                    LocalPath("/local/file"),
-                    LocalPath("/local/another.file"),
-                ]
-            )
-
-            details1 = """
-                2 files (30.7 kB):
-                    '/local/file' (10.2 kB)
-                    '/local/another.file' (20.5 kB)
-            """
-
-            assert path_set1.details == details1
-
-            assert FileSet().details == "No files"
-        '''
+        >>> path_set2 = FileSet()
+        >>> print(path_set2.details)
+        No files
+        """
 
         if not self:
             return self.summary

--- a/onetl/file/file_uploader/file_uploader.py
+++ b/onetl/file/file_uploader/file_uploader.py
@@ -161,7 +161,7 @@ class FileUploader(FrozenModel):
 
         Returns
         -------
-        uploaded_files : :obj:`UploadResult <onetl.file.file_uploader.upload_result.UploadResult>`
+        :obj:`UploadResult <onetl.file.file_uploader.upload_result.UploadResult>`
 
             Upload result object
 
@@ -182,85 +182,76 @@ class FileUploader(FrozenModel):
         Examples
         --------
 
-        Upload files from ``local_path`` to ``target_path``
+        Upload files from ``local_path`` to ``target_path``:
 
-        .. code:: python
-
-            from onetl.impl import (
-                RemoteFile,
-                LocalPath,
-            )
-            from onetl.file import FileUploader
-
-            uploader = FileUploader(local_path="/local", target_path="/remote", ...)
-            uploaded_files = uploader.run()
-
-            assert uploaded_files.successful == {
+        >>> from onetl.file import FileUploader
+        >>> uploader = FileUploader(local_path="/local", target_path="/remote", ...)
+        >>> upload_result = uploader.run()
+        >>> upload_result
+        UploadResult(
+            successful=FileSet([
                 RemoteFile("/remote/file1"),
                 RemoteFile("/remote/file2"),
-                RemoteFile("/remote/nested/path/file3"),  # directory structure is preserved
-            }
-            assert uploaded_files.failed == {FailedLocalFile("/local/failed.file")}
-            assert uploaded_files.skipped == {LocalPath("/local/already.exists")}
-            assert uploaded_files.missing == {LocalPath("/local/missing.file")}
+                # directory structure is preserved
+                RemoteFile("/remote/nested/path/file3")
+            ]),
+            failed=FileSet([
+                FailedLocalFile("/local/failed.file"),
+            ]),
+            skipped=FileSet([
+                LocalPath("/local/already.exists"),
+            ]),
+            missing=FileSet([
+                LocalPath("/local/missing.file"),
+            ]),
+        )
 
-        Upload only certain files from ``local_path``
+        Upload only certain files from ``local_path``:
 
-        .. code:: python
-
-            from onetl.impl import (
-                RemoteFile,
-                LocalPath,
-            )
-            from onetl.file import FileUploader
-
-            uploader = FileUploader(local_path="/local", target_path="/remote", ...)
-
-            # paths could be relative or absolute, but all should be in "/local"
-            uploaded_files = uploader.run(
-                [
-                    "/local/file1",
-                    "/local/nested/path/file3",
-                    # excluding "/local/file2",
-                ]
-            )
-
-            assert uploaded_files.successful == {
+        >>> from onetl.file import FileUploader
+        >>> uploader = FileUploader(local_path="/local", target_path="/remote", ...)
+        >>> # paths could be relative or absolute, but all should be in "/local"
+        >>> upload_result = uploader.run(
+        ...     [
+        ...         "/local/file1",
+        ...         "/local/nested/path/file3",
+        ...         # excluding "/local/file2",
+        ...     ]
+        ... )
+        >>> upload_result
+        UploadResult(
+            successful=FileSet([
                 RemoteFile("/remote/file1"),
-                RemoteFile("/remote/nested/path/file3"),  # directory structure is preserved
-            }
-            assert not uploaded_files.failed
-            assert not uploaded_files.skipped
-            assert not uploaded_files.missing
+                # directory structure is preserved
+                RemoteFile("/remote/nested/path/file3"),
+            ]),
+            failed=FileSet([]),
+            skipped=FileSet([]),
+            missing=FileSet([]),
+        )
 
-        Upload only certain files from any folder
+        Upload only certain files from any folder:
 
-        .. code:: python
-
-            from onetl.impl import (
-                RemoteFile,
-                LocalPath,
-            )
-            from onetl.file import FileUploader
-
-            uploader = FileUploader(target_path="/remote", ...)  # no local_path set
-
-            # only absolute paths
-            uploaded_files = uploader.run(
-                [
-                    "/local/file1.txt",
-                    "/any/nested/path/file3.txt",
-                ]
-            )
-
-            assert uploaded_files.successful == {
-                RemoteFile("/remote/file1"),
-                RemoteFile("/remote/file3"),
+        >>> from onetl.file import FileUploader
+        >>> uploader = FileUploader(target_path="/remote", ...)  # no local_path set
+        >>> # only absolute paths
+        >>> upload_result = uploader.run(
+        ...     [
+        ...         "/local/file1.txt",
+        ...         "/any/nested/path/file3.txt",
+        ...     ]
+        ... )
+        >>> upload_result
+        UploadResult(
+            successful=FileSet([
+                RemoteFile("/remote/file1.txt"),
                 # directory structure is NOT preserved without local_path
-            }
-            assert not uploaded_files.failed
-            assert not uploaded_files.skipped
-            assert not uploaded_files.missing
+                RemoteFile("/remote/file3.txt"),
+            ]),
+            failed=FileSet([]),
+            skipped=FileSet([]),
+            missing=FileSet([]),
+        )
         """
 
         entity_boundary_log(log, f"{self.__class__.__name__}.run() starts")
@@ -332,22 +323,16 @@ class FileUploader(FrozenModel):
         Examples
         --------
 
-        View files
+        View files:
 
-        .. code:: python
-
-            from onetl.impl import LocalPath
-            from onetl.file import FileUploader
-
-            uploader = FileUploader(local_path="/local", ...)
-
-            view_files = uploader.view_files()
-
-            assert view_files == {
-                LocalPath("/local/file1.txt"),
-                LocalPath("/local/file3.txt"),
-                LocalPath("/local/nested/path/file3.txt"),
-            }
+        >>> from onetl.file import FileUploader
+        >>> uploader = FileUploader(local_path="/local", ...)
+        >>> uploader.view_files()
+        FileSet([
+            LocalPath("/local/file1.txt"),
+            LocalPath("/local/file3.txt"),
+            LocalPath("/local/nested/path/file3.txt"),
+        ])
         """
 
         if not self.local_path:

--- a/onetl/file/file_uploader/result.py
+++ b/onetl/file/file_uploader/result.py
@@ -25,34 +25,33 @@ class UploadResult(FileResult):
     Examples
     --------
 
-    Upload files
-
-    .. code:: python
-
-        from onetl.impl import LocalPath, RemoteFile, FailedLocalFile
-        from onetl.file import FileUploader, UploadResult
-
-        uploader = FileUploader(target_path="/remote", ...)
-
-        uploaded_files = uploader.run(
-            [
-                "/local/file1",
-                "/local/file2",
-                "/failed/file",
-                "/existing/file",
-                "/missing/file",
-            ]
-        )
-
-        assert uploaded_files == UploadResult(
-            successful={
-                RemoteFile("/remote/file1"),
-                RemoteFile("/remote/file2"),
-            },
-            failed={FailedLocalFile("/failed/file")},
-            skipped={LocalPath("/existing/file")},
-            missing={LocalPath("/missing/file")},
-        )
+    >>> from onetl.file import FileUploader
+    >>> uploader = FileUploader(target_path="/remote", ...)
+    >>> upload_result = uploader.run(
+    ...     [
+    ...         "/local/file1",
+    ...         "/local/file2",
+    ...         "/failed/file",
+    ...         "/existing/file",
+    ...         "/missing/file",
+    ...     ]
+    ... )
+    >>> upload_result
+    UploadResult(
+        successful=FileSet([
+            RemoteFile("/remote/file1"),
+            RemoteFile("/remote/file2"),
+        ]),
+        failed=FileSet([
+            FailedLocalFile("/failed/file")
+        ]),
+        skipped=FileSet([
+            LocalPath("/existing/file")
+        ]),
+        missing=FileSet([
+            LocalPath("/missing/file")
+        ]),
+    )
     """
 
     successful: FileSet[RemoteFile] = Field(default_factory=FileSet)

--- a/onetl/file/filter/match_all_filters.py
+++ b/onetl/file/filter/match_all_filters.py
@@ -31,16 +31,15 @@ def match_all_filters(path: PathProtocol, filters: Iterable[BaseFileFilter]) -> 
     Examples
     --------
 
-    .. code:: python
-
-        from onetl.file.filter import Glob, ExcludeDir, match_all_filters
-        from onetl.impl import LocalPath
-
-        filters = [Glob("*.csv"), ExcludeDir("/excluded")]
-
-        assert match_all_filters(LocalPath("/path/to/file.csv"), filters)
-        assert not match_all_filters(LocalPath("/path/to/file.txt"), filters)
-        assert not match_all_filters(LocalPath("/excluded/path/file.csv"), filters)
+    >>> from onetl.file.filter import Glob, ExcludeDir, match_all_filters
+    >>> from onetl.impl import RemoteFile, RemotePathStat
+    >>> filters = [Glob("*.csv"), ExcludeDir("/excluded")]
+    >>> match_all_filters(RemoteFile("/path/to/file.csv", stats=RemotePathStat()), filters)
+    True
+    >>> match_all_filters(RemoteFile("/path/to/file.txt", stats=RemotePathStat()), filters)
+    False
+    >>> match_all_filters(RemoteFile("/excluded/path/file.csv", stats=RemotePathStat()), filters)
+    False
     """
 
     empty = True

--- a/onetl/file/limit/limits_reached.py
+++ b/onetl/file/limit/limits_reached.py
@@ -28,18 +28,17 @@ def limits_reached(limits: Iterable[BaseFileLimit]) -> bool:
     Examples
     --------
 
-    .. code:: python
-
-        from onetl.file.limit import MaxFilesCount, limits_reached, limits_stop_at
-        from onetl.impl import LocalPath
-
-        limits = [MaxFilesCount(2)]
-        assert not limits_reached(limits)
-
-        assert not limits_stop_at(LocalPath("/path/to/file.csv"), limits)
-        assert limits_stop_at(LocalPath("/path/to/file.csv"), limits)
-
-        assert limits_reached(limits)
+    >>> from onetl.file.limit import MaxFilesCount, limits_reached, limits_stop_at
+    >>> from onetl.impl import LocalPath
+    >>> limits = [MaxFilesCount(2)]
+    >>> limits_reached(limits)
+    False
+    >>> limits_stop_at(LocalPath("/path/to/file.csv"), limits)
+    False
+    >>> limits_stop_at(LocalPath("/path/to/file.csv"), limits)
+    True
+    >>> limits_reached(limits)
+    True
     """
     debug = log.isEnabledFor(logging.DEBUG)
 

--- a/onetl/file/limit/limits_stop_at.py
+++ b/onetl/file/limit/limits_stop_at.py
@@ -31,15 +31,13 @@ def limits_stop_at(path: PathProtocol, limits: Iterable[BaseFileLimit]) -> bool:
     Examples
     --------
 
-    .. code:: python
-
-        from onetl.file.limit import MaxFilesCount, limits_stop_at
-        from onetl.impl import LocalPath
-
-        limits = [MaxFilesCount(1)]
-
-        assert not limits_stop_at(LocalPath("/path/to/file.csv"), limits)
-        assert limits_stop_at(LocalPath("/path/to/file.csv"), limits)
+    >>> from onetl.file.limit import MaxFilesCount, limits_stop_at
+    >>> from onetl.impl import LocalPath
+    >>> limits = [MaxFilesCount(2)]
+    >>> limits_stop_at(LocalPath("/path/to/file.csv"), limits)
+    False
+    >>> limits_stop_at(LocalPath("/path/to/file.csv"), limits)
+    True
     """
     reached = []
     for limit in limits:

--- a/onetl/file/limit/reset_limits.py
+++ b/onetl/file/limit/reset_limits.py
@@ -29,18 +29,18 @@ def reset_limits(limits: Iterable[BaseFileLimit]) -> list[BaseFileLimit]:
     Examples
     --------
 
-    .. code:: python
-
-        from onetl.file.limit import MaxFilesCount, limits_reached, reset_limits
-        from onetl.impl import LocalPath
-
-        limits = [MaxFilesCount(1)]
-
-        assert not limits_reached(limits)
-        # do something
-        assert limits_reached(limits)
-
-        new_limits = reset_limits(limits)
-        assert not limits_reached(new_limits)
+    >>> from onetl.file.limit import MaxFilesCount, limits_reached, limits_stop_at, reset_limits
+    >>> from onetl.impl import LocalPath
+    >>> limits = [MaxFilesCount(1)]
+    >>> limits_reached(limits)
+    False
+    >>> # do something
+    >>> limits_stop_at(LocalPath("/path/to/file.csv"), limits)
+    True
+    >>> limits_reached(limits)
+    True
+    >>> new_limits = reset_limits(limits)
+    >>> limits_reached(new_limits)
+    False
     """
     return [limit.reset() for limit in limits]

--- a/onetl/hooks/hook.py
+++ b/onetl/hooks/hook.py
@@ -84,13 +84,13 @@ class Hook(Generic[T]):  # noqa: WPS338
         Examples
         --------
 
-        .. code:: python
-
-            hook = Hook(..., enabled=False)
-            assert not hook.enabled
-
-            hook.enable()
-            assert hook.enabled
+        >>> def func1(): ...
+        >>> hook = Hook(callback=func1, enabled=False)
+        >>> hook.enabled
+        False
+        >>> hook.enable()
+        >>> hook.enabled
+        True
         """
         if self.enabled:
             logger.log(
@@ -110,13 +110,13 @@ class Hook(Generic[T]):  # noqa: WPS338
         Examples
         --------
 
-        .. code:: python
-
-            hook = Hook(..., enabled=True)
-            assert hook.enabled
-
-            hook.disable()
-            assert not hook.enabled
+        >>> def func1(): ...
+        >>> hook = Hook(callback=func1, enabled=True)
+        >>> hook.enabled
+        True
+        >>> hook.disable()
+        >>> hook.enabled
+        False
         """
         if self.enabled:
             logger.log(NOTICE, "|Hooks| Disable hook '%s.%s'", self.callback.__module__, self.callback.__qualname__)
@@ -146,30 +146,33 @@ class Hook(Generic[T]):  # noqa: WPS338
 
         .. tabs::
 
-            .. code-tab:: py Context manager syntax
+            .. tab:: Context manager syntax
 
-                hook = Hook(..., enabled=True)
-                assert hook.enabled
+                >>> def func1(): ...
+                >>> hook = Hook(callback=func1, enabled=True)
+                >>> hook.enabled
+                True
+                >>> with hook.skip():
+                ...     print(hook.enabled)
+                False
+                >>> # hook state is restored as it was before entering the context manager
+                >>> hook.enabled
+                True
 
-                with hook.skip():
-                    assert not hook.enabled
+            .. tab:: Decorator syntax
 
-                # hook state is restored as it was before entering the context manager
-                assert hook.enabled
-
-            .. code-tab:: py Decorator syntax
-
-                hook = Hook(..., enabled=True)
-                assert hook.enabled
-
-                @hook.skip()
-                def hook_disabled():
-                    assert not hook.enabled
-
-                hook_disabled()
-
-                # hook state is restored as it was before entering the context manager
-                assert hook.enabled
+                >>> def func1(): ...
+                >>> hook = Hook(callback=func1, enabled=True)
+                >>> hook.enabled
+                True
+                >>> @hook.skip()
+                ... def hook_disabled():
+                ...     print(hook.enabled)
+                >>> hook_disabled()
+                False
+                >>> # hook state is restored as it was before entering the context manager
+                >>> hook.enabled
+                True
         """
         if not self.enabled:
             logger.log(
@@ -205,18 +208,17 @@ class Hook(Generic[T]):  # noqa: WPS338
         Examples
         --------
 
-        .. code:: python
-
-            from onetl.hooks.hook import Hook, HookPriority
-
-
-            def some_func(*args, **kwargs): ...
-
-
-            hook = Hook(callback=some_func)
-
-            result = hook(1, "abc", some="arg")
-            assert result == some_func(1, "abc", some="arg")
+        >>> from onetl.hooks.hook import Hook, HookPriority
+        >>> def some_func(*args, **kwargs):
+        ...     print(args)
+        ...     print(kwargs)
+        ...     return "func result"
+        >>> hook = Hook(callback=some_func)
+        >>> result = hook(1, "abc", some="arg")
+        (1, 'abc')
+        {'some': 'arg'}
+        >>> result
+        'func result'
         """
         result = self.callback(*args, **kwargs)
         if isinstance(result, Generator):

--- a/onetl/hooks/hook_collection.py
+++ b/onetl/hooks/hook_collection.py
@@ -34,26 +34,25 @@ class HookCollection:
     @property
     def active(self):
         """
-        Return HookCollection but containing only hooks with enabled state.
+        Return new HookCollection but containing only hooks with ``enabled=True`` state.
 
         If called after :obj:`~stop` or inside :obj:`~skip`, empty collection will be returned.
 
         Examples
         --------
 
-        .. code:: python
-
-            from onetl.hooks.hook import Hook
-            from onetl.hooks.hook_collection import HookCollection
-
-            hooks = HookCollection(
-                [
-                    Hook(callback=func1, enabled=True),
-                    Hook(callback=func2, enabled=False),
-                ]
-            )
-
-            assert hooks.active == HookCollection([Hook(callback=func1)])
+        >>> from onetl.hooks.hook import Hook
+        >>> from onetl.hooks.hook_collection import HookCollection
+        >>> def func1(): ...
+        >>> def func2(): ...
+        >>> hooks = HookCollection(
+        ...     [
+        ...         Hook(callback=func1, enabled=True),
+        ...         Hook(callback=func2, enabled=False),
+        ...     ],
+        ... )
+        >>> len(hooks.active)
+        1
         """
 
         if self._enabled:
@@ -68,20 +67,19 @@ class HookCollection:
         Examples
         --------
 
-        .. code:: python
-
-            from onetl.hooks.hook import Hook
-            from onetl.hooks.hook_collection import HookCollection
-
-            hooks = HookCollection(
-                [
-                    Hook(callback=func1),
-                    Hook(callback=func2),
-                ]
-            )
-
-            hooks.stop()
-            assert hooks.active == HookCollection()
+        >>> from onetl.hooks.hook import Hook
+        >>> from onetl.hooks.hook_collection import HookCollection
+        >>> def func1(): ...
+        >>> def func2(): ...
+        >>> hooks = HookCollection(
+        ...     [
+        ...         Hook(callback=func1),
+        ...         Hook(callback=func2),
+        ...     ],
+        ... )
+        >>> hooks.stop()
+        >>> hooks.active
+        HookCollection([])
         """
         self._enabled = False
 
@@ -97,26 +95,24 @@ class HookCollection:
         Examples
         --------
 
-        .. code:: python
-
-            from onetl.hooks.hook import Hook
-            from onetl.hooks.hook_collection import HookCollection
-
-            hooks = HookCollection(
-                [
-                    Hook(callback=func1),
-                    Hook(callback=func2),
-                ]
-            )
-
-            hooks.resume()
-
-            assert hooks.active == HookCollection(
-                [
-                    Hook(callback=func1),
-                    Hook(callback=func2),
-                ]
-            )
+        >>> from onetl.hooks.hook import Hook
+        >>> from onetl.hooks.hook_collection import HookCollection
+        >>> def func1(): ...
+        >>> def func2(): ...
+        >>> hooks = HookCollection(
+        ...     [
+        ...         Hook(callback=func1),
+        ...         Hook(callback=func2),
+        ...     ],
+        ... )
+        >>> hooks.resume()
+        >>> hooks.active # doctest: +SKIP
+        HookCollection(
+            [
+                Hook(callback=func1),
+                Hook(callback=func2),
+            ]
+        )
         """
 
         self._enabled = True
@@ -135,25 +131,26 @@ class HookCollection:
         Examples
         --------
 
-        .. code:: python
-
-            from onetl.hooks.hook import Hook
-            from onetl.hooks.hook_collection import HookCollection
-
-            hooks = HookCollection(
-                [
-                    Hook(callback=func1),
-                    Hook(callback=func2),
-                ]
-            )
-
-            # hooks state is same as created by constructor
-
-            with hooks.skip():
-                # all hooks are disabled here
-                ...
-
-            # hooks state is restored as it was before entering the context manager
+        >>> from onetl.hooks.hook import Hook
+        >>> from onetl.hooks.hook_collection import HookCollection
+        >>> def func1(): ...
+        >>> def func2(): ...
+        >>> hooks = HookCollection(
+        ...     [
+        ...         Hook(callback=func1),
+        ...         Hook(callback=func2),
+        ...     ],
+        ... )
+        >>> # hooks state is same as created by constructor
+        >>> len(hooks.active)
+        2
+        >>> with hooks.skip():
+        ...     # all hooks are disabled here
+        ...     print(len(hooks.active))
+        0
+        >>> # hooks state is restored as it was before entering the context manager
+        >>> len(hooks.active)
+        2
         """
 
         if not self._enabled:
@@ -171,26 +168,20 @@ class HookCollection:
         Examples
         --------
 
-        .. code:: python
+        >>> from onetl.hooks.hook import Hook
+        >>> from onetl.hooks.hook_collection import HookCollection
+        >>> def func1(): ...
+        >>> def func2(): ...
+        >>> hooks = HookCollection(
+        ...     [
+        ...         Hook(callback=func1),
+        ...     ],
+        ... )
 
-            from onetl.hooks.hook import Hook
-            from onetl.hooks.hook_collection import HookCollection
-
-            hooks = HookCollection(
-                [
-                    Hook(callback=func1, enabled=True),
-                ]
-            )
-
-            new_hook = Hook(callback=func2, enabled=False)
-            hooks.add(new_hook)
-
-            assert hooks == HookCollection(
-                [
-                    Hook(callback=func1, enabled=True),
-                    Hook(callback=func2, enabled=False),
-                ]
-            )
+        >>> new_hook = Hook(callback=func2)
+        >>> hooks.add(new_hook)
+        >>> len(hooks.active)
+        2
         """
         self._hooks.append(item)
 
@@ -200,26 +191,20 @@ class HookCollection:
         Examples
         --------
 
-        .. code:: python
+        >>> from onetl.hooks.hook import Hook
+        >>> from onetl.hooks.hook_collection import HookCollection
+        >>> def func1(): ...
+        >>> def func2(): ...
+        >>> hooks = HookCollection(
+        ...     [
+        ...         Hook(callback=func1),
+        ...     ],
+        ... )
 
-            from onetl.hooks.hook import Hook
-            from onetl.hooks.hook_collection import HookCollection
-
-            hooks = HookCollection(
-                [
-                    Hook(callback=func1, enabled=True),
-                ]
-            )
-
-            new_hooks = [Hook(callback=func2, enabled=False)]
-            hooks.extend(new_hook)
-
-            assert hooks == HookCollection(
-                [
-                    Hook(callback=func1, enabled=True),
-                    Hook(callback=func2, enabled=False),
-                ]
-            )
+        >>> new_hooks = [Hook(callback=func2)]
+        >>> hooks.extend(new_hooks)
+        >>> len(hooks.active)
+        2
         """
         self._hooks.extend(hooks)
 
@@ -229,20 +214,20 @@ class HookCollection:
         Examples
         --------
 
-        .. code:: python
-
-            from onetl.hooks.hook import Hook
-            from onetl.hooks.hook_collection import HookCollection
-
-            hooks = HookCollection(
-                [
-                    Hook(callback=func1, enabled=True),
-                    Hook(callback=func2, enabled=True),
-                ]
-            )
-
-            for hook in hooks:
-                assert hook.enabled
+        >>> from onetl.hooks.hook import Hook
+        >>> from onetl.hooks.hook_collection import HookCollection
+        >>> def func1(): ...
+        >>> def func2(): ...
+        >>> hooks = HookCollection(
+        ...    [
+        ...        Hook(callback=func1, enabled=True),
+        ...        Hook(callback=func2, enabled=False),
+        ...    ],
+        ... )
+        >>> for hook in hooks:
+        ...    print(hook.enabled)
+        True
+        False
         """
         return iter(self._hooks)
 
@@ -252,18 +237,20 @@ class HookCollection:
         Examples
         --------
 
-        .. code:: python
-
-            from onetl.hooks.hook import Hook
-            from onetl.hooks.hook_collection import HookCollection
-
-            hooks = HookCollection(
-                [
-                    Hook(callback=func1, enabled=True),
-                    Hook(callback=func2, enabled=True),
-                ]
-            )
-
-            assert len(hooks) == 2
+        >>> from onetl.hooks.hook import Hook
+        >>> from onetl.hooks.hook_collection import HookCollection
+        >>> def func1(): ...
+        >>> def func2(): ...
+        >>> hooks = HookCollection(
+        ...     [
+        ...         Hook(callback=func1),
+        ...         Hook(callback=func2),
+        ...     ],
+        ... )
+        >>> len(hooks)
+        2
         """
         return len(self._hooks)
+
+    def __repr__(self):
+        return f"HookCollection({self._hooks})"

--- a/onetl/hooks/method_inheritance_stack.py
+++ b/onetl/hooks/method_inheritance_stack.py
@@ -20,30 +20,28 @@ class MethodInheritanceStack:
     Examples
     --------
 
-    .. code:: python
+    >>> from onetl.hooks import support_hooks, slot
+    >>> from onetl.hooks.method_inheritance_stack import MethodInheritanceStack
+    >>> @support_hooks
+    ... class BaseClass:
+    ...     @slot
+    ...     def some_method(self, *args, **kwargs):
+    ...         pass
+    >>> @support_hooks
+    ... class MyClass(BaseClass):
+    ...    @slot
+    ...    def some_method(self, *args, **kwargs):
+    ...        self.do_something()
+    ...        super().some_method(*args, **kwargs)
 
-        @support_hooks
-        class BaseClass:
-            @slot
-            def some_method(self, *args, **kwargs):
-                pass
-
-
-        @support_hooks
-        class MyClass(BaseClass):
-            @slot
-            def some_method(self, *args, **kwargs):
-                self.do_something()
-                super().some_method(*args, **kwargs)
-
-
-        # caused by MyClass.some_method() call
-        with MethodInheritanceStack(MyClass, "some_method") as method_call_stack:
-            assert method_call_stack.level == 0
-
-            # MyClass.some_method() called super().some_method()
-            with MethodInheritanceStack(BaseClass, "some_method") as method_call_stack:
-                assert method_call_stack.level == 1
+    >>> # caused by MyClass.some_method() call
+    >>> with MethodInheritanceStack(MyClass, "some_method") as method_call_stack:
+    ...     print("MyClass", method_call_stack.level)
+    ...     # MyClass.some_method() called super().some_method()
+    ...     with MethodInheritanceStack(BaseClass, "some_method") as method_call_stack:
+    ...         print("BaseClass", method_call_stack.level)
+    MyClass 0
+    BaseClass 1
     """
 
     _stack: dict[type, dict[str, int]] = defaultdict(lambda: defaultdict(int))

--- a/onetl/hwm/store/hwm_class_registry.py
+++ b/onetl/hwm/store/hwm_class_registry.py
@@ -13,18 +13,16 @@ class SparkTypeToHWM:
     Examples
     --------
 
-    .. code:: python
-
-        from etl_entities.hwm import ColumnIntHWM, ColumnDateHWM
-        from onetl.hwm.store import SparkTypeToHWM
-
-        assert SparkTypeToHWM.get("integer") == ColumnIntHWM
-        assert SparkTypeToHWM.get("short") == ColumnIntHWM  # multiple type names are supported
-
-        assert SparkTypeToHWM.get("date") == ColumnDateHWM
-
-        assert SparkTypeToHWM.get("unknown") is None
-
+    >>> from etl_entities.hwm import ColumnIntHWM, ColumnDateHWM
+    >>> from onetl.hwm.store import SparkTypeToHWM
+    >>> SparkTypeToHWM.get("integer")
+    <class 'etl_entities.hwm.column.int_hwm.ColumnIntHWM'>
+    >>> # multiple type names are supported
+    >>> SparkTypeToHWM.get("short")
+    <class 'etl_entities.hwm.column.int_hwm.ColumnIntHWM'>
+    >>> SparkTypeToHWM.get("date")
+    <class 'etl_entities.hwm.column.date_hwm.ColumnDateHWM'>
+    >>> SparkTypeToHWM.get("unknown")
     """
 
     _mapping: ClassVar[dict[str, type[HWM]]] = {
@@ -57,20 +55,15 @@ def register_spark_type_to_hwm_type_mapping(*type_names: str):
     Examples
     --------
 
-    .. code:: python
-
-        from etl_entities import HWM
-        from onetl.hwm.store import SparkTypeToHWM
-        from onetl.hwm.store import SparkTypeToHWM, register_spark_type_to_hwm_type_mapping
-
-
-        @register_spark_type_to_hwm_type_mapping("somename", "anothername")
-        class MyHWM(HWM): ...
-
-
-        assert SparkTypeToHWM.get("somename") == MyClass
-        assert SparkTypeToHWM.get("anothername") == MyClass
-
+    >>> from etl_entities.hwm import ColumnHWM
+    >>> from onetl.hwm.store import SparkTypeToHWM
+    >>> from onetl.hwm.store import SparkTypeToHWM, register_spark_type_to_hwm_type_mapping
+    >>> @register_spark_type_to_hwm_type_mapping("somename", "anothername")
+    ... class MyHWM(ColumnHWM): ...
+    >>> SparkTypeToHWM.get("somename")
+    <class 'onetl.hwm.store.hwm_class_registry.MyHWM'>
+    >>> SparkTypeToHWM.get("anothername")
+    <class 'onetl.hwm.store.hwm_class_registry.MyHWM'>
     """
 
     def wrapper(cls: type[HWM]):

--- a/onetl/strategy/incremental_strategy.py
+++ b/onetl/strategy/incremental_strategy.py
@@ -75,21 +75,26 @@ class IncrementalStrategy(OffsetMixin, HWMStrategy):
 
             .. code:: python
 
-                assert download_result == DownloadResult(
-                    successful=[
-                        "/path/my/file1",
-                        "/path/my/file2",
-                    ]
+                DownloadResult(
+                    ...,
+                    successful={
+                        LocalFile("/downloaded/file1"),
+                        LocalFile("/downloaded/file2"),
+                    },
                 )
 
             Then the downloaded files list is saved as ``FileListHWM`` object into :ref:`HWM Store <hwm>`:
 
             .. code:: python
 
-                [
-                    "/path/my/file1",
-                    "/path/my/file2",
-                ]
+                FileListHWM(
+                    ...,
+                    entity="/path",
+                    value=[
+                        "/path/my/file1",
+                        "/path/my/file2",
+                    ],
+                )
 
             Next incremental run will download only new files from the source:
 
@@ -104,22 +109,26 @@ class IncrementalStrategy(OffsetMixin, HWMStrategy):
             .. code:: python
 
                 # only files which are not in FileListHWM
-
-                assert download_result == DownloadResult(
-                    successful=[
-                        "/path/my/file3",
-                    ]
+                DownloadResult(
+                    ...,
+                    successful={
+                        LocalFile("/downloaded/file3"),
+                    },
                 )
 
             New files will be added to the ``FileListHWM`` and saved to :ref:`HWM Store <hwm>`:
 
             .. code:: python
 
-                [
-                    "/path/my/file1",
-                    "/path/my/file2",
-                    "/path/my/file3",
-                ]
+                FileListHWM(
+                    ...,
+                    entity="/path",
+                    value=[
+                        "/path/my/file1",
+                        "/path/my/file2",
+                        "/path/my/file3",
+                    ],
+                )
 
         .. warning::
 

--- a/onetl/strategy/snapshot_strategy.py
+++ b/onetl/strategy/snapshot_strategy.py
@@ -38,11 +38,12 @@ class SnapshotStrategy(BaseStrategy):
 
         .. code:: python
 
-            assert download_result == DownloadResult(
-                successful=[
-                    "/path/my/file1",
-                    "/path/my/file2",
-                ]
+            DownloadResult(
+                ...,
+                successful={
+                    LocalFile("/downloaded/file1"),
+                    LocalFile("/downloaded/file2"),
+                },
             )
 
     Examples

--- a/setup.cfg
+++ b/setup.cfg
@@ -273,7 +273,9 @@ ignore =
 # E704 multiple statements on one line: def func(): ...
     E704,
 # WPS474 Found import object collision
-    WPS474
+    WPS474,
+# WPS318 Found extra indentation
+    WPS318
 
 # http://flake8.pycqa.org/en/latest/user/options.html?highlight=per-file-ignores#cmdoption-flake8-per-file-ignores
 per-file-ignores =

--- a/tests/tests_integration/tests_db_connection_integration/test_postgres_integration.py
+++ b/tests/tests_integration/tests_db_connection_integration/test_postgres_integration.py
@@ -213,7 +213,7 @@ def test_postgres_connection_dml(request, spark, processing, load_table_data, su
         SELECT * FROM {table_name}
         WHERE id_int >= 50
         RETURNING id_int{suffix}
-    """,
+        """,
     )
 
     df = postgres.fetch(f"SELECT * FROM {temp_table}{suffix}")
@@ -302,7 +302,7 @@ def test_postgres_connection_execute_procedure(
         AS $$
             SELECT COUNT(*) FROM {table};
         $${suffix}
-    """,
+        """,
     )
 
     def proc_finalizer():
@@ -358,7 +358,7 @@ def test_postgres_connection_execute_procedure(
         AS $$
             SELECT COUNT(*) FROM {table};
         $${suffix}
-    """,
+        """,
     )
 
     with pytest.raises(Exception):
@@ -412,7 +412,7 @@ def test_postgres_connection_execute_procedure_arguments(
             SELECT COUNT(*) FROM {table}
             WHERE id_int = idd;
         $${suffix}
-    """,
+        """,
     )
 
     def proc_finalizer():
@@ -471,7 +471,7 @@ def test_postgres_connection_execute_procedure_inout(
                 WHERE id_int < idd;
             END
         $${suffix}
-    """,
+        """,
     )
 
     def proc_finalizer():
@@ -518,7 +518,7 @@ def test_postgres_connection_execute_procedure_ddl(
         AS $$
             CREATE TABLE {table} (iid INT, text VARCHAR(400));
         $${suffix}
-    """,
+        """,
     )
 
     def proc_finalizer():
@@ -565,7 +565,7 @@ def test_postgres_connection_execute_procedure_dml(
         AS $$
             INSERT INTO {table} VALUES(idd, text);
         $${suffix}
-    """,
+        """,
     )
 
     def proc_finalizer():
@@ -605,7 +605,7 @@ def test_postgres_connection_execute_function(
                 RETURN 100;
             END
         $$ LANGUAGE PLPGSQL{suffix}
-    """,
+        """,
     )
 
     def function_finalizer():
@@ -667,7 +667,7 @@ def test_postgres_connection_execute_function(
                     RETURN 100;
                 END
             $$ LANGUAGE PLPGSQL{suffix}
-        """,
+            """,
         )
 
     # replace
@@ -681,7 +681,7 @@ def test_postgres_connection_execute_function(
                 RETURN 100;
             END
         $$ LANGUAGE PLPGSQL{suffix}
-    """,
+        """,
     )
 
     # missing
@@ -706,7 +706,7 @@ def test_postgres_connection_execute_function(
                 RETURN 100
             END
             $$ LANGUAGE PLPGSQL{suffix}
-        """,
+            """,
         )
 
 
@@ -746,7 +746,7 @@ def test_postgres_connection_execute_function_arguments(
                 RETURN i*100;
             END
         $$ LANGUAGE PLPGSQL{suffix}
-    """,
+        """,
     )
 
     def function_finalizer():
@@ -825,7 +825,7 @@ def test_postgres_connection_execute_function_table(
             FROM {table}
             WHERE id_int < i;
         $$ LANGUAGE SQL{suffix}
-    """,
+        """,
     )
 
     def function_finalizer():
@@ -873,7 +873,7 @@ def test_postgres_connection_execute_function_ddl(
             RETURN 1;
         END;
         $$ LANGUAGE PLPGSQL{suffix}
-    """,
+        """,
     )
 
     def function_finalizer():
@@ -941,7 +941,7 @@ def test_postgres_connection_execute_function_dml(
             RETURN idd;
         END;
         $$ LANGUAGE PLPGSQL{suffix}
-    """,
+        """,
     )
 
     def function_finalizer():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Instead of syntax:
```python
assert some == "other"
```
Use doctest style:
```python
>>> some
"other"
```

This should make examples easier to understand. See https://onetl--273.org.readthedocs.build/en/273/.

Also run pytest on these docstrings, to increase coverage.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [X] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
