### PR TITLE
[DOP-16103] - add class format to HiveWriteOptions

### DIFF
--- a/docs/changelog/next_release/292.feature.rst
+++ b/docs/changelog/next_release/292.feature.rst
@@ -1,0 +1,1 @@
+Add support for specifying file formats (``ORC``, ``Parquet``, ``CSV``, etc.) in ``HiveWriteOptions.format``: ``Hive.WriteOptions(format=ORC(compression="snappy"))``.

--- a/docs/connection/db_connection/hive/write.rst
+++ b/docs/connection/db_connection/hive/write.rst
@@ -5,6 +5,10 @@ Writing to Hive using ``DBWriter``
 
 For writing data to Hive, use :obj:`DBWriter <onetl.db.db_writer.db_writer.DBWriter>`.
 
+.. warning::
+    When using ``DBWriter`` with ``Hive.WriteOptions``, the default spark data format configured in ``spark.sql.sources.default`` is overridden to use ``orc`` by default. This may affect performance and storage characteristics.
+
+
 Examples
 --------
 

--- a/docs/connection/db_connection/hive/write.rst
+++ b/docs/connection/db_connection/hive/write.rst
@@ -5,9 +5,6 @@ Writing to Hive using ``DBWriter``
 
 For writing data to Hive, use :obj:`DBWriter <onetl.db.db_writer.db_writer.DBWriter>`.
 
-.. warning::
-    When using ``DBWriter`` with ``Hive.WriteOptions``, the default spark data format configured in ``spark.sql.sources.default`` is overridden to use ``orc`` by default. This may affect performance and storage characteristics.
-
 
 Examples
 --------
@@ -55,13 +52,16 @@ Use column-based write formats
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Prefer these write formats:
-  * `ORC <https://spark.apache.org/docs/latest/sql-data-sources-orc.html>`_
+  * `ORC <https://spark.apache.org/docs/latest/sql-data-sources-orc.html>`_ (**default**)
   * `Parquet <https://spark.apache.org/docs/latest/sql-data-sources-parquet.html>`_
   * `Iceberg <https://iceberg.apache.org/spark-quickstart/>`_
   * `Hudi <https://hudi.apache.org/docs/quick-start-guide/>`_
   * `Delta <https://docs.delta.io/latest/quick-start.html#set-up-apache-spark-with-delta-lake>`_
 
-For colum-based write formats, each file contains separated sections there column data is stored. The file footer contains
+.. warning::
+    When using ``DBWriter``, the default spark data format configured in ``spark.sql.sources.default`` is ignored, as  ``Hive.WriteOptions(format=...)`` default value is explicitly set to ``orc``.
+
+For column-based write formats, each file contains separated sections where column data is stored. The file footer contains
 location of each column section/group. Spark can use this information to load only sections required by specific query, e.g. only selected columns,
 to drastically speed up the query.
 

--- a/onetl/connection/db_connection/hive/connection.py
+++ b/onetl/connection/db_connection/hive/connection.py
@@ -453,16 +453,11 @@ class Hive(DBConnection):
         options_dict = write_options.dict(
             by_alias=True,
             exclude_unset=True,
-            exclude_defaults=True,
             exclude={"if_exists"},
         )
 
         if isinstance(write_options.format, WriteOnlyFileFormat):
-            if write_options.format.name != HiveWriteOptions.__fields__["format"].default:
-                options_dict["format"] = write_options.format.name
-            elif "format" in options_dict:
-                options_dict.pop("format")  # remove format key if it matches the default
-
+            options_dict["format"] = write_options.format.name
             options_dict.update(write_options.format.dict(exclude={"name"}))
 
         return options_dict

--- a/onetl/connection/db_connection/hive/options.py
+++ b/onetl/connection/db_connection/hive/options.py
@@ -218,6 +218,8 @@ class HiveWriteOptions(GenericOptions):
 
         # or using an ORC format class instance:
 
+        from onetl.file.format import ORC
+
         options = Hive.WriteOptions(
             if_exists="append",
             partition_by="reg_id",
@@ -305,16 +307,6 @@ class HiveWriteOptions(GenericOptions):
 
         Used **only** while **creating new table**, or in case of ``if_exists=replace_entire_table``
     """
-
-    def dict(self, **kwargs):
-        d = super().dict(**kwargs)
-        if isinstance(self.format, ReadWriteFileFormat):
-            if self.format.name != self.__fields__["format"].default:
-                d["format"] = self.format.name
-            elif "format" in d:
-                d.pop("format")
-            d.update(self.format.dict(exclude={"name"}))
-        return d
 
     @validator("sort_by")
     def _sort_by_cannot_be_used_without_bucket_by(cls, sort_by, values):

--- a/onetl/connection/db_connection/hive/options.py
+++ b/onetl/connection/db_connection/hive/options.py
@@ -13,7 +13,7 @@ except (ImportError, AttributeError):
 
 from typing_extensions import deprecated
 
-from onetl.file.format.file_format import ReadWriteFileFormat
+from onetl.file.format.file_format import WriteOnlyFileFormat
 from onetl.impl import GenericOptions
 
 
@@ -199,7 +199,7 @@ class HiveWriteOptions(GenericOptions):
         does not affect behavior.
     """
 
-    format: Union[str, ReadWriteFileFormat] = "orc"
+    format: Union[str, WriteOnlyFileFormat] = "orc"
     """Format of files which should be used for storing table data.
 
     Examples

--- a/tests/tests_integration/tests_core_integration/tests_db_writer_integration/test_hive_writer_integration.py
+++ b/tests/tests_integration/tests_core_integration/tests_db_writer_integration/test_hive_writer_integration.py
@@ -7,6 +7,7 @@ import pytest
 from onetl._util.spark import get_spark_version
 from onetl.connection import Hive
 from onetl.db import DBWriter
+from onetl.file.format import CSV, ORC, Parquet
 
 pytestmark = pytest.mark.hive
 
@@ -69,14 +70,17 @@ def test_hive_writer_with_options(spark, processing, get_schema_table, options):
 
 
 @pytest.mark.parametrize(
-    "options, fmt",
+    "options, format",
     [
-        (Hive.WriteOptions(format="orc"), "orc"),
         (Hive.WriteOptions(), "orc"),  # default
+        (Hive.WriteOptions(format="orc"), "orc"),
         (Hive.WriteOptions(format="parquet"), "parquet"),
+        (Hive.WriteOptions(format=ORC(compression="snappy")), "orc"),
+        (Hive.WriteOptions(format=CSV(sep=",", encoding="utf-8", inferSchema=True, compression="gzip")), "csv"),
+        (Hive.WriteOptions(format=Parquet(compression="snappy")), "parquet"),
     ],
 )
-def test_hive_writer_with_format(spark, processing, get_schema_table, options, fmt):
+def test_hive_writer_with_format(spark, processing, get_schema_table, options, format):
     df = processing.create_spark_df(spark)
     hive = Hive(cluster="rnd-dwh", spark=spark)
 
@@ -90,7 +94,7 @@ def test_hive_writer_with_format(spark, processing, get_schema_table, options, f
     response = hive.sql(f"SHOW CREATE TABLE {get_schema_table.full_name}")
     response = response.collect()[0][0]
 
-    assert f"USING {fmt}" in response
+    assert f"USING {format}" in response
 
 
 @pytest.mark.parametrize(
@@ -264,11 +268,13 @@ def test_hive_writer_create_table_if_exists(spark, processing, get_schema_table,
             Hive.WriteOptions(bucketBy=(5, "id_int"), sortBy="hwm_int"),
             "{'bucketBy': (5, 'id_int'), 'sortBy': 'hwm_int'}",
         ),
-        (Hive.WriteOptions(compression="snappy"), "{'compression': 'snappy'}"),
         (Hive.WriteOptions(format="parquet"), "{'format': 'parquet'}"),
+        (Hive.WriteOptions(format=Parquet()), "{'format': 'parquet'}"),
+        (Hive.WriteOptions(compression="snappy"), "{'compression': 'snappy'}"),
+        (Hive.WriteOptions(format=ORC(compression="snappy")), "{'compression': 'snappy'}"),
     ],
 )
-def test_hive_writer_insert_into_with_options(spark, processing, get_schema_table, options, option_kv, caplog):
+def test_hive_writer_insert_into_with_options_ignored(spark, processing, get_schema_table, options, option_kv, caplog):
     df = processing.create_spark_df(spark)
     hive = Hive(cluster="rnd-dwh", spark=spark)
 

--- a/tests/tests_integration/tests_core_integration/tests_db_writer_integration/test_hive_writer_integration.py
+++ b/tests/tests_integration/tests_core_integration/tests_db_writer_integration/test_hive_writer_integration.py
@@ -271,7 +271,8 @@ def test_hive_writer_create_table_if_exists(spark, processing, get_schema_table,
         (Hive.WriteOptions(format="parquet"), "{'format': 'parquet'}"),
         (Hive.WriteOptions(format=Parquet()), "{'format': 'parquet'}"),
         (Hive.WriteOptions(compression="snappy"), "{'compression': 'snappy'}"),
-        (Hive.WriteOptions(format=ORC(compression="snappy")), "{'compression': 'snappy'}"),
+        (Hive.WriteOptions(format="orc"), "{'format': 'orc'}"),
+        (Hive.WriteOptions(format=ORC(compression="snappy")), "{'format': 'orc', 'compression': 'snappy'}"),
     ],
 )
 def test_hive_writer_insert_into_with_options_ignored(spark, processing, get_schema_table, options, option_kv, caplog):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

- Add support for specifying file formats (``ORC``, ``Parquet``, ``CSV``, etc.) in ``HiveWriteOptions.format``: 

     ```
     options = Hive.WriteOptions(
                if_exists="append",
                partition_by="reg_id",
                format=ORC(compression="snappy"),
            )
    ```
- Update following tests and documentation

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [ ] Tests pass on CI and coverage does not decrease
* [x] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
