### PR TITLE
[DOP-21408] Fix logging KeyValueIntHWM using log_hwm

### DIFF
--- a/docs/changelog/next_release/316.bugfix.1.rst
+++ b/docs/changelog/next_release/316.bugfix.1.rst
@@ -1,0 +1,1 @@
+Fix ``log_hwm`` result for ``KeyValueIntHWM`` (used by Kafka).

--- a/docs/changelog/next_release/316.bugfix.2.rst
+++ b/docs/changelog/next_release/316.bugfix.2.rst
@@ -1,0 +1,1 @@
+Fix ``log_collection`` hiding values of ``Kafka.addresses`` in logs with ``INFO`` level.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Currently KeyValueIntHWM in printed to logs like this:
```|IncrementalStrategy| Fetched HWM:
    hwm = KeyValueIntHWM(
        name = 'test_offset1',
        entity = 'test_topic',
        expression = 'offset',
        value = [
            0,
        ]
    )
```

But it should be:
```|IncrementalStrategy| Fetched HWM:
    hwm = KeyValueIntHWM(
        name = 'test_offset1',
        entity = 'test_topic',
        expression = 'offset',
        value = {
            0: 123,
        }
    )
```

I've added handling of dict and set to `log_collection` function.

Also fixed bug then logging with INFO level lead hiding up Kafka addresses:
```
|Kafka| Checking connection availability...
|Kafka| Using connection parameters:
        cluster = 'cluster'
        addresses = [
            # change level to 'DEBUG' to print all values,
        ]
        protocol = KafkaPlaintextProtocol()
        auth = None
        extra = {}
```

Now it is:
```
|Kafka| Checking connection availability...
|Kafka| Using connection parameters:
        cluster = 'cluster'
        addresses = [
            'localhost:9093',
        ]
        protocol = KafkaPlaintextProtocol()
        auth = None
        extra = {}
```

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
