### PR TITLE
[DOP-16270] Allow passing instanceName to MSSQL(extra=...)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -341,7 +341,7 @@ Read data from MSSQL, transform & write to Hive.
         database="Telecom",
         spark=spark,
         # These options are passed to MSSQL JDBC Driver:
-        extra={"ApplicationIntent": "ReadOnly"},
+        extra={"applicationIntent": "ReadOnly"},
     ).check()
 
     # >>> INFO:|MSSQL| Connection is available

--- a/docs/changelog/next_release/287.feature.rst
+++ b/docs/changelog/next_release/287.feature.rst
@@ -1,0 +1,1 @@
+Change ``MSSQL.port`` default from ``1433`` to ``None``, allowing use of ``instanceName`` to detect port number.

--- a/docs/connection/db_connection/mssql/prerequisites.rst
+++ b/docs/connection/db_connection/mssql/prerequisites.rst
@@ -27,8 +27,10 @@ Connecting to MSSQL
 Connection port
 ~~~~~~~~~~~~~~~
 
-Connection is usually performed to port 1443. Port may differ for different MSSQL instances.
+Connection is usually performed to port 1433. Port may differ for different MSSQL instances.
 Please ask your MSSQL administrator to provide required information.
+
+For named MSSQL instances (``instanceName`` option), `port number is optional <https://learn.microsoft.com/en-us/sql/connect/jdbc/building-the-connection-url?view=sql-server-ver16#named-and-multiple-sql-server-instances>`_, and could be omitted.
 
 Connection host
 ~~~~~~~~~~~~~~~

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -69,7 +69,7 @@ This changes both log level and log formatting to something like this:
         2024-04-12 10:12:12,190 [INFO    ] MainThread:         host = 'mssql.host'
         2024-04-12 10:12:12,190 [INFO    ] MainThread:         port = 1433
         2024-04-12 10:12:12,191 [INFO    ] MainThread:         database = 'somedb'
-        2024-04-12 10:12:12,191 [INFO    ] MainThread:         extra = {'ApplicationIntent': 'ReadOnly', 'trustServerCertificate': 'true'}
+        2024-04-12 10:12:12,191 [INFO    ] MainThread:         extra = {'applicationIntent': 'ReadOnly', 'trustServerCertificate': 'true'}
         2024-04-12 10:12:12,191 [INFO    ] MainThread:         jdbc_url = 'jdbc:sqlserver:/mssql.host:1433'
         2024-04-12 10:12:12,579 [INFO    ] MainThread: |MSSQL| Connection is available.
         2024-04-12 10:12:12,581 [INFO    ] MainThread: |MSSQL| Executing SQL query (on driver):

--- a/onetl/connection/db_connection/clickhouse/connection.py
+++ b/onetl/connection/db_connection/clickhouse/connection.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import ClassVar, Optional
 
+from etl_entities.instance import Host
+
 from onetl._util.classproperty import classproperty
 from onetl._util.version import Version
 from onetl.connection.db_connection.clickhouse.dialect import ClickhouseDialect
@@ -106,6 +108,7 @@ class Clickhouse(JDBCConnection):
 
     """
 
+    host: Host
     port: int = 8123
     database: Optional[str] = None
     extra: ClickhouseExtra = ClickhouseExtra()
@@ -188,6 +191,10 @@ class Clickhouse(JDBCConnection):
         result = super().jdbc_params
         result.update(self.extra.dict(by_alias=True))
         return result
+
+    @property
+    def instance_url(self) -> str:
+        return f"{self.__class__.__name__.lower()}://{self.host}:{self.port}"
 
     @staticmethod
     def _build_statement(

--- a/onetl/connection/db_connection/jdbc_connection/connection.py
+++ b/onetl/connection/db_connection/jdbc_connection/connection.py
@@ -7,8 +7,6 @@ import secrets
 import warnings
 from typing import TYPE_CHECKING, Any
 
-from etl_entities.instance import Host
-
 from onetl._internal import clear_statement
 from onetl.connection.db_connection.db_connection import DBConnection
 from onetl.connection.db_connection.jdbc_connection.dialect import JDBCDialect
@@ -47,18 +45,11 @@ WRITE_TOP_LEVEL_OPTIONS = frozenset("url")
 
 @support_hooks
 class JDBCConnection(JDBCMixin, DBConnection):
-    host: Host
-    port: int
-
     Dialect = JDBCDialect
     ReadOptions = JDBCReadOptions
     SQLOptions = JDBCSQLOptions
     WriteOptions = JDBCWriteOptions
     Options = JDBCLegacyOptions
-
-    @property
-    def instance_url(self) -> str:
-        return f"{self.__class__.__name__.lower()}://{self.host}:{self.port}"
 
     @slot
     def sql(

--- a/onetl/connection/db_connection/mysql/connection.py
+++ b/onetl/connection/db_connection/mysql/connection.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import warnings
 from typing import ClassVar, Optional
 
+from etl_entities.instance import Host
+
 from onetl._util.classproperty import classproperty
 from onetl._util.version import Version
 from onetl.connection.db_connection.jdbc_connection import JDBCConnection
@@ -103,6 +105,7 @@ class MySQL(JDBCConnection):
 
     """
 
+    host: Host
     port: int = 3306
     database: Optional[str] = None
     extra: MySQLExtra = MySQLExtra()
@@ -168,3 +171,7 @@ class MySQL(JDBCConnection):
         result = super().jdbc_params
         result.update(self.extra.dict(by_alias=True))
         return result
+
+    @property
+    def instance_url(self) -> str:
+        return f"{self.__class__.__name__.lower()}://{self.host}:{self.port}"

--- a/onetl/connection/db_connection/oracle/connection.py
+++ b/onetl/connection/db_connection/oracle/connection.py
@@ -17,6 +17,8 @@ try:
 except (ImportError, AttributeError):
     from pydantic import root_validator  # type: ignore[no-redef, assignment]
 
+from etl_entities.instance import Host
+
 from onetl._internal import clear_statement
 from onetl._util.classproperty import classproperty
 from onetl._util.version import Version
@@ -177,6 +179,7 @@ class Oracle(JDBCConnection):
 
     """
 
+    host: Host
     port: int = 1521
     sid: Optional[str] = None
     service_name: Optional[str] = None
@@ -259,9 +262,9 @@ class Oracle(JDBCConnection):
     @property
     def instance_url(self) -> str:
         if self.sid:
-            return f"{super().instance_url}/{self.sid}"
+            return f"{self.__class__.__name__.lower()}://{self.host}:{self.port}/{self.sid}"
 
-        return f"{super().instance_url}/{self.service_name}"
+        return f"{self.__class__.__name__.lower()}://{self.host}:{self.port}/{self.service_name}"
 
     @slot
     def get_min_max_values(

--- a/onetl/connection/db_connection/postgres/connection.py
+++ b/onetl/connection/db_connection/postgres/connection.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import warnings
 from typing import ClassVar
 
+from etl_entities.instance import Host
+
 from onetl._util.classproperty import classproperty
 from onetl._util.version import Version
 from onetl.connection.db_connection.jdbc_connection import JDBCConnection
@@ -112,6 +114,7 @@ class Postgres(JDBCConnection):
 
     """
 
+    host: Host
     database: str
     port: int = 5432
     extra: PostgresExtra = PostgresExtra()
@@ -178,7 +181,7 @@ class Postgres(JDBCConnection):
 
     @property
     def instance_url(self) -> str:
-        return f"{super().instance_url}/{self.database}"
+        return f"{self.__class__.__name__.lower()}://{self.host}:{self.port}/{self.database}"
 
     def _options_to_connection_properties(
         self,

--- a/onetl/connection/db_connection/teradata/connection.py
+++ b/onetl/connection/db_connection/teradata/connection.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import warnings
 from typing import ClassVar, Optional
 
+from etl_entities.instance import Host
+
 from onetl._internal import stringify
 from onetl._util.classproperty import classproperty
 from onetl._util.version import Version
@@ -123,6 +125,7 @@ class Teradata(JDBCConnection):
 
     """
 
+    host: Host
     port: int = 1025
     database: Optional[str] = None
     extra: TeradataExtra = TeradataExtra()
@@ -201,3 +204,7 @@ class Teradata(JDBCConnection):
                 connection_params.append(f"{key}={string_value}")
 
         return f"jdbc:teradata://{self.host}/{','.join(connection_params)}"
+
+    @property
+    def instance_url(self) -> str:
+        return f"{self.__class__.__name__.lower()}://{self.host}:{self.port}"

--- a/tests/tests_unit/tests_db_connection_unit/test_clickhouse_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_clickhouse_unit.py
@@ -131,6 +131,8 @@ def test_clickhouse(spark_mock):
     assert "password='passwd'" not in str(conn)
     assert "password='passwd'" not in repr(conn)
 
+    assert conn.instance_url == "clickhouse://some_host:8123"
+
 
 def test_clickhouse_with_port(spark_mock):
     conn = Clickhouse(

--- a/tests/tests_unit/tests_db_connection_unit/test_greenplum_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_greenplum_unit.py
@@ -132,6 +132,8 @@ def test_greenplum(spark_mock):
     assert "password='passwd'" not in str(conn)
     assert "password='passwd'" not in repr(conn)
 
+    assert conn.instance_url == "greenplum://some_host:5432/database"
+
 
 def test_greenplum_with_port(spark_mock):
     conn = Greenplum(host="some_host", port=5000, user="user", database="database", password="passwd", spark=spark_mock)
@@ -152,6 +154,8 @@ def test_greenplum_with_port(spark_mock):
         "ApplicationName": "abc",
         "tcpKeepAlive": "true",
     }
+
+    assert conn.instance_url == "greenplum://some_host:5000/database"
 
 
 def test_greenplum_without_database_error(spark_mock):

--- a/tests/tests_unit/tests_db_connection_unit/test_mssql_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_mssql_unit.py
@@ -86,26 +86,28 @@ def test_mssql(spark_mock):
     conn = MSSQL(host="some_host", user="user", database="database", password="passwd", spark=spark_mock)
 
     assert conn.host == "some_host"
-    assert conn.port == 1433
+    assert conn.port is None
     assert conn.user == "user"
     assert conn.password != "passwd"
     assert conn.password.get_secret_value() == "passwd"
     assert conn.database == "database"
 
-    assert conn.jdbc_url == "jdbc:sqlserver://some_host:1433"
+    assert conn.jdbc_url == "jdbc:sqlserver://some_host"
     assert conn.jdbc_params == {
         "user": "user",
         "password": "passwd",
         "driver": "com.microsoft.sqlserver.jdbc.SQLServerDriver",
-        "url": "jdbc:sqlserver://some_host:1433",
+        "url": "jdbc:sqlserver://some_host",
         "databaseName": "database",
     }
 
     assert "password='passwd'" not in str(conn)
     assert "password='passwd'" not in repr(conn)
 
+    assert conn.instance_url == "mssql://some_host:1433/database"
 
-def test_mssql_with_port(spark_mock):
+
+def test_mssql_with_custom_port(spark_mock):
     conn = MSSQL(host="some_host", port=5000, user="user", database="database", password="passwd", spark=spark_mock)
 
     assert conn.host == "some_host"
@@ -123,6 +125,38 @@ def test_mssql_with_port(spark_mock):
         "url": "jdbc:sqlserver://some_host:5000",
         "databaseName": "database",
     }
+
+    assert conn.instance_url == "mssql://some_host:5000/database"
+
+
+def test_mssql_with_instance_name(spark_mock):
+    conn = MSSQL(
+        host="some_host",
+        user="user",
+        database="database",
+        password="passwd",
+        extra={"instanceName": "myinstance"},
+        spark=spark_mock,
+    )
+
+    assert conn.host == "some_host"
+    assert conn.port is None
+    assert conn.user == "user"
+    assert conn.password != "passwd"
+    assert conn.password.get_secret_value() == "passwd"
+    assert conn.database == "database"
+
+    assert conn.jdbc_url == "jdbc:sqlserver://some_host"
+    assert conn.jdbc_params == {
+        "user": "user",
+        "password": "passwd",
+        "driver": "com.microsoft.sqlserver.jdbc.SQLServerDriver",
+        "url": "jdbc:sqlserver://some_host",
+        "instanceName": "myinstance",
+        "databaseName": "database",
+    }
+
+    assert conn.instance_url == "mssql://some_host\\myinstance/database"
 
 
 def test_mssql_without_database_error(spark_mock):
@@ -145,12 +179,12 @@ def test_mssql_with_extra(spark_mock):
         spark=spark_mock,
     )
 
-    assert conn.jdbc_url == "jdbc:sqlserver://some_host:1433"
+    assert conn.jdbc_url == "jdbc:sqlserver://some_host"
     assert conn.jdbc_params == {
         "user": "user",
         "password": "passwd",
         "driver": "com.microsoft.sqlserver.jdbc.SQLServerDriver",
-        "url": "jdbc:sqlserver://some_host:1433",
+        "url": "jdbc:sqlserver://some_host",
         "databaseName": "database",
         "characterEncoding": "UTF-8",
         "trustServerCertificate": "true",

--- a/tests/tests_unit/tests_db_connection_unit/test_mysql_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_mysql_unit.py
@@ -92,6 +92,8 @@ def test_mysql(spark_mock):
     assert "password='passwd'" not in str(conn)
     assert "password='passwd'" not in repr(conn)
 
+    assert conn.instance_url == "mysql://some_host:3306"
+
 
 def test_mysql_with_port(spark_mock):
     conn = MySQL(host="some_host", port=5000, user="user", database="database", password="passwd", spark=spark_mock)
@@ -113,6 +115,8 @@ def test_mysql_with_port(spark_mock):
         "useUnicode": "yes",
     }
 
+    assert conn.instance_url == "mysql://some_host:5000"
+
 
 def test_mysql_without_database(spark_mock):
     conn = MySQL(host="some_host", user="user", password="passwd", spark=spark_mock)
@@ -133,6 +137,8 @@ def test_mysql_without_database(spark_mock):
         "characterEncoding": "UTF-8",
         "useUnicode": "yes",
     }
+
+    assert conn.instance_url == "mysql://some_host:3306"
 
 
 def test_mysql_with_extra(spark_mock):

--- a/tests/tests_unit/tests_db_connection_unit/test_oracle_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_oracle_unit.py
@@ -113,6 +113,8 @@ def test_oracle(spark_mock):
     assert "password='passwd'" not in str(conn)
     assert "password='passwd'" not in repr(conn)
 
+    assert conn.instance_url == "oracle://some_host:1521/sid"
+
 
 def test_oracle_with_port(spark_mock):
     conn = Oracle(host="some_host", port=5000, user="user", sid="sid", password="passwd", spark=spark_mock)
@@ -132,6 +134,8 @@ def test_oracle_with_port(spark_mock):
         "url": "jdbc:oracle:thin:@some_host:5000:sid",
     }
 
+    assert conn.instance_url == "oracle://some_host:5000/sid"
+
 
 def test_oracle_uri_with_service_name(spark_mock):
     conn = Oracle(host="some_host", user="user", password="passwd", service_name="service", spark=spark_mock)
@@ -143,6 +147,8 @@ def test_oracle_uri_with_service_name(spark_mock):
         "driver": "oracle.jdbc.driver.OracleDriver",
         "url": "jdbc:oracle:thin:@//some_host:1521/service",
     }
+
+    assert conn.instance_url == "oracle://some_host:1521/service"
 
 
 def test_oracle_without_sid_and_service_name(spark_mock):

--- a/tests/tests_unit/tests_db_connection_unit/test_postgres_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_postgres_unit.py
@@ -93,6 +93,8 @@ def test_postgres(spark_mock):
     assert "password='passwd'" not in str(conn)
     assert "password='passwd'" not in repr(conn)
 
+    assert conn.instance_url == "postgres://some_host:5432/database"
+
 
 def test_postgres_with_port(spark_mock):
     conn = Postgres(host="some_host", port=5000, user="user", database="database", password="passwd", spark=spark_mock)
@@ -114,6 +116,8 @@ def test_postgres_with_port(spark_mock):
         "tcpKeepAlive": "true",
         "stringtype": "unspecified",
     }
+
+    assert conn.instance_url == "postgres://some_host:5000/database"
 
 
 def test_postgres_without_database_error(spark_mock):

--- a/tests/tests_unit/tests_db_connection_unit/test_teradata_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_teradata_unit.py
@@ -92,6 +92,8 @@ def test_teradata(spark_mock):
     assert "password='passwd'" not in str(conn)
     assert "password='passwd'" not in repr(conn)
 
+    assert conn.instance_url == "teradata://some_host:1025"
+
 
 def test_teradata_with_port(spark_mock):
     conn = Teradata(host="some_host", port=5000, user="user", database="database", password="passwd", spark=spark_mock)
@@ -113,6 +115,8 @@ def test_teradata_with_port(spark_mock):
         "driver": "com.teradata.jdbc.TeraDriver",
         "url": conn.jdbc_url,
     }
+
+    assert conn.instance_url == "teradata://some_host:5000"
 
 
 def test_teradata_without_database(spark_mock):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Make MSSQL.port optional, to allow using [instanceName](https://learn.microsoft.com/en-us/sql/connect/jdbc/building-the-connection-url?view=sql-server-ver16#named-and-multiple-sql-server-instances).

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [X] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
