### PR TITLE
[DOP-21634] Make DBReader and DBWriter table name requirements less strict

### DIFF
--- a/.github/workflows/test-mssql.yml
+++ b/.github/workflows/test-mssql.yml
@@ -45,6 +45,13 @@ jobs:
         with:
           python-version: ${{ inputs.python-version }}
 
+      # https://github.com/pymssql/pymssql/issues/372#issuecomment-742386160
+      - name: Add missing sqlfont.h file
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends freetds-dev libkrb5-dev gcc
+
       - name: Cache Ivy
         uses: actions/cache@v4
         if: inputs.with-cache

--- a/docs/changelog/0.12.3.rst
+++ b/docs/changelog/0.12.3.rst
@@ -1,0 +1,7 @@
+0.12.3 (2024-11-21)
+===================
+
+Bug Fixes
+---------
+
+- Allow passing table names in format ``schema."table.with.dots"`` to ``DBReader(name=...)`` and ``DBWriter(name=...)``.

--- a/docs/changelog/index.rst
+++ b/docs/changelog/index.rst
@@ -3,6 +3,7 @@
     :caption: Changelog
 
     DRAFT
+    0.12.3
     0.12.2
     0.12.1
     0.12.0

--- a/onetl/connection/db_connection/dialect_mixins/support_name_with_schema_only.py
+++ b/onetl/connection/db_connection/dialect_mixins/support_name_with_schema_only.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 class SupportNameWithSchemaOnly:
     def validate_name(self, value: str) -> str:
-        if value.count(".") != 1:
+        if "." not in value:
             raise ValueError(
                 f"Name should be passed in `schema.name` format, got '{value}'",
             )

--- a/tests/tests_unit/test_db/test_db_reader_unit/test_clickhouse_reader_unit.py
+++ b/tests/tests_unit/test_db/test_db_reader_unit/test_clickhouse_reader_unit.py
@@ -35,14 +35,13 @@ def test_clickhouse_reader_snapshot_error_pass_df_schema(spark_mock):
         )
 
 
-@pytest.mark.parametrize("table", ["table", "table.table.table"])
-def test_clickhouse_reader_wrong_table_name(spark_mock, table):
+def test_clickhouse_reader_wrong_table_name(spark_mock):
     clickhouse = Clickhouse(host="some_host", user="user", database="database", password="passwd", spark=spark_mock)
 
     with pytest.raises(ValueError, match="Name should be passed in `schema.name` format"):
         DBReader(
             connection=clickhouse,
-            table=table,  # Required format: table="schema.table"
+            table="table",  # Required format: table="schema.table"
         )
 
 

--- a/tests/tests_unit/test_db/test_db_reader_unit/test_greenplum_reader_unit.py
+++ b/tests/tests_unit/test_db/test_db_reader_unit/test_greenplum_reader_unit.py
@@ -36,14 +36,13 @@ def test_greenplum_reader_snapshot_error_pass_df_schema(spark_mock):
         )
 
 
-@pytest.mark.parametrize("table", ["table", "table.table.table"])
-def test_greenplum_reader_wrong_table_name(spark_mock, table):
+def test_greenplum_reader_wrong_table_name(spark_mock):
     greenplum = Greenplum(host="some_host", user="user", database="database", password="passwd", spark=spark_mock)
 
     with pytest.raises(ValueError, match="Name should be passed in `schema.name` format"):
         DBReader(
             connection=greenplum,
-            table=table,  # Required format: table="schema.table"
+            table="table",  # Required format: table="schema.table"
         )
 
 

--- a/tests/tests_unit/test_db/test_db_reader_unit/test_hive_reader_unit.py
+++ b/tests/tests_unit/test_db/test_db_reader_unit/test_hive_reader_unit.py
@@ -36,14 +36,13 @@ def test_hive_reader_snapshot_error_pass_df_schema(spark_mock):
         )
 
 
-@pytest.mark.parametrize("table", ["table", "table.table.table"])
-def test_hive_reader_wrong_table_name(spark_mock, table):
+def test_hive_reader_wrong_table_name(spark_mock):
     hive = Hive(cluster="rnd-dwh", spark=spark_mock)
 
     with pytest.raises(ValueError):
         DBReader(
             connection=hive,
-            table=table,  # Required format: table="schema.table"
+            table="table",  # Required format: table="schema.table"
         )
 
 

--- a/tests/tests_unit/test_db/test_db_reader_unit/test_mssql_reader_unit.py
+++ b/tests/tests_unit/test_db/test_db_reader_unit/test_mssql_reader_unit.py
@@ -36,14 +36,13 @@ def test_mssql_reader_snapshot_error_pass_df_schema(spark_mock):
         )
 
 
-@pytest.mark.parametrize("table", ["table", "table.table.table"])
-def test_mssql_reader_wrong_table_name(spark_mock, table):
+def test_mssql_reader_wrong_table_name(spark_mock):
     mssql = MSSQL(host="some_host", user="user", database="database", password="passwd", spark=spark_mock)
 
     with pytest.raises(ValueError, match="Name should be passed in `schema.name` format"):
         DBReader(
             connection=mssql,
-            table=table,  # Required format: table="schema.table"
+            table="table",  # Required format: table="schema.table"
         )
 
 

--- a/tests/tests_unit/test_db/test_db_reader_unit/test_mysql_reader_unit.py
+++ b/tests/tests_unit/test_db/test_db_reader_unit/test_mysql_reader_unit.py
@@ -36,14 +36,13 @@ def test_mysql_reader_snapshot_error_pass_df_schema(spark_mock):
         )
 
 
-@pytest.mark.parametrize("table", ["table", "table.table.table"])
-def test_mysql_reader_wrong_table_name(spark_mock, table):
+def test_mysql_reader_wrong_table_name(spark_mock):
     mysql = MySQL(host="some_host", user="user", database="database", password="passwd", spark=spark_mock)
 
     with pytest.raises(ValueError, match="Name should be passed in `schema.name` format"):
         DBReader(
             connection=mysql,
-            table=table,  # Required format: table="schema.table"
+            table="table",  # Required format: table="schema.table"
         )
 
 

--- a/tests/tests_unit/test_db/test_db_reader_unit/test_oracle_reader_unit.py
+++ b/tests/tests_unit/test_db/test_db_reader_unit/test_oracle_reader_unit.py
@@ -36,13 +36,12 @@ def test_oracle_reader_error_df_schema(spark_mock):
         )
 
 
-@pytest.mark.parametrize("table", ["table", "table.table.table"])
-def test_oracle_reader_wrong_table_name(spark_mock, table):
+def test_oracle_reader_wrong_table_name(spark_mock):
     oracle = Oracle(host="some_host", user="user", sid="sid", password="passwd", spark=spark_mock)
     with pytest.raises(ValueError, match="Name should be passed in `schema.name` format"):
         DBReader(
             connection=oracle,
-            table=table,  # Required format: table="schema.table"
+            table="table",  # Required format: table="schema.table"
         )
 
 

--- a/tests/tests_unit/test_db/test_db_reader_unit/test_postgres_reader_unit.py
+++ b/tests/tests_unit/test_db/test_db_reader_unit/test_postgres_reader_unit.py
@@ -36,14 +36,13 @@ def test_postgres_reader_snapshot_error_pass_df_schema(spark_mock):
         )
 
 
-@pytest.mark.parametrize("table", ["table", "table.table.table"])
-def test_postgres_reader_wrong_table_name(spark_mock, table):
+def test_postgres_reader_wrong_table_name(spark_mock):
     postgres = Postgres(host="some_host", user="user", database="database", password="passwd", spark=spark_mock)
 
     with pytest.raises(ValueError, match="Name should be passed in `schema.name` format"):
         DBReader(
             connection=postgres,
-            table=table,  # Required format: table="schema.table"
+            table="table",  # Required format: table="schema.table"
         )
 
 

--- a/tests/tests_unit/test_db/test_db_reader_unit/test_teradata_reader_unit.py
+++ b/tests/tests_unit/test_db/test_db_reader_unit/test_teradata_reader_unit.py
@@ -36,14 +36,13 @@ def test_teradata_reader_snapshot_error_pass_df_schema(spark_mock):
         )
 
 
-@pytest.mark.parametrize("table", ["table", "table.table.table"])
-def test_teradata_reader_wrong_table_name(spark_mock, table):
+def test_teradata_reader_wrong_table_name(spark_mock):
     teradata = Teradata(host="some_host", user="user", database="database", password="passwd", spark=spark_mock)
 
     with pytest.raises(ValueError, match="Name should be passed in `schema.name` format"):
         DBReader(
             connection=teradata,
-            table=table,  # Required format: table="schema.table"
+            table="table",  # Required format: table="schema.table"
         )
 
 

--- a/tests/tests_unit/test_db/test_db_writer_unit/test_clickhouse_writer_unit.py
+++ b/tests/tests_unit/test_db/test_db_writer_unit/test_clickhouse_writer_unit.py
@@ -6,12 +6,11 @@ from onetl.db import DBWriter
 pytestmark = pytest.mark.clickhouse
 
 
-@pytest.mark.parametrize("table", ["table", "table.table.table"])
-def test_clickhouse_writer_wrong_table_name(spark_mock, table):
+def test_clickhouse_writer_wrong_table_name(spark_mock):
     clickhouse = Clickhouse(host="some_host", user="user", database="database", password="passwd", spark=spark_mock)
 
     with pytest.raises(ValueError, match="Name should be passed in `schema.name` format"):
         DBWriter(
             connection=clickhouse,
-            table=table,  # Required format: table="schema.table"
+            table="table",  # Required format: table="schema.table"
         )

--- a/tests/tests_unit/test_db/test_db_writer_unit/test_greenplum_writer_unit.py
+++ b/tests/tests_unit/test_db/test_db_writer_unit/test_greenplum_writer_unit.py
@@ -6,12 +6,11 @@ from onetl.db import DBWriter
 pytestmark = pytest.mark.greenplum
 
 
-@pytest.mark.parametrize("table", ["table", "table.table.table"])
-def test_greenplum_writer_wrong_table_name(spark_mock, table):
+def test_greenplum_writer_wrong_table_name(spark_mock):
     greenplum = Greenplum(host="some_host", user="user", database="database", password="passwd", spark=spark_mock)
 
     with pytest.raises(ValueError, match="Name should be passed in `schema.name` format"):
         DBWriter(
             connection=greenplum,
-            table=table,  # Required format: table="schema.table"
+            table="table",  # Required format: table="schema.table"
         )

--- a/tests/tests_unit/test_db/test_db_writer_unit/test_hive_writer_unit.py
+++ b/tests/tests_unit/test_db/test_db_writer_unit/test_hive_writer_unit.py
@@ -6,12 +6,11 @@ from onetl.db import DBWriter
 pytestmark = pytest.mark.hive
 
 
-@pytest.mark.parametrize("table", ["table", "table.table.table"])
-def test_hive_writer_wrong_table_name(spark_mock, table):
+def test_hive_writer_wrong_table_name(spark_mock):
     hive = Hive(cluster="rnd-dwh", spark=spark_mock)
 
     with pytest.raises(ValueError, match="Name should be passed in `schema.name` format"):
         DBWriter(
             connection=hive,
-            table=table,  # Required format: table="schema.table"
+            table="table",  # Required format: table="schema.table"
         )

--- a/tests/tests_unit/test_db/test_db_writer_unit/test_mssql_writer_unit.py
+++ b/tests/tests_unit/test_db/test_db_writer_unit/test_mssql_writer_unit.py
@@ -6,12 +6,11 @@ from onetl.db import DBWriter
 pytestmark = pytest.mark.mssql
 
 
-@pytest.mark.parametrize("table", ["table", "table.table.table"])
-def test_mssql_writer_wrong_table_name(spark_mock, table):
+def test_mssql_writer_wrong_table_name(spark_mock):
     mssql = MSSQL(host="some_host", user="user", database="database", password="passwd", spark=spark_mock)
 
     with pytest.raises(ValueError, match="Name should be passed in `schema.name` format"):
         DBWriter(
             connection=mssql,
-            table=table,  # Required format: table="schema.table"
+            table="table",  # Required format: table="schema.table"
         )

--- a/tests/tests_unit/test_db/test_db_writer_unit/test_mysql_writer_unit.py
+++ b/tests/tests_unit/test_db/test_db_writer_unit/test_mysql_writer_unit.py
@@ -6,12 +6,11 @@ from onetl.db import DBWriter
 pytestmark = pytest.mark.mysql
 
 
-@pytest.mark.parametrize("table", ["table", "table.table.table"])
-def test_mysql_writer_wrong_table_name(spark_mock, table):
+def test_mysql_writer_wrong_table_name(spark_mock):
     mysql = MySQL(host="some_host", user="user", database="database", password="passwd", spark=spark_mock)
 
     with pytest.raises(ValueError, match="Name should be passed in `schema.name` format"):
         DBWriter(
             connection=mysql,
-            table=table,  # Required format: table="schema.table"
+            table="table",  # Required format: table="schema.table"
         )

--- a/tests/tests_unit/test_db/test_db_writer_unit/test_oracle_writer_unit.py
+++ b/tests/tests_unit/test_db/test_db_writer_unit/test_oracle_writer_unit.py
@@ -6,12 +6,11 @@ from onetl.db import DBWriter
 pytestmark = pytest.mark.oracle
 
 
-@pytest.mark.parametrize("table", ["table", "table.table.table"])
-def test_oracle_writer_wrong_table_name(spark_mock, table):
+def test_oracle_writer_wrong_table_name(spark_mock):
     oracle = Oracle(host="some_host", user="user", sid="sid", password="passwd", spark=spark_mock)
 
     with pytest.raises(ValueError, match="Name should be passed in `schema.name` format"):
         DBWriter(
             connection=oracle,
-            table=table,  # Required format: table="schema.table"
+            table="table",  # Required format: table="schema.table"
         )

--- a/tests/tests_unit/test_db/test_db_writer_unit/test_postgres_writer_unit.py
+++ b/tests/tests_unit/test_db/test_db_writer_unit/test_postgres_writer_unit.py
@@ -6,12 +6,11 @@ from onetl.db import DBWriter
 pytestmark = pytest.mark.postgres
 
 
-@pytest.mark.parametrize("table", ["table", "table.table.table"])
-def test_postgres_writer_wrong_table_name(spark_mock, table):
+def test_postgres_writer_wrong_table_name(spark_mock):
     postgres = Postgres(host="some_host", user="user", database="database", password="passwd", spark=spark_mock)
 
     with pytest.raises(ValueError, match="Name should be passed in `schema.name` format"):
         DBWriter(
             connection=postgres,
-            table=table,  # Required format: table="schema.table"
+            table="table",  # Required format: table="schema.table"
         )

--- a/tests/tests_unit/test_db/test_db_writer_unit/test_teradata_writer_unit.py
+++ b/tests/tests_unit/test_db/test_db_writer_unit/test_teradata_writer_unit.py
@@ -6,12 +6,11 @@ from onetl.db import DBWriter
 pytestmark = pytest.mark.teradata
 
 
-@pytest.mark.parametrize("table", ["table", "table.table.table"])
-def test_teradata_writer_wrong_table_name(spark_mock, table):
+def test_teradata_writer_wrong_table_name(spark_mock):
     teradata = Teradata(host="some_host", user="user", database="database", password="passwd", spark=spark_mock)
 
     with pytest.raises(ValueError, match="Name should be passed in `schema.name` format"):
         DBWriter(
             connection=teradata,
-            table=table,  # Required format: table="schema.table"
+            table="table",  # Required format: table="schema.table"
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

`DBReader(name=...)` and `DBWriter(name=...)` validators are too strict, and don't allow passing table names with multiple dots. Fixed.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
