### PR TITLE
[DOP-19024] Fix passing custom JDBC options to Greenplum.extra

### DIFF
--- a/docs/changelog/next_release/308.bugfix.rst
+++ b/docs/changelog/next_release/308.bugfix.rst
@@ -1,0 +1,1 @@
+Fix passing ``Greenplum(extra={"options": ...)`` during read/write operations.

--- a/tests/tests_unit/tests_db_connection_unit/test_greenplum_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_greenplum_unit.py
@@ -128,6 +128,14 @@ def test_greenplum(spark_mock):
         "ApplicationName": "abc",
         "tcpKeepAlive": "true",
     }
+    assert conn._get_connector_params("some.table") == {
+        "user": "user",
+        "password": "passwd",
+        "driver": "org.postgresql.Driver",
+        "url": "jdbc:postgresql://some_host:5432/database?ApplicationName=abc&tcpKeepAlive=true",
+        "dbschema": "some",
+        "dbtable": "table",
+    }
 
     assert "passwd" not in repr(conn)
 
@@ -154,6 +162,14 @@ def test_greenplum_with_port(spark_mock):
         "ApplicationName": "abc",
         "tcpKeepAlive": "true",
     }
+    assert conn._get_connector_params("some.table") == {
+        "user": "user",
+        "password": "passwd",
+        "driver": "org.postgresql.Driver",
+        "url": "jdbc:postgresql://some_host:5000/database?ApplicationName=abc&tcpKeepAlive=true",
+        "dbschema": "some",
+        "dbtable": "table",
+    }
 
     assert conn.instance_url == "greenplum://some_host:5000/database"
     assert str(conn) == "Greenplum[some_host:5000/database]"
@@ -174,6 +190,7 @@ def test_greenplum_with_extra(spark_mock):
             "autosave": "always",
             "tcpKeepAlive": "false",
             "ApplicationName": "override",
+            "options": "-c search_path=public",
             "server.port": 8000,
             "pool.maxSize": 40,
         },
@@ -191,6 +208,17 @@ def test_greenplum_with_extra(spark_mock):
         "ApplicationName": "override",
         "tcpKeepAlive": "false",
         "autosave": "always",
+        "options": "-c search_path=public",
+    }
+    assert conn._get_connector_params("some.table") == {
+        "user": "user",
+        "password": "passwd",
+        "driver": "org.postgresql.Driver",
+        "url": "jdbc:postgresql://some_host:5432/database?ApplicationName=override&autosave=always&options=-c%20search_path%3Dpublic&tcpKeepAlive=false",
+        "dbschema": "some",
+        "dbtable": "table",
+        "pool.maxSize": 40,
+        "server.port": 8000,
     }
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

<!-- Please give a short summary of the changes. -->

Add options passed to `Greenplum(extra={"some": "value"})` to JDBC URL query part.
Add unit tests.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
