### PR TITLE
[DOP-18571] Collect and log Spark metrics in various method calls

### DIFF
--- a/docs/changelog/next_release/303.feature.1.rst
+++ b/docs/changelog/next_release/303.feature.1.rst
@@ -1,0 +1,1 @@
+Log estimated size of in-memory dataframe created by ``JDBC.fetch`` and ``JDBC.execute`` methods.

--- a/docs/changelog/next_release/303.feature.2.rst
+++ b/docs/changelog/next_release/303.feature.2.rst
@@ -1,0 +1,10 @@
+Collect Spark execution metrics in following methods, and log then in DEBUG mode:
+* ``DBWriter.run()``
+* ``FileDFWriter.run()``
+* ``Hive.sql()``
+* ``Hive.execute()``
+
+This is implemented using custom ``SparkListener`` which wraps the entire method call, and
+then report collected metrics. But these metrics sometimes may be missing due to Spark architecture,
+so they are not reliable source of information. That's why logs are printed only in DEBUG mode, and
+are not returned as method call result.

--- a/onetl/base/base_db_connection.py
+++ b/onetl/base/base_db_connection.py
@@ -10,7 +10,7 @@ from onetl.hwm import Window
 
 if TYPE_CHECKING:
     from etl_entities.hwm import HWM
-    from pyspark.sql import DataFrame
+    from pyspark.sql import DataFrame, SparkSession
     from pyspark.sql.types import StructField, StructType
 
 
@@ -106,6 +106,7 @@ class BaseDBConnection(BaseConnection):
     Implements generic methods for reading and writing dataframe from/to database-like source
     """
 
+    spark: SparkSession
     Dialect = BaseDBDialect
 
     @property

--- a/onetl/base/base_file_df_connection.py
+++ b/onetl/base/base_file_df_connection.py
@@ -11,7 +11,7 @@ from onetl.base.base_file_format import BaseReadableFileFormat, BaseWritableFile
 from onetl.base.pure_path_protocol import PurePathProtocol
 
 if TYPE_CHECKING:
-    from pyspark.sql import DataFrame, DataFrameReader, DataFrameWriter
+    from pyspark.sql import DataFrame, DataFrameReader, DataFrameWriter, SparkSession
     from pyspark.sql.types import StructType
 
 
@@ -71,6 +71,8 @@ class BaseFileDFConnection(BaseConnection):
 
     .. versionadded:: 0.9.0
     """
+
+    spark: SparkSession
 
     @abstractmethod
     def check_if_format_supported(

--- a/onetl/connection/db_connection/jdbc_connection/connection.py
+++ b/onetl/connection/db_connection/jdbc_connection/connection.py
@@ -92,9 +92,13 @@ class JDBCConnection(JDBCMixin, DBConnection):
         log.info("|%s| Executing SQL query (on executor):", self.__class__.__name__)
         log_lines(log, query)
 
-        df = self._query_on_executor(query, self.SQLOptions.parse(options))
+        try:
+            df = self._query_on_executor(query, self.SQLOptions.parse(options))
+        except Exception:
+            log.error("|%s| Query failed!", self.__class__.__name__)
+            raise
 
-        log.info("|Spark| DataFrame successfully created from SQL statement ")
+        log.info("|Spark| DataFrame successfully created from SQL statement")
         return df
 
     @slot

--- a/onetl/file/file_df_writer/file_df_writer.py
+++ b/onetl/file/file_df_writer/file_df_writer.py
@@ -10,6 +10,8 @@ try:
 except (ImportError, AttributeError):
     from pydantic import PrivateAttr, validator  # type: ignore[no-redef, assignment]
 
+from onetl._metrics.command import SparkCommandMetrics
+from onetl._metrics.recorder import SparkMetricsRecorder
 from onetl.base import BaseFileDFConnection, BaseWritableFileFormat, PurePathProtocol
 from onetl.file.file_df_writer.options import FileDFWriterOptions
 from onetl.hooks import slot, support_hooks
@@ -17,6 +19,7 @@ from onetl.impl import FrozenModel
 from onetl.log import (
     entity_boundary_log,
     log_dataframe_schema,
+    log_lines,
     log_options,
     log_with_indent,
 )
@@ -125,12 +128,32 @@ class FileDFWriter(FrozenModel):
             self.connection.check()
             self._connection_checked = True
 
-        self.connection.write_df_as_files(
-            df=df,
-            path=self.target_path,
-            format=self.format,
-            options=self.options,
-        )
+        with SparkMetricsRecorder(self.connection.spark) as recorder:
+            try:
+                self.connection.write_df_as_files(
+                    df=df,
+                    path=self.target_path,
+                    format=self.format,
+                    options=self.options,
+                )
+            except Exception:
+                metrics = recorder.metrics()
+                if metrics.output.is_empty:
+                    # SparkListener is not a reliable source of information, metrics may or may not be present.
+                    # Because of this we also do not return these metrics as method result
+                    log.error(
+                        "|%s| Error while writing dataframe.",
+                        self.__class__.__name__,
+                    )
+                else:
+                    log.error(
+                        "|%s| Error while writing dataframe. Target MAY contain partially written data!",
+                        self.__class__.__name__,
+                    )
+                self._log_metrics(metrics)
+                raise
+            finally:
+                self._log_metrics(recorder.metrics())
 
         entity_boundary_log(log, f"{self.__class__.__name__}.run() ends", char="-")
 
@@ -142,6 +165,11 @@ class FileDFWriter(FrozenModel):
         options_dict = self.options.dict(exclude_none=True)
         log_options(log, options_dict)
         log_dataframe_schema(log, df)
+
+    def _log_metrics(self, metrics: SparkCommandMetrics) -> None:
+        if not metrics.is_empty:
+            log.debug("|%s| Recorded metrics (some values may be missing!):", self.__class__.__name__)
+            log_lines(log, str(metrics), level=logging.DEBUG)
 
     @validator("target_path", pre=True)
     def _validate_target_path(cls, target_path, values):

--- a/tests/.coveragerc
+++ b/tests/.coveragerc
@@ -11,6 +11,7 @@ exclude_lines =
     def __repr__
     if self.debug:
     if settings.DEBUG
+    if log.isEnabledFor\(logging.DEBUG\)
     raise AssertionError
     raise NotImplementedError
     if __name__ == .__main__.:
@@ -20,6 +21,5 @@ exclude_lines =
     if pyspark_version
     if spark_version
     spark = SparkSession._instantiatedSession
-    if log.isEnabledFor(logging.DEBUG):
     if sys.version_info
     except .*ImportError

--- a/tests/tests_integration/tests_db_connection_integration/test_postgres_integration.py
+++ b/tests/tests_integration/tests_db_connection_integration/test_postgres_integration.py
@@ -1007,7 +1007,7 @@ def test_postgres_connection_sql_options(
     processing.assert_equal_df(df=df, other_frame=table_df)
 
 
-def test_postgres_fetch_with_legacy_jdbc_options(spark, processing):
+def test_postgres_connection_fetch_with_legacy_jdbc_options(spark, processing):
     postgres = Postgres(
         host=processing.host,
         port=processing.port,
@@ -1023,7 +1023,7 @@ def test_postgres_fetch_with_legacy_jdbc_options(spark, processing):
     assert df is not None
 
 
-def test_postgres_execute_with_legacy_jdbc_options(spark, processing):
+def test_postgres_connection_execute_with_legacy_jdbc_options(spark, processing):
     postgres = Postgres(
         host=processing.host,
         port=processing.port,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Use `SparkMetricsRecorded` to collect Spark metrics from those methods:
* `DBWriter.run()`
* `FileDFWriter.run()`
* `JDBC.fetch()`, `JDBC.execute()`
* `Hive.execute()`

And log these metrics. But the only metrics logged in INFO level are JDBC ones, as they are reliable, others are DEBUG only.

Also I've added function to get estimated size of in-memory dataframe using Spark's `SizeEstimator`. This is an approximate metric, but it always present.

Few examples:

`DBWriter.run` with Hive:
```
DEBUG |DBWriter| Recorded metrics (may be incomplete!):
DEBUG         Output:
DEBUG             Written rows: 100
DEBUG             Written size: 2.5 kB
DEBUG             Created files: 1
DEBUG         Executor:
DEBUG             Total run time: 0.13 seconds
DEBUG             Total CPU time: 0.04 seconds
```

`DBWriter.run` with Postgres:
```
DEBUG |DBWriter| Recorded metrics (may be incomplete!):
DEBUG         Output:
DEBUG             Written rows: 100
DEBUG         Executor:
DEBUG             Total run time: 0.13 seconds
DEBUG             Total CPU time: 0.05 seconds
```

`Postgres.fetch`:
```
INFO |Postgres| Recorded metrics:
INFO         Input:
INFO             Read rows: 100
INFO         Driver:
INFO             In-memory data (approximate): 44.2 MB
```

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
