### PR TITLE
[DOP-18743] Set default jobDescription

### DIFF
--- a/docs/changelog/next_release/304.breaking.rst
+++ b/docs/changelog/next_release/304.breaking.rst
@@ -1,0 +1,3 @@
+Change connection URL used for generating HWM names of S3 and Samba sources:
+* ``smb://host:port`` -> ``smb://host:port/share``
+* ``s3://host:port`` -> ``s3://host:port/bucket``

--- a/docs/changelog/next_release/304.feature.rst
+++ b/docs/changelog/next_release/304.feature.rst
@@ -1,0 +1,6 @@
+Generate default ``jobDescription`` based on currently executed method. Examples:
+* ``DBWriter() -> Postgres[host:5432/database]``
+* ``MongoDB[localhost:27017/admin] -> DBReader.run()``
+* ``Hive[cluster].execute()``
+
+If user already set custom ``jobDescription``, it will left intact.

--- a/onetl/_util/hadoop.py
+++ b/onetl/_util/hadoop.py
@@ -14,7 +14,7 @@ def get_hadoop_version(spark_session: SparkSession) -> Version:
     """
     Get version of Hadoop libraries embedded to Spark
     """
-    jvm = spark_session._jvm  # noqa: WPS437
+    jvm = spark_session._jvm  # noqa: WPS437 # type: ignore[attr-defined]
     version_info = jvm.org.apache.hadoop.util.VersionInfo  # type: ignore[union-attr]
     hadoop_version: str = version_info.getVersion()
     return Version(hadoop_version)
@@ -24,4 +24,4 @@ def get_hadoop_config(spark_session: SparkSession):
     """
     Get ``org.apache.hadoop.conf.Configuration`` object
     """
-    return spark_session.sparkContext._jsc.hadoopConfiguration()
+    return spark_session.sparkContext._jsc.hadoopConfiguration()  # type: ignore[attr-defined]

--- a/onetl/_util/java.py
+++ b/onetl/_util/java.py
@@ -16,7 +16,7 @@ def get_java_gateway(spark_session: SparkSession) -> JavaGateway:
     """
     Get py4j Java gateway object
     """
-    return spark_session._sc._gateway  # noqa: WPS437  # type: ignore
+    return spark_session._sc._gateway  # noqa: WPS437 # type: ignore[attr-defined]
 
 
 def try_import_java_class(spark_session: SparkSession, name: str):

--- a/onetl/connection/db_connection/clickhouse/connection.py
+++ b/onetl/connection/db_connection/clickhouse/connection.py
@@ -196,6 +196,9 @@ class Clickhouse(JDBCConnection):
     def instance_url(self) -> str:
         return f"{self.__class__.__name__.lower()}://{self.host}:{self.port}"
 
+    def __str__(self):
+        return f"{self.__class__.__name__}[{self.host}:{self.port}]"
+
     @staticmethod
     def _build_statement(
         statement: str,

--- a/onetl/connection/db_connection/greenplum/connection.py
+++ b/onetl/connection/db_connection/greenplum/connection.py
@@ -267,6 +267,9 @@ class Greenplum(JDBCMixin, DBConnection):
     def instance_url(self) -> str:
         return f"{self.__class__.__name__.lower()}://{self.host}:{self.port}/{self.database}"
 
+    def __str__(self):
+        return f"{self.__class__.__name__}[{self.host}:{self.port}/{self.database}]"
+
     @property
     def jdbc_url(self) -> str:
         return f"jdbc:postgresql://{self.host}:{self.port}/{self.database}"

--- a/onetl/connection/db_connection/jdbc_connection/connection.py
+++ b/onetl/connection/db_connection/jdbc_connection/connection.py
@@ -7,6 +7,7 @@ import secrets
 import warnings
 from typing import TYPE_CHECKING, Any
 
+from onetl._util.spark import override_job_description
 from onetl._util.sql import clear_statement
 from onetl.connection.db_connection.db_connection import DBConnection
 from onetl.connection.db_connection.jdbc_connection.dialect import JDBCDialect
@@ -93,7 +94,8 @@ class JDBCConnection(JDBCMixin, DBConnection):
         log_lines(log, query)
 
         try:
-            df = self._query_on_executor(query, self.SQLOptions.parse(options))
+            with override_job_description(self.spark, f"{self}.sql()"):
+                df = self._query_on_executor(query, self.SQLOptions.parse(options))
         except Exception:
             log.error("|%s| Query failed!", self.__class__.__name__)
             raise

--- a/onetl/connection/db_connection/kafka/connection.py
+++ b/onetl/connection/db_connection/kafka/connection.py
@@ -497,7 +497,7 @@ class Kafka(DBConnection):
             # https://kafka.apache.org/22/javadoc/org/apache/kafka/clients/consumer/KafkaConsumer.html#partitionsFor-java.lang.String-
             partition_infos = consumer.partitionsFor(source)
 
-            jvm = self.spark._jvm
+            jvm = self.spark._jvm  # type: ignore[attr-defined]
             topic_partitions = [
                 jvm.org.apache.kafka.common.TopicPartition(source, p.partition())  # type: ignore[union-attr]
                 for p in partition_infos
@@ -541,6 +541,9 @@ class Kafka(DBConnection):
     @property
     def instance_url(self):
         return "kafka://" + self.cluster
+
+    def __str__(self):
+        return f"{self.__class__.__name__}[{self.cluster}]"
 
     @root_validator(pre=True)
     def _get_addresses_by_cluster(cls, values):
@@ -639,7 +642,7 @@ class Kafka(DBConnection):
         return consumer_class(connection_properties)
 
     def _get_topics(self, timeout: int = 10) -> set[str]:
-        jvm = self.spark._jvm
+        jvm = self.spark._jvm  # type: ignore[attr-defined]
         # Maybe we should not pass explicit timeout at all,
         # and instead use default.api.timeout.ms which is configurable via self.extra.
         # Think about this next time if someone see issues in real use

--- a/onetl/connection/db_connection/mssql/connection.py
+++ b/onetl/connection/db_connection/mssql/connection.py
@@ -268,3 +268,12 @@ class MSSQL(JDBCConnection):
         # for backward compatibility keep port number in legacy HWM instance url
         port = self.port or 1433
         return f"{self.__class__.__name__.lower()}://{self.host}:{port}/{self.database}"
+
+    def __str__(self):
+        extra_dict = self.extra.dict(by_alias=True)
+        instance_name = extra_dict.get("instanceName")
+        if instance_name:
+            return rf"{self.__class__.__name__}[{self.host}\{instance_name}/{self.database}]"
+
+        port = self.port or 1433
+        return f"{self.__class__.__name__}[{self.host}:{port}/{self.database}]"

--- a/onetl/connection/db_connection/mysql/connection.py
+++ b/onetl/connection/db_connection/mysql/connection.py
@@ -175,3 +175,6 @@ class MySQL(JDBCConnection):
     @property
     def instance_url(self) -> str:
         return f"{self.__class__.__name__.lower()}://{self.host}:{self.port}"
+
+    def __str__(self):
+        return f"{self.__class__.__name__}[{self.host}:{self.port}]"

--- a/onetl/connection/db_connection/oracle/connection.py
+++ b/onetl/connection/db_connection/oracle/connection.py
@@ -262,6 +262,12 @@ class Oracle(JDBCConnection):
 
         return f"{self.__class__.__name__.lower()}://{self.host}:{self.port}/{self.service_name}"
 
+    def __str__(self):
+        if self.sid:
+            return f"{self.__class__.__name__}[{self.host}:{self.port}/{self.sid}]"
+
+        return f"{self.__class__.__name__}[{self.host}:{self.port}/{self.service_name}]"
+
     @slot
     def get_min_max_values(
         self,

--- a/onetl/connection/db_connection/postgres/connection.py
+++ b/onetl/connection/db_connection/postgres/connection.py
@@ -182,6 +182,9 @@ class Postgres(JDBCConnection):
     def instance_url(self) -> str:
         return f"{self.__class__.__name__.lower()}://{self.host}:{self.port}/{self.database}"
 
+    def __str__(self):
+        return f"{self.__class__.__name__}[{self.host}:{self.port}/{self.database}]"
+
     def _options_to_connection_properties(
         self,
         options: JDBCFetchOptions | JDBCExecuteOptions,

--- a/onetl/connection/db_connection/teradata/connection.py
+++ b/onetl/connection/db_connection/teradata/connection.py
@@ -208,3 +208,6 @@ class Teradata(JDBCConnection):
     @property
     def instance_url(self) -> str:
         return f"{self.__class__.__name__.lower()}://{self.host}:{self.port}"
+
+    def __str__(self):
+        return f"{self.__class__.__name__}[{self.host}:{self.port}]"

--- a/onetl/connection/file_connection/ftp.py
+++ b/onetl/connection/file_connection/ftp.py
@@ -105,7 +105,10 @@ class FTP(FileConnection, RenameDirMixin):
 
     @property
     def instance_url(self) -> str:
-        return f"ftp://{self.host}:{self.port}"
+        return f"{self.__class__.__name__.lower()}://{self.host}:{self.port}"
+
+    def __str__(self):
+        return f"{self.__class__.__name__}[{self.host}:{self.port}]"
 
     @slot
     def path_exists(self, path: os.PathLike | str) -> bool:

--- a/onetl/connection/file_connection/ftps.py
+++ b/onetl/connection/file_connection/ftps.py
@@ -95,10 +95,6 @@ class FTPS(FTP):
         )
     """
 
-    @property
-    def instance_url(self) -> str:
-        return f"ftps://{self.host}:{self.port}"
-
     def _get_client(self) -> FTPHost:
         """
         Returns a FTPS connection object

--- a/onetl/connection/file_connection/hdfs/connection.py
+++ b/onetl/connection/file_connection/hdfs/connection.py
@@ -264,6 +264,11 @@ class HDFS(FileConnection, RenameDirMixin):
             return self.cluster
         return f"hdfs://{self.host}:{self.webhdfs_port}"
 
+    def __str__(self):
+        if self.cluster:
+            return f"{self.__class__.__name__}[{self.cluster}]"
+        return f"{self.__class__.__name__}[{self.host}:{self.webhdfs_port}]"
+
     @slot
     def path_exists(self, path: os.PathLike | str) -> bool:
         return self.client.status(os.fspath(path), strict=False)

--- a/onetl/connection/file_connection/s3.py
+++ b/onetl/connection/file_connection/s3.py
@@ -131,7 +131,10 @@ class S3(FileConnection):
 
     @property
     def instance_url(self) -> str:
-        return f"s3://{self.host}:{self.port}"
+        return f"{self.__class__.__name__.lower()}://{self.host}:{self.port}/{self.bucket}"
+
+    def __str__(self):
+        return f"{self.__class__.__name__}[{self.host}:{self.port}/{self.bucket}]"
 
     @slot
     def create_dir(self, path: os.PathLike | str) -> RemoteDirectory:

--- a/onetl/connection/file_connection/samba.py
+++ b/onetl/connection/file_connection/samba.py
@@ -125,7 +125,10 @@ class Samba(FileConnection):
 
     @property
     def instance_url(self) -> str:
-        return f"smb://{self.host}:{self.port}"
+        return f"smb://{self.host}:{self.port}/{self.share}"
+
+    def __str__(self):
+        return f"{self.__class__.__name__}[{self.host}:{self.port}/{self.share}]"
 
     @slot
     def check(self):

--- a/onetl/connection/file_connection/sftp.py
+++ b/onetl/connection/file_connection/sftp.py
@@ -120,7 +120,10 @@ class SFTP(FileConnection, RenameDirMixin):
 
     @property
     def instance_url(self) -> str:
-        return f"sftp://{self.host}:{self.port}"
+        return f"{self.__class__.__name__.lower()}://{self.host}:{self.port}"
+
+    def __str__(self):
+        return f"{self.__class__.__name__}[{self.host}:{self.port}]"
 
     @slot
     def path_exists(self, path: os.PathLike | str) -> bool:

--- a/onetl/connection/file_connection/webdav.py
+++ b/onetl/connection/file_connection/webdav.py
@@ -130,7 +130,10 @@ class WebDAV(FileConnection, RenameDirMixin):
 
     @property
     def instance_url(self) -> str:
-        return f"webdav://{self.host}:{self.port}"
+        return f"{self.__class__.__name__.lower()}://{self.host}:{self.port}"
+
+    def __str__(self):
+        return f"{self.__class__.__name__}[{self.host}:{self.port}]"
 
     @slot
     def path_exists(self, path: os.PathLike | str) -> bool:

--- a/onetl/connection/file_df_connection/spark_hdfs/connection.py
+++ b/onetl/connection/file_df_connection/spark_hdfs/connection.py
@@ -164,6 +164,9 @@ class SparkHDFS(SparkFileDFConnection):
     def instance_url(self):
         return self.cluster
 
+    def __str__(self):
+        return f"HDFS[{self.cluster}]"
+
     def __enter__(self):
         return self
 

--- a/onetl/connection/file_df_connection/spark_local_fs.py
+++ b/onetl/connection/file_df_connection/spark_local_fs.py
@@ -74,6 +74,10 @@ class SparkLocalFS(SparkFileDFConnection):
         fqdn = socket.getfqdn()
         return f"file://{fqdn}"
 
+    def __str__(self):
+        # str should not make network requests
+        return "LocalFS"
+
     @validator("spark")
     def _validate_spark(cls, spark):
         master = spark.conf.get("spark.master")

--- a/onetl/connection/file_df_connection/spark_s3/connection.py
+++ b/onetl/connection/file_df_connection/spark_s3/connection.py
@@ -256,7 +256,10 @@ class SparkS3(SparkFileDFConnection):
 
     @property
     def instance_url(self):
-        return f"s3://{self.host}:{self.port}"
+        return f"s3://{self.host}:{self.port}/{self.bucket}"
+
+    def __str__(self):
+        return f"S3[{self.host}:{self.port}/{self.bucket}]"
 
     def __enter__(self):
         return self

--- a/onetl/file/file_df_reader/file_df_reader.py
+++ b/onetl/file/file_df_reader/file_df_reader.py
@@ -13,7 +13,7 @@ try:
 except (ImportError, AttributeError):
     from pydantic import PrivateAttr, validator  # type: ignore[no-redef, assignment]
 
-from onetl._util.spark import try_import_pyspark
+from onetl._util.spark import override_job_description, try_import_pyspark
 from onetl.base import BaseFileDFConnection, BaseReadableFileFormat, PurePathProtocol
 from onetl.file.file_df_reader.options import FileDFReaderOptions
 from onetl.file.file_set import FileSet
@@ -211,18 +211,23 @@ class FileDFReader(FrozenModel):
         if not self._connection_checked:
             self._log_parameters(files)
 
-        paths: FileSet[PurePathProtocol] = FileSet()
-        if files is not None:
-            paths = FileSet(self._validate_files(files))
-        elif self.source_path:
-            paths = FileSet([self.source_path])
+        with override_job_description(
+            self.connection.spark,
+            f"{self.connection} -> {self.__class__.__name__}.run()",
+        ):
+            paths: FileSet[PurePathProtocol] = FileSet()
+            if files is not None:
+                paths = FileSet(self._validate_files(files))
+            elif self.source_path:
+                paths = FileSet([self.source_path])
 
-        if not self._connection_checked:
-            self.connection.check()
-            log_with_indent(log, "")
-            self._connection_checked = True
+            if not self._connection_checked:
+                self.connection.check()
+                log_with_indent(log, "")
+                self._connection_checked = True
 
-        df = self._read_files(paths)
+            df = self._read_files(paths)
+
         entity_boundary_log(log, msg=f"{self.__class__.__name__}.run() ends", char="-")
         return df
 

--- a/tests/fixtures/spark.py
+++ b/tests/fixtures/spark.py
@@ -123,12 +123,11 @@ def excluded_packages():
 
 @pytest.fixture(
     scope="session",
-    name="spark",
     params=[
         pytest.param("real-spark", marks=[pytest.mark.db_connection, pytest.mark.connection]),
     ],
 )
-def get_spark_session(warehouse_dir, spark_metastore_dir, ivysettings_path, maven_packages, excluded_packages):
+def spark(warehouse_dir, spark_metastore_dir, ivysettings_path, maven_packages, excluded_packages):
     from pyspark.sql import SparkSession
 
     spark = (

--- a/tests/tests_unit/tests_db_connection_unit/test_clickhouse_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_clickhouse_unit.py
@@ -128,10 +128,10 @@ def test_clickhouse(spark_mock):
         "url": "jdbc:clickhouse://some_host:8123/database",
     }
 
-    assert "password='passwd'" not in str(conn)
-    assert "password='passwd'" not in repr(conn)
+    assert "passwd" not in repr(conn)
 
     assert conn.instance_url == "clickhouse://some_host:8123"
+    assert str(conn) == "Clickhouse[some_host:8123]"
 
 
 def test_clickhouse_with_port(spark_mock):

--- a/tests/tests_unit/tests_db_connection_unit/test_greenplum_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_greenplum_unit.py
@@ -129,10 +129,10 @@ def test_greenplum(spark_mock):
         "tcpKeepAlive": "true",
     }
 
-    assert "password='passwd'" not in str(conn)
-    assert "password='passwd'" not in repr(conn)
+    assert "passwd" not in repr(conn)
 
     assert conn.instance_url == "greenplum://some_host:5432/database"
+    assert str(conn) == "Greenplum[some_host:5432/database]"
 
 
 def test_greenplum_with_port(spark_mock):
@@ -156,6 +156,7 @@ def test_greenplum_with_port(spark_mock):
     }
 
     assert conn.instance_url == "greenplum://some_host:5000/database"
+    assert str(conn) == "Greenplum[some_host:5000/database]"
 
 
 def test_greenplum_without_database_error(spark_mock):

--- a/tests/tests_unit/tests_db_connection_unit/test_kafka_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_kafka_unit.py
@@ -181,6 +181,7 @@ def test_kafka_basic_auth_get_jaas_conf(spark_mock):
     assert conn.addresses == ["192.168.1.1"]
 
     assert conn.instance_url == "kafka://some_cluster"
+    assert str(conn) == "Kafka[some_cluster]"
 
 
 def test_kafka_anon_auth(spark_mock):
@@ -194,6 +195,7 @@ def test_kafka_anon_auth(spark_mock):
     assert conn.addresses == ["192.168.1.1"]
 
     assert conn.instance_url == "kafka://some_cluster"
+    assert str(conn) == "Kafka[some_cluster]"
 
 
 @pytest.mark.parametrize("digest", ["SHA-256", "SHA-512"])
@@ -217,6 +219,7 @@ def test_kafka_scram_auth(spark_mock, digest):
     assert conn.addresses == ["192.168.1.1"]
 
     assert conn.instance_url == "kafka://some_cluster"
+    assert str(conn) == "Kafka[some_cluster]"
 
 
 def test_kafka_auth_keytab(spark_mock, create_keytab):
@@ -235,6 +238,7 @@ def test_kafka_auth_keytab(spark_mock, create_keytab):
     assert conn.addresses == ["192.168.1.1"]
 
     assert conn.instance_url == "kafka://some_cluster"
+    assert str(conn) == "Kafka[some_cluster]"
 
 
 def test_kafka_empty_addresses(spark_mock):

--- a/tests/tests_unit/tests_db_connection_unit/test_mongodb_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_mongodb_unit.py
@@ -126,9 +126,10 @@ def test_mongodb(spark_mock):
     assert conn.database == "database"
 
     assert conn.connection_url == "mongodb://user:password@host:27017/database"
+    assert conn.instance_url == "mongodb://host:27017/database"
+    assert str(conn) == "MongoDB[host:27017/database]"
 
-    assert "password='passwd'" not in str(conn)
-    assert "password='passwd'" not in repr(conn)
+    assert "passwd" not in repr(conn)
 
 
 @pytest.mark.parametrize(
@@ -150,7 +151,7 @@ def test_mongodb_options_hint():
 
 
 def test_mongodb_with_port(spark_mock):
-    mongo = MongoDB(
+    conn = MongoDB(
         host="host",
         user="user",
         password="password",
@@ -159,14 +160,15 @@ def test_mongodb_with_port(spark_mock):
         spark=spark_mock,
     )
 
-    assert mongo.host == "host"
-    assert mongo.port == 12345
-    assert mongo.user == "user"
-    assert mongo.password != "password"
-    assert mongo.password.get_secret_value() == "password"
-    assert mongo.database == "database"
+    assert conn.host == "host"
+    assert conn.port == 12345
+    assert conn.user == "user"
+    assert conn.password != "password"
+    assert conn.password.get_secret_value() == "password"
+    assert conn.database == "database"
 
-    assert mongo.connection_url == "mongodb://user:password@host:12345/database"
+    assert conn.connection_url == "mongodb://user:password@host:12345/database"
+    assert conn.instance_url == "mongodb://host:12345/database"
 
 
 def test_mongodb_without_mandatory_args(spark_mock):

--- a/tests/tests_unit/tests_db_connection_unit/test_mssql_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_mssql_unit.py
@@ -101,10 +101,10 @@ def test_mssql(spark_mock):
         "databaseName": "database",
     }
 
-    assert "password='passwd'" not in str(conn)
-    assert "password='passwd'" not in repr(conn)
+    assert "passwd" not in repr(conn)
 
     assert conn.instance_url == "mssql://some_host:1433/database"
+    assert str(conn) == "MSSQL[some_host:1433/database]"
 
 
 def test_mssql_with_custom_port(spark_mock):
@@ -127,6 +127,7 @@ def test_mssql_with_custom_port(spark_mock):
     }
 
     assert conn.instance_url == "mssql://some_host:5000/database"
+    assert str(conn) == "MSSQL[some_host:5000/database]"
 
 
 def test_mssql_with_instance_name(spark_mock):
@@ -157,6 +158,7 @@ def test_mssql_with_instance_name(spark_mock):
     }
 
     assert conn.instance_url == "mssql://some_host\\myinstance/database"
+    assert str(conn) == "MSSQL[some_host\\myinstance/database]"
 
 
 def test_mssql_without_database_error(spark_mock):

--- a/tests/tests_unit/tests_db_connection_unit/test_mysql_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_mysql_unit.py
@@ -89,10 +89,10 @@ def test_mysql(spark_mock):
         "useUnicode": "yes",
     }
 
-    assert "password='passwd'" not in str(conn)
-    assert "password='passwd'" not in repr(conn)
+    assert "passwd" not in repr(conn)
 
     assert conn.instance_url == "mysql://some_host:3306"
+    assert str(conn) == "MySQL[some_host:3306]"
 
 
 def test_mysql_with_port(spark_mock):
@@ -116,6 +116,7 @@ def test_mysql_with_port(spark_mock):
     }
 
     assert conn.instance_url == "mysql://some_host:5000"
+    assert str(conn) == "MySQL[some_host:5000]"
 
 
 def test_mysql_without_database(spark_mock):
@@ -139,6 +140,7 @@ def test_mysql_without_database(spark_mock):
     }
 
     assert conn.instance_url == "mysql://some_host:3306"
+    assert str(conn) == "MySQL[some_host:3306]"
 
 
 def test_mysql_with_extra(spark_mock):

--- a/tests/tests_unit/tests_db_connection_unit/test_oracle_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_oracle_unit.py
@@ -110,10 +110,10 @@ def test_oracle(spark_mock):
         "url": "jdbc:oracle:thin:@some_host:1521:sid",
     }
 
-    assert "password='passwd'" not in str(conn)
-    assert "password='passwd'" not in repr(conn)
+    assert "passwd" not in repr(conn)
 
     assert conn.instance_url == "oracle://some_host:1521/sid"
+    assert str(conn) == "Oracle[some_host:1521/sid]"
 
 
 def test_oracle_with_port(spark_mock):
@@ -135,6 +135,7 @@ def test_oracle_with_port(spark_mock):
     }
 
     assert conn.instance_url == "oracle://some_host:5000/sid"
+    assert str(conn) == "Oracle[some_host:5000/sid]"
 
 
 def test_oracle_uri_with_service_name(spark_mock):
@@ -149,6 +150,7 @@ def test_oracle_uri_with_service_name(spark_mock):
     }
 
     assert conn.instance_url == "oracle://some_host:1521/service"
+    assert str(conn) == "Oracle[some_host:1521/service]"
 
 
 def test_oracle_without_sid_and_service_name(spark_mock):

--- a/tests/tests_unit/tests_db_connection_unit/test_postgres_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_postgres_unit.py
@@ -90,10 +90,10 @@ def test_postgres(spark_mock):
         "stringtype": "unspecified",
     }
 
-    assert "password='passwd'" not in str(conn)
-    assert "password='passwd'" not in repr(conn)
+    assert "passwd" not in repr(conn)
 
     assert conn.instance_url == "postgres://some_host:5432/database"
+    assert str(conn) == "Postgres[some_host:5432/database]"
 
 
 def test_postgres_with_port(spark_mock):
@@ -118,6 +118,7 @@ def test_postgres_with_port(spark_mock):
     }
 
     assert conn.instance_url == "postgres://some_host:5000/database"
+    assert str(conn) == "Postgres[some_host:5000/database]"
 
 
 def test_postgres_without_database_error(spark_mock):

--- a/tests/tests_unit/tests_db_connection_unit/test_teradata_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_teradata_unit.py
@@ -89,10 +89,10 @@ def test_teradata(spark_mock):
         "url": conn.jdbc_url,
     }
 
-    assert "password='passwd'" not in str(conn)
-    assert "password='passwd'" not in repr(conn)
+    assert "passwd" not in repr(conn)
 
     assert conn.instance_url == "teradata://some_host:1025"
+    assert str(conn) == "Teradata[some_host:1025]"
 
 
 def test_teradata_with_port(spark_mock):
@@ -117,6 +117,7 @@ def test_teradata_with_port(spark_mock):
     }
 
     assert conn.instance_url == "teradata://some_host:5000"
+    assert str(conn) == "Teradata[some_host:5000]"
 
 
 def test_teradata_without_database(spark_mock):

--- a/tests/tests_unit/tests_file_connection_unit/test_ftp_unit.py
+++ b/tests/tests_unit/tests_file_connection_unit/test_ftp_unit.py
@@ -8,35 +8,34 @@ pytestmark = [pytest.mark.ftp, pytest.mark.file_connection, pytest.mark.connecti
 def test_ftp_connection():
     from onetl.connection import FTP
 
-    ftp = FTP(host="some_host", user="some_user", password="pwd")
-    assert isinstance(ftp, FileConnection)
-    assert ftp.host == "some_host"
-    assert ftp.user == "some_user"
-    assert ftp.password != "pwd"
-    assert ftp.password.get_secret_value() == "pwd"
-    assert ftp.port == 21
+    conn = FTP(host="some_host", user="some_user", password="pwd")
+    assert isinstance(conn, FileConnection)
+    assert conn.host == "some_host"
+    assert conn.user == "some_user"
+    assert conn.password != "pwd"
+    assert conn.password.get_secret_value() == "pwd"
+    assert conn.port == 21
 
-    assert "password='pwd'" not in str(ftp)
-    assert "password='pwd'" not in repr(ftp)
+    assert str(conn) == "FTP[some_host:21]"
+    assert "pwd" not in repr(conn)
 
 
 def test_ftp_connection_anonymous():
     from onetl.connection import FTP
 
-    ftp = FTP(host="some_host")
-
-    assert isinstance(ftp, FileConnection)
-    assert ftp.host == "some_host"
-    assert ftp.user is None
-    assert ftp.password is None
+    conn = FTP(host="some_host")
+    assert conn.host == "some_host"
+    assert conn.user is None
+    assert conn.password is None
 
 
 def test_ftp_connection_with_port():
     from onetl.connection import FTP
 
-    ftp = FTP(host="some_host", user="some_user", password="pwd", port=500)
+    conn = FTP(host="some_host", user="some_user", password="pwd", port=500)
 
-    assert ftp.port == 500
+    assert conn.port == 500
+    assert str(conn) == "FTP[some_host:500]"
 
 
 def test_ftp_connection_without_mandatory_args():

--- a/tests/tests_unit/tests_file_connection_unit/test_ftps_unit.py
+++ b/tests/tests_unit/tests_file_connection_unit/test_ftps_unit.py
@@ -8,35 +8,36 @@ pytestmark = [pytest.mark.ftps, pytest.mark.file_connection, pytest.mark.connect
 def test_ftps_connection():
     from onetl.connection import FTPS
 
-    ftps = FTPS(host="some_host", user="some_user", password="pwd")
-    assert isinstance(ftps, FileConnection)
-    assert ftps.host == "some_host"
-    assert ftps.user == "some_user"
-    assert ftps.password != "pwd"
-    assert ftps.password.get_secret_value() == "pwd"
-    assert ftps.port == 21
+    conn = FTPS(host="some_host", user="some_user", password="pwd")
+    assert isinstance(conn, FileConnection)
+    assert conn.host == "some_host"
+    assert conn.user == "some_user"
+    assert conn.password != "pwd"
+    assert conn.password.get_secret_value() == "pwd"
+    assert conn.port == 21
 
-    assert "password='pwd'" not in str(ftps)
-    assert "password='pwd'" not in repr(ftps)
+    assert str(conn) == "FTPS[some_host:21]"
+    assert "pwd" not in repr(conn)
 
 
 def test_ftps_connection_anonymous():
     from onetl.connection import FTPS
 
-    ftps = FTPS(host="some_host")
+    conn = FTPS(host="some_host")
 
-    assert isinstance(ftps, FileConnection)
-    assert ftps.host == "some_host"
-    assert ftps.user is None
-    assert ftps.password is None
+    assert isinstance(conn, FileConnection)
+    assert conn.host == "some_host"
+    assert conn.user is None
+    assert conn.password is None
 
 
 def test_ftps_connection_with_port():
     from onetl.connection import FTPS
 
-    ftps = FTPS(host="some_host", user="some_user", password="pwd", port=500)
+    conn = FTPS(host="some_host", user="some_user", password="pwd", port=500)
 
-    assert ftps.port == 500
+    assert conn.port == 500
+    assert str(conn) == "FTPS[some_host:500]"
 
 
 def test_ftps_connection_without_mandatory_args():

--- a/tests/tests_unit/tests_file_connection_unit/test_hdfs_unit.py
+++ b/tests/tests_unit/tests_file_connection_unit/test_hdfs_unit.py
@@ -15,73 +15,74 @@ pytestmark = [pytest.mark.hdfs, pytest.mark.file_connection, pytest.mark.connect
 def test_hdfs_connection_with_host():
     from onetl.connection import HDFS
 
-    hdfs = HDFS(host="some-host.domain.com")
-    assert isinstance(hdfs, FileConnection)
-    assert hdfs.host == "some-host.domain.com"
-    assert hdfs.webhdfs_port == 50070
-    assert not hdfs.user
-    assert not hdfs.password
-    assert not hdfs.keytab
-    assert hdfs.instance_url == "hdfs://some-host.domain.com:50070"
+    conn = HDFS(host="some-host.domain.com")
+    assert isinstance(conn, FileConnection)
+    assert conn.host == "some-host.domain.com"
+    assert conn.webhdfs_port == 50070
+    assert not conn.user
+    assert not conn.password
+    assert not conn.keytab
+    assert conn.instance_url == "hdfs://some-host.domain.com:50070"
+    assert str(conn) == "HDFS[some-host.domain.com:50070]"
 
 
 def test_hdfs_connection_with_cluster():
     from onetl.connection import HDFS
 
-    hdfs = HDFS(cluster="rnd-dwh")
-    assert isinstance(hdfs, FileConnection)
-    assert hdfs.cluster == "rnd-dwh"
-    assert hdfs.webhdfs_port == 50070
-    assert not hdfs.user
-    assert not hdfs.password
-    assert not hdfs.keytab
-    assert hdfs.instance_url == "rnd-dwh"
+    conn = HDFS(cluster="rnd-dwh")
+    assert conn.cluster == "rnd-dwh"
+    assert conn.webhdfs_port == 50070
+    assert not conn.user
+    assert not conn.password
+    assert not conn.keytab
+    assert conn.instance_url == "rnd-dwh"
+    assert str(conn) == "HDFS[rnd-dwh]"
 
 
 def test_hdfs_connection_with_cluster_and_host():
     from onetl.connection import HDFS
 
-    hdfs = HDFS(cluster="rnd-dwh", host="some-host.domain.com")
-    assert isinstance(hdfs, FileConnection)
-    assert hdfs.cluster == "rnd-dwh"
-    assert hdfs.host == "some-host.domain.com"
-    assert hdfs.instance_url == "rnd-dwh"
+    conn = HDFS(cluster="rnd-dwh", host="some-host.domain.com")
+    assert conn.cluster == "rnd-dwh"
+    assert conn.host == "some-host.domain.com"
+    assert conn.instance_url == "rnd-dwh"
+    assert str(conn) == "HDFS[rnd-dwh]"
 
 
-def test_hdfs_connection_with_port():
+def test_hdfs_connection_with_host_and_port():
     from onetl.connection import HDFS
 
-    hdfs = HDFS(host="some-host.domain.com", port=9080)
-    assert isinstance(hdfs, FileConnection)
-    assert hdfs.host == "some-host.domain.com"
-    assert hdfs.webhdfs_port == 9080
-    assert hdfs.instance_url == "hdfs://some-host.domain.com:9080"
+    conn = HDFS(host="some-host.domain.com", port=9080)
+    assert conn.host == "some-host.domain.com"
+    assert conn.webhdfs_port == 9080
+    assert conn.instance_url == "hdfs://some-host.domain.com:9080"
+    assert str(conn) == "HDFS[some-host.domain.com:9080]"
 
 
 def test_hdfs_connection_with_user():
     from onetl.connection import HDFS
 
-    hdfs = HDFS(host="some-host.domain.com", user="some_user")
-    assert hdfs.host == "some-host.domain.com"
-    assert hdfs.webhdfs_port == 50070
-    assert hdfs.user == "some_user"
-    assert not hdfs.password
-    assert not hdfs.keytab
+    conn = HDFS(host="some-host.domain.com", user="some_user")
+    assert conn.host == "some-host.domain.com"
+    assert conn.webhdfs_port == 50070
+    assert conn.user == "some_user"
+    assert not conn.password
+    assert not conn.keytab
 
 
 def test_hdfs_connection_with_password():
     from onetl.connection import HDFS
 
-    hdfs = HDFS(host="some-host.domain.com", user="some_user", password="pwd")
-    assert hdfs.host == "some-host.domain.com"
-    assert hdfs.webhdfs_port == 50070
-    assert hdfs.user == "some_user"
-    assert hdfs.password != "pwd"
-    assert hdfs.password.get_secret_value() == "pwd"
-    assert not hdfs.keytab
+    conn = HDFS(host="some-host.domain.com", user="some_user", password="pwd")
+    assert conn.host == "some-host.domain.com"
+    assert conn.webhdfs_port == 50070
+    assert conn.user == "some_user"
+    assert conn.password != "pwd"
+    assert conn.password.get_secret_value() == "pwd"
+    assert not conn.keytab
+    assert str(conn) == "HDFS[some-host.domain.com:50070]"
 
-    assert "password='pwd'" not in str(hdfs)
-    assert "password='pwd'" not in repr(hdfs)
+    assert "pwd" not in repr(conn)
 
 
 def test_hdfs_connection_with_keytab(request, tmp_path_factory):
@@ -91,15 +92,15 @@ def test_hdfs_connection_with_keytab(request, tmp_path_factory):
     folder.mkdir(exist_ok=True, parents=True)
     keytab = folder / "user.keytab"
     keytab.touch()
-    hdfs = HDFS(host="some-host.domain.com", user="some_user", keytab=keytab)
+    conn = HDFS(host="some-host.domain.com", user="some_user", keytab=keytab)
 
     def finalizer():
         shutil.rmtree(folder)
 
     request.addfinalizer(finalizer)
 
-    assert hdfs.user == "some_user"
-    assert not hdfs.password
+    assert conn.user == "some_user"
+    assert not conn.password
 
 
 def test_hdfs_connection_keytab_does_not_exist():
@@ -242,7 +243,7 @@ def test_hdfs_get_webhdfs_port_hook(request):
     assert HDFS(host="some-node.domain.com", cluster="rnd-dwh").webhdfs_port == 9080
 
 
-def test_hdfs_known_get_current(request, mocker):
+def test_hdfs_known_get_current(request):
     from onetl.connection import HDFS
 
     # no hooks bound to HDFS.Slots.get_current_cluster
@@ -259,5 +260,5 @@ def test_hdfs_known_get_current(request, mocker):
 
     request.addfinalizer(get_current_cluster.disable)
 
-    hdfs = HDFS.get_current()
-    assert hdfs.cluster == "rnd-dwh"
+    conn = HDFS.get_current()
+    assert conn.cluster == "rnd-dwh"

--- a/tests/tests_unit/tests_file_connection_unit/test_s3_unit.py
+++ b/tests/tests_unit/tests_file_connection_unit/test_s3_unit.py
@@ -6,29 +6,29 @@ pytestmark = [pytest.mark.s3, pytest.mark.file_connection, pytest.mark.connectio
 def test_s3_connection():
     from onetl.connection import S3
 
-    s3 = S3(
+    conn = S3(
         host="some_host",
         access_key="access key",
         secret_key="some key",
         bucket="bucket",
     )
 
-    assert s3.host == "some_host"
-    assert s3.access_key == "access key"
-    assert s3.secret_key != "some key"
-    assert s3.secret_key.get_secret_value() == "some key"
-    assert s3.protocol == "https"
-    assert s3.port == 443
-    assert s3.instance_url == "s3://some_host:443"
+    assert conn.host == "some_host"
+    assert conn.access_key == "access key"
+    assert conn.secret_key != "some key"
+    assert conn.secret_key.get_secret_value() == "some key"
+    assert conn.protocol == "https"
+    assert conn.port == 443
+    assert conn.instance_url == "s3://some_host:443/bucket"
+    assert str(conn) == "S3[some_host:443/bucket]"
 
-    assert "some key" not in str(s3)
-    assert "some key" not in repr(s3)
+    assert "some key" not in repr(conn)
 
 
 def test_s3_connection_with_session_token():
     from onetl.connection import S3
 
-    s3 = S3(
+    conn = S3(
         host="some_host",
         access_key="access_key",
         secret_key="some key",
@@ -36,17 +36,16 @@ def test_s3_connection_with_session_token():
         bucket="bucket",
     )
 
-    assert s3.session_token != "some token"
-    assert s3.session_token.get_secret_value() == "some token"
+    assert conn.session_token != "some token"
+    assert conn.session_token.get_secret_value() == "some token"
 
-    assert "some token" not in str(s3)
-    assert "some token" not in repr(s3)
+    assert "some token" not in repr(conn)
 
 
 def test_s3_connection_https():
     from onetl.connection import S3
 
-    s3 = S3(
+    conn = S3(
         host="some_host",
         access_key="access_key",
         secret_key="secret_key",
@@ -54,15 +53,16 @@ def test_s3_connection_https():
         protocol="https",
     )
 
-    assert s3.protocol == "https"
-    assert s3.port == 443
-    assert s3.instance_url == "s3://some_host:443"
+    assert conn.protocol == "https"
+    assert conn.port == 443
+    assert conn.instance_url == "s3://some_host:443/bucket"
+    assert str(conn) == "S3[some_host:443/bucket]"
 
 
 def test_s3_connection_http():
     from onetl.connection import S3
 
-    s3 = S3(
+    conn = S3(
         host="some_host",
         access_key="access_key",
         secret_key="secret_key",
@@ -70,16 +70,17 @@ def test_s3_connection_http():
         protocol="http",
     )
 
-    assert s3.protocol == "http"
-    assert s3.port == 80
-    assert s3.instance_url == "s3://some_host:80"
+    assert conn.protocol == "http"
+    assert conn.port == 80
+    assert conn.instance_url == "s3://some_host:80/bucket"
+    assert str(conn) == "S3[some_host:80/bucket]"
 
 
 @pytest.mark.parametrize("protocol", ["http", "https"])
 def test_s3_connection_with_port(protocol):
     from onetl.connection import S3
 
-    s3 = S3(
+    conn = S3(
         host="some_host",
         port=9000,
         access_key="access_key",
@@ -88,6 +89,7 @@ def test_s3_connection_with_port(protocol):
         protocol=protocol,
     )
 
-    assert s3.protocol == protocol
-    assert s3.port == 9000
-    assert s3.instance_url == "s3://some_host:9000"
+    assert conn.protocol == protocol
+    assert conn.port == 9000
+    assert conn.instance_url == "s3://some_host:9000/bucket"
+    assert str(conn) == "S3[some_host:9000/bucket]"

--- a/tests/tests_unit/tests_file_connection_unit/test_samba_unit.py
+++ b/tests/tests_unit/tests_file_connection_unit/test_samba_unit.py
@@ -8,36 +8,39 @@ pytestmark = [pytest.mark.samba, pytest.mark.file_connection, pytest.mark.connec
 def test_samba_connection():
     from onetl.connection import Samba
 
-    samba = Samba(host="some_host", share="share_name", user="some_user", password="pwd")
-    assert isinstance(samba, FileConnection)
-    assert samba.host == "some_host"
-    assert samba.protocol == "SMB"
-    assert samba.domain == ""
-    assert samba.auth_type == "NTLMv2"
-    assert samba.port == 445
-    assert samba.user == "some_user"
-    assert samba.password != "pwd"
-    assert samba.password.get_secret_value() == "pwd"
+    conn = Samba(host="some_host", share="share_name", user="some_user", password="pwd")
+    assert isinstance(conn, FileConnection)
+    assert conn.host == "some_host"
+    assert conn.port == 445
+    assert conn.share == "share_name"
+    assert conn.protocol == "SMB"
+    assert conn.domain == ""
+    assert conn.auth_type == "NTLMv2"
+    assert conn.user == "some_user"
+    assert conn.password != "pwd"
+    assert conn.password.get_secret_value() == "pwd"
 
-    assert "password='pwd'" not in str(samba)
-    assert "password='pwd'" not in repr(samba)
+    assert conn.instance_url == "smb://some_host:445/share_name"
+    assert str(conn) == "Samba[some_host:445/share_name]"
+
+    assert "pwd" not in repr(conn)
 
 
 def test_samba_connection_with_net_bios():
     from onetl.connection import Samba
 
-    samba = Samba(host="some_host", share="share_name", user="some_user", password="pwd", protocol="NetBIOS")
-    assert samba.protocol == "NetBIOS"
-    assert samba.port == 139
+    conn = Samba(host="some_host", share="share_name", user="some_user", password="pwd", protocol="NetBIOS")
+    assert conn.protocol == "NetBIOS"
+    assert conn.port == 139
 
 
 @pytest.mark.parametrize("protocol", ["SMB", "NetBIOS"])
 def test_samba_connection_with_custom_port(protocol):
     from onetl.connection import Samba
 
-    samba = Samba(host="some_host", share="share_name", user="some_user", password="pwd", protocol=protocol, port=444)
-    assert samba.protocol == protocol
-    assert samba.port == 444
+    conn = Samba(host="some_host", share="share_name", user="some_user", password="pwd", protocol=protocol, port=444)
+    assert conn.protocol == protocol
+    assert conn.port == 444
 
 
 def test_samba_connection_without_mandatory_args():

--- a/tests/tests_unit/tests_file_connection_unit/test_sftp_unit.py
+++ b/tests/tests_unit/tests_file_connection_unit/test_sftp_unit.py
@@ -7,35 +7,41 @@ pytestmark = [pytest.mark.sftp, pytest.mark.file_connection, pytest.mark.connect
 
 
 def test_sftp_connection_anonymous():
-    from onetl.connection import SFTP
+    from onetl.connection import SFTP, FileConnection
 
-    sftp = SFTP(host="some_host")
-    assert sftp.host == "some_host"
-    assert sftp.port == 22
-    assert not sftp.user
-    assert not sftp.password
-    assert not sftp.key_file
+    conn = SFTP(host="some_host")
+    assert isinstance(conn, FileConnection)
+    assert conn.host == "some_host"
+    assert conn.port == 22
+    assert not conn.user
+    assert not conn.password
+    assert not conn.key_file
+    assert conn.instance_url == "sftp://some_host:22"
+    assert str(conn) == "SFTP[some_host:22]"
 
 
 def test_sftp_connection_with_port():
     from onetl.connection import SFTP
 
-    sftp = SFTP(host="some_host", port=500)
+    conn = SFTP(host="some_host", port=500)
 
-    assert sftp.port == 500
+    assert conn.port == 500
+    assert conn.instance_url == "sftp://some_host:500"
+    assert str(conn) == "SFTP[some_host:500]"
 
 
 def test_sftp_connection_with_password():
     from onetl.connection import SFTP
 
-    sftp = SFTP(host="some_host", user="some_user", password="pwd")
-    assert sftp.user == "some_user"
-    assert sftp.password != "pwd"
-    assert sftp.password.get_secret_value() == "pwd"
-    assert not sftp.key_file
+    conn = SFTP(host="some_host", user="some_user", password="pwd")
+    assert conn.user == "some_user"
+    assert conn.password != "pwd"
+    assert conn.password.get_secret_value() == "pwd"
+    assert not conn.key_file
+    assert conn.instance_url == "sftp://some_host:22"
+    assert str(conn) == "SFTP[some_host:22]"
 
-    assert "password='pwd'" not in str(sftp)
-    assert "password='pwd'" not in repr(sftp)
+    assert "pwd" not in repr(conn)
 
 
 def test_sftp_connection_with_key_file(request, tmp_path_factory):
@@ -51,10 +57,10 @@ def test_sftp_connection_with_key_file(request, tmp_path_factory):
 
     request.addfinalizer(finalizer)
 
-    sftp = SFTP(host="some_host", user="some_user", key_file=key_file)
-    assert sftp.user == "some_user"
-    assert not sftp.password
-    assert sftp.key_file == key_file
+    conn = SFTP(host="some_host", user="some_user", key_file=key_file)
+    assert conn.user == "some_user"
+    assert not conn.password
+    assert conn.key_file == key_file
 
 
 def test_sftp_connection_key_file_does_not_exist():

--- a/tests/tests_unit/tests_file_connection_unit/test_webdav_unit.py
+++ b/tests/tests_unit/tests_file_connection_unit/test_webdav_unit.py
@@ -8,34 +8,39 @@ pytestmark = [pytest.mark.webdav, pytest.mark.file_connection, pytest.mark.conne
 def test_webdav_connection():
     from onetl.connection import WebDAV
 
-    webdav = WebDAV(host="some_host", user="some_user", password="pwd")
-    assert isinstance(webdav, FileConnection)
-    assert webdav.host == "some_host"
-    assert webdav.protocol == "https"
-    assert webdav.port == 443
-    assert webdav.user == "some_user"
-    assert webdav.password != "pwd"
-    assert webdav.password.get_secret_value() == "pwd"
+    conn = WebDAV(host="some_host", user="some_user", password="pwd")
+    assert isinstance(conn, FileConnection)
+    assert conn.host == "some_host"
+    assert conn.protocol == "https"
+    assert conn.port == 443
+    assert conn.user == "some_user"
+    assert conn.password != "pwd"
+    assert conn.password.get_secret_value() == "pwd"
+    assert conn.instance_url == "webdav://some_host:443"
+    assert str(conn) == "WebDAV[some_host:443]"
 
-    assert "password='pwd'" not in str(webdav)
-    assert "password='pwd'" not in repr(webdav)
+    assert "pwd" not in repr(conn)
 
 
 def test_webdav_connection_with_http():
     from onetl.connection import WebDAV
 
-    webdav = WebDAV(host="some_host", user="some_user", password="pwd", protocol="http")
-    assert webdav.protocol == "http"
-    assert webdav.port == 80
+    conn = WebDAV(host="some_host", user="some_user", password="pwd", protocol="http")
+    assert conn.protocol == "http"
+    assert conn.port == 80
+    assert conn.instance_url == "webdav://some_host:80"
+    assert str(conn) == "WebDAV[some_host:80]"
 
 
 @pytest.mark.parametrize("protocol", ["http", "https"])
 def test_webdav_connection_with_custom_port(protocol):
     from onetl.connection import WebDAV
 
-    webdav = WebDAV(host="some_host", user="some_user", password="pwd", port=500, protocol=protocol)
-    assert webdav.protocol == protocol
-    assert webdav.port == 500
+    conn = WebDAV(host="some_host", user="some_user", password="pwd", port=500, protocol=protocol)
+    assert conn.protocol == protocol
+    assert conn.port == 500
+    assert conn.instance_url == "webdav://some_host:500"
+    assert str(conn) == "WebDAV[some_host:500]"
 
 
 def test_webdav_connection_without_mandatory_args():

--- a/tests/tests_unit/tests_file_df_connection_unit/test_spark_hdfs_unit.py
+++ b/tests/tests_unit/tests_file_df_connection_unit/test_spark_hdfs_unit.py
@@ -12,28 +12,31 @@ pytestmark = [pytest.mark.hdfs, pytest.mark.file_df_connection, pytest.mark.conn
 
 
 def test_spark_hdfs_with_cluster(spark_mock):
-    hdfs = SparkHDFS(cluster="rnd-dwh", spark=spark_mock)
-    assert isinstance(hdfs, BaseFileDFConnection)
-    assert hdfs.cluster == "rnd-dwh"
-    assert hdfs.host is None
-    assert hdfs.ipc_port == 8020
-    assert hdfs.instance_url == "rnd-dwh"
+    conn = SparkHDFS(cluster="rnd-dwh", spark=spark_mock)
+    assert isinstance(conn, BaseFileDFConnection)
+    assert conn.cluster == "rnd-dwh"
+    assert conn.host is None
+    assert conn.ipc_port == 8020
+    assert conn.instance_url == "rnd-dwh"
+    assert str(conn) == "HDFS[rnd-dwh]"
 
 
 def test_spark_hdfs_with_cluster_and_host(spark_mock):
-    hdfs = SparkHDFS(cluster="rnd-dwh", host="some-host.domain.com", spark=spark_mock)
-    assert isinstance(hdfs, BaseFileDFConnection)
-    assert hdfs.cluster == "rnd-dwh"
-    assert hdfs.host == "some-host.domain.com"
-    assert hdfs.instance_url == "rnd-dwh"
+    conn = SparkHDFS(cluster="rnd-dwh", host="some-host.domain.com", spark=spark_mock)
+    assert isinstance(conn, BaseFileDFConnection)
+    assert conn.cluster == "rnd-dwh"
+    assert conn.host == "some-host.domain.com"
+    assert conn.instance_url == "rnd-dwh"
+    assert str(conn) == "HDFS[rnd-dwh]"
 
 
 def test_spark_hdfs_with_port(spark_mock):
-    hdfs = SparkHDFS(cluster="rnd-dwh", port=9020, spark=spark_mock)
-    assert isinstance(hdfs, BaseFileDFConnection)
-    assert hdfs.cluster == "rnd-dwh"
-    assert hdfs.ipc_port == 9020
-    assert hdfs.instance_url == "rnd-dwh"
+    conn = SparkHDFS(cluster="rnd-dwh", port=9020, spark=spark_mock)
+    assert isinstance(conn, BaseFileDFConnection)
+    assert conn.cluster == "rnd-dwh"
+    assert conn.ipc_port == 9020
+    assert conn.instance_url == "rnd-dwh"
+    assert str(conn) == "HDFS[rnd-dwh]"
 
 
 def test_spark_hdfs_without_cluster(spark_mock):
@@ -143,5 +146,5 @@ def test_spark_hdfs_known_get_current(request, spark_mock):
 
     request.addfinalizer(get_current_cluster.disable)
 
-    hdfs = SparkHDFS.get_current(spark=spark_mock)
-    assert hdfs.cluster == "rnd-dwh"
+    conn = SparkHDFS.get_current(spark=spark_mock)
+    assert conn.cluster == "rnd-dwh"

--- a/tests/tests_unit/tests_file_df_connection_unit/test_spark_local_fs_unit.py
+++ b/tests/tests_unit/tests_file_df_connection_unit/test_spark_local_fs_unit.py
@@ -13,6 +13,7 @@ def test_spark_local_fs_spark_local(spark_mock):
     conn = SparkLocalFS(spark=spark_mock)
     assert conn.spark == spark_mock
     assert conn.instance_url == f"file://{socket.getfqdn()}"
+    assert str(conn) == "LocalFS"
 
 
 @pytest.mark.parametrize("master", ["k8s", "yarn"])

--- a/tests/tests_unit/tests_file_df_connection_unit/test_spark_s3_unit.py
+++ b/tests/tests_unit/tests_file_df_connection_unit/test_spark_s3_unit.py
@@ -84,7 +84,7 @@ def spark_mock_hadoop_3(spark_mock):
 
 
 def test_spark_s3(spark_mock_hadoop_3):
-    s3 = SparkS3(
+    conn = SparkS3(
         host="some_host",
         access_key="access key",
         secret_key="some key",
@@ -92,20 +92,20 @@ def test_spark_s3(spark_mock_hadoop_3):
         spark=spark_mock_hadoop_3,
     )
 
-    assert s3.host == "some_host"
-    assert s3.access_key == "access key"
-    assert s3.secret_key != "some key"
-    assert s3.secret_key.get_secret_value() == "some key"
-    assert s3.protocol == "https"
-    assert s3.port == 443
-    assert s3.instance_url == "s3://some_host:443"
+    assert conn.host == "some_host"
+    assert conn.access_key == "access key"
+    assert conn.secret_key != "some key"
+    assert conn.secret_key.get_secret_value() == "some key"
+    assert conn.protocol == "https"
+    assert conn.port == 443
+    assert conn.instance_url == "s3://some_host:443/bucket"
+    assert str(conn) == "S3[some_host:443/bucket]"
 
-    assert "some key" not in str(s3)
-    assert "some key" not in repr(s3)
+    assert "some key" not in repr(conn)
 
 
 def test_spark_s3_with_protocol_https(spark_mock_hadoop_3):
-    s3 = SparkS3(
+    conn = SparkS3(
         host="some_host",
         access_key="access_key",
         secret_key="secret_key",
@@ -114,13 +114,14 @@ def test_spark_s3_with_protocol_https(spark_mock_hadoop_3):
         spark=spark_mock_hadoop_3,
     )
 
-    assert s3.protocol == "https"
-    assert s3.port == 443
-    assert s3.instance_url == "s3://some_host:443"
+    assert conn.protocol == "https"
+    assert conn.port == 443
+    assert conn.instance_url == "s3://some_host:443/bucket"
+    assert str(conn) == "S3[some_host:443/bucket]"
 
 
 def test_spark_s3_with_protocol_http(spark_mock_hadoop_3):
-    s3 = SparkS3(
+    conn = SparkS3(
         host="some_host",
         access_key="access_key",
         secret_key="secret_key",
@@ -129,14 +130,15 @@ def test_spark_s3_with_protocol_http(spark_mock_hadoop_3):
         spark=spark_mock_hadoop_3,
     )
 
-    assert s3.protocol == "http"
-    assert s3.port == 80
-    assert s3.instance_url == "s3://some_host:80"
+    assert conn.protocol == "http"
+    assert conn.port == 80
+    assert conn.instance_url == "s3://some_host:80/bucket"
+    assert str(conn) == "S3[some_host:80/bucket]"
 
 
 @pytest.mark.parametrize("protocol", ["http", "https"])
 def test_spark_s3_with_port(spark_mock_hadoop_3, protocol):
-    s3 = SparkS3(
+    conn = SparkS3(
         host="some_host",
         port=9000,
         access_key="access_key",
@@ -146,9 +148,10 @@ def test_spark_s3_with_port(spark_mock_hadoop_3, protocol):
         spark=spark_mock_hadoop_3,
     )
 
-    assert s3.protocol == protocol
-    assert s3.port == 9000
-    assert s3.instance_url == "s3://some_host:9000"
+    assert conn.protocol == protocol
+    assert conn.port == 9000
+    assert conn.instance_url == "s3://some_host:9000/bucket"
+    assert str(conn) == "S3[some_host:9000/bucket]"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

<!-- Please give a short summary of the changes. -->

Set jobDescription in any method which interact with Spark in some way. Examples:
![Снимок экрана_20240808_192304](https://github.com/user-attachments/assets/6998d01b-49d8-415c-82e2-5c0afb1ce740)
![Снимок экрана_20240808_192326](https://github.com/user-attachments/assets/05a9b510-9acc-4620-945d-0f07ea37c1aa)

This does not work if Spark action was triggered outside of onETL methods, e.g. user called `df.count()` or `df.toPandas()`:
![Снимок экрана_20240808_192425](https://github.com/user-attachments/assets/232f9fd1-5a14-4e12-b0c2-f4f19cba9fea)

It's hard to write tests on this because jobDescription is reset just before method returned some result.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
