### PR TITLE
[DOP-21732] Fix Oracle reading with partitioning_mode=hash

### DIFF
--- a/docs/changelog/next_release/319.bugfix.rst
+++ b/docs/changelog/next_release/319.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``DBReader(conn=oracle, options={"partitioning_mode": "hash"})`` lead to data skew in last partition due to wrong ``ora_hash`` usage.

--- a/onetl/connection/db_connection/clickhouse/dialect.py
+++ b/onetl/connection/db_connection/clickhouse/dialect.py
@@ -10,7 +10,7 @@ from onetl.connection.db_connection.jdbc_connection import JDBCDialect
 
 class ClickhouseDialect(JDBCDialect):
     def get_partition_column_hash(self, partition_column: str, num_partitions: int) -> str:
-        return f"modulo(halfMD5({partition_column}), {num_partitions})"
+        return f"halfMD5({partition_column}) % {num_partitions}"
 
     def get_partition_column_mod(self, partition_column: str, num_partitions: int) -> str:
         return f"{partition_column} % {num_partitions}"

--- a/onetl/connection/db_connection/mssql/dialect.py
+++ b/onetl/connection/db_connection/mssql/dialect.py
@@ -10,7 +10,7 @@ from onetl.connection.db_connection.jdbc_connection import JDBCDialect
 class MSSQLDialect(JDBCDialect):
     # https://docs.microsoft.com/ru-ru/sql/t-sql/functions/hashbytes-transact-sql?view=sql-server-ver16
     def get_partition_column_hash(self, partition_column: str, num_partitions: int) -> str:
-        return f"CONVERT(BIGINT, HASHBYTES ( 'SHA' , {partition_column} )) % {num_partitions}"
+        return f"CONVERT(BIGINT, HASHBYTES ('SHA', {partition_column})) % {num_partitions}"
 
     def get_partition_column_mod(self, partition_column: str, num_partitions: int) -> str:
         return f"{partition_column} % {num_partitions}"

--- a/onetl/connection/db_connection/oracle/dialect.py
+++ b/onetl/connection/db_connection/oracle/dialect.py
@@ -43,7 +43,9 @@ class OracleDialect(JDBCDialect):
         )
 
     def get_partition_column_hash(self, partition_column: str, num_partitions: int) -> str:
-        return f"ora_hash({partition_column}, {num_partitions})"
+        # ora_hash returns values from 0 to N including N.
+        # Balancing N+1 splits to N partitions leads to data skew in last partition.
+        return f"ora_hash({partition_column}, {num_partitions - 1})"
 
     def get_partition_column_mod(self, partition_column: str, num_partitions: int) -> str:
         return f"MOD({partition_column}, {num_partitions})"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

<!-- Please give a short summary of the changes. -->

`ORA_HASH(col, N)` returns results from 0 to N including N (N+1 in total). Spark creates exactly N partitions, so last partition gets twice the data relative to other ones.

Fixed by calling `ORA_HASH(col, N-1)`. Other JDBC sources don't have such an issue, as they use modulo which always returns values from 0 to N-1.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
