### PR TITLE
[DOP-15764] Remove fetchsize from JDBCWriteOptions

### DIFF
--- a/.github/workflows/data/db/tracked.txt
+++ b/.github/workflows/data/db/tracked.txt
@@ -1,5 +1,6 @@
 .github/workflows/data/db/**
-onetl/db_connection/db_connection.py
-onetl/db_connection/jdbc*.py
+onetl/db_connection/db_connection/*
 onetl/db_connection/dialect_mixins/*
+onetl/db_connection/jdbc_connection/*
+onetl/db_connection/jdbc_mixin/*
 onetl/db/**

--- a/docs/changelog/next_release/288.bugfix.rst
+++ b/docs/changelog/next_release/288.bugfix.rst
@@ -1,0 +1,1 @@
+Remove ``fetchsize`` from ``JDBC.WriteOptions``.

--- a/onetl/connection/db_connection/jdbc_connection/connection.py
+++ b/onetl/connection/db_connection/jdbc_connection/connection.py
@@ -21,7 +21,7 @@ from onetl.connection.db_connection.jdbc_connection.options import (
     JDBCWriteOptions,
 )
 from onetl.connection.db_connection.jdbc_mixin import JDBCMixin
-from onetl.connection.db_connection.jdbc_mixin.options import JDBCOptions
+from onetl.connection.db_connection.jdbc_mixin.options import JDBCFetchOptions
 from onetl.hooks import slot, support_hooks
 from onetl.hwm import Window
 from onetl.log import log_lines, log_with_indent
@@ -265,10 +265,12 @@ class JDBCConnection(JDBCMixin, DBConnection):
         self,
         options: JDBCReadOptions,
         fetchsize: int,
-    ) -> JDBCOptions:
-        return options.copy(
-            update={"fetchsize": fetchsize},
-            exclude={"partition_column", "lower_bound", "upper_bound", "num_partitions", "partitioning_mode"},
+    ) -> JDBCFetchOptions:
+        return self.FetchOptions.parse(
+            options.copy(
+                update={"fetchsize": fetchsize},
+                exclude={"partition_column", "lower_bound", "upper_bound", "num_partitions", "partitioning_mode"},
+            ).dict(),
         )
 
     def _set_lower_upper_bound(

--- a/onetl/connection/db_connection/postgres/connection.py
+++ b/onetl/connection/db_connection/postgres/connection.py
@@ -11,7 +11,6 @@ from onetl.connection.db_connection.jdbc_connection import JDBCConnection
 from onetl.connection.db_connection.jdbc_mixin.options import (
     JDBCExecuteOptions,
     JDBCFetchOptions,
-    JDBCOptions,
 )
 from onetl.connection.db_connection.postgres.dialect import PostgresDialect
 from onetl.connection.db_connection.postgres.options import (
@@ -182,7 +181,7 @@ class Postgres(JDBCConnection):
 
     def _options_to_connection_properties(
         self,
-        options: JDBCOptions | JDBCFetchOptions | JDBCExecuteOptions,
+        options: JDBCFetchOptions | JDBCExecuteOptions,
     ):  # noqa: WPS437
         # See https://github.com/pgjdbc/pgjdbc/pull/1252
         # Since 42.2.9 Postgres JDBC Driver added new option readOnlyMode=transaction


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

<!-- Please give a short summary of the changes. -->

Currently `JDBC.WriteOptions` have `fetchsize` option. This should not be the case.

Instead of inheriting `JDBC.ReadOptions`, `JDBC.SQLOptions` and `JDBC.WriteOptions from legacy `JDBC.JDBCOptions`, inherit them from `GenericOptions`. Copy `query_timeout` to both of these classes, as Spark can accept this option in both read and write operations.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [x] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
