### PR TITLE
[DOP-21813] Fix partitioning_mode=hash and cover with tests

### DIFF
--- a/docs/changelog/0.12.5.rst
+++ b/docs/changelog/0.12.5.rst
@@ -1,0 +1,15 @@
+0.12.5 (2024-12-02)
+===================
+
+Improvements
+------------
+
+- Use ``sipHash64`` instead of ``md5`` in Clickhouse for reading data with ``{"partitioning_mode": "hash"}``, as it is 5 times faster.
+- Use ``hashtext`` instead of ``md5`` in Postgres for reading data with ``{"partitioning_mode": "hash"}``, as it is 3-5 times faster.
+- Use ``BINARY_CHECKSUM`` instead of ``HASHBYTES`` in MSSQL for reading data with ``{"partitioning_mode": "hash"}``, as it is 5 times faster.
+
+Big fixes
+---------
+
+- In JDBC sources wrap ``MOD(partitionColumn, numPartitions)`` with ``ABS(...)`` to make al returned values positive. This prevents data sked.
+- Fix reading table data from MSSQL using ``{"partitioning_mode": "hash"}`` with ``partitionColumn`` of integer type.

--- a/docs/changelog/index.rst
+++ b/docs/changelog/index.rst
@@ -3,6 +3,7 @@
     :caption: Changelog
 
     DRAFT
+    0.12.5
     0.12.4
     0.12.3
     0.12.2

--- a/onetl/connection/db_connection/jdbc_connection/options.py
+++ b/onetl/connection/db_connection/jdbc_connection/options.py
@@ -155,10 +155,9 @@ class JDBCReadOptions(JDBCFetchOptions):
     .. note::
         Column type depends on :obj:`~partitioning_mode`.
 
-        * ``partitioning_mode="range"`` requires column to be an integer or date (can be NULL, but not recommended).
-        * ``partitioning_mode="hash"`` requires column to be an string (NOT NULL).
+        * ``partitioning_mode="range"`` requires column to be an integer, date or timestamp (can be NULL, but not recommended).
+        * ``partitioning_mode="hash"`` accepts any column type (NOT NULL).
         * ``partitioning_mode="mod"`` requires column to be an integer (NOT NULL).
-
 
     See documentation for :obj:`~partitioning_mode` for more details"""
 
@@ -258,6 +257,10 @@ class JDBCReadOptions(JDBCFetchOptions):
 
         .. note::
 
+            Can be used only with columns of integer, date or timestamp types.
+
+        .. note::
+
             :obj:`~lower_bound`, :obj:`~upper_bound` and :obj:`~num_partitions` are used just to
             calculate the partition stride, **NOT** for filtering the rows in table.
             So all rows in the table will be returned (unlike *Incremental* :ref:`strategy`).
@@ -297,7 +300,7 @@ class JDBCReadOptions(JDBCFetchOptions):
         .. note::
 
             The hash function implementation depends on RDBMS. It can be ``MD5`` or any other fast hash function,
-            or expression based on this function call.
+            or expression based on this function call. Usually such functions accepts any column type as an input.
 
     * ``mod``
         Allocate each executor a set of values based on modulus of the :obj:`~partition_column` column.
@@ -324,6 +327,10 @@ class JDBCReadOptions(JDBCFetchOptions):
 
             SELECT ... FROM table
             WHERE (partition_column mod num_partitions) = num_partitions-1 -- upper_bound
+
+        .. note::
+
+            Can be used only with columns of integer type.
 
     .. versionadded:: 0.5.0
 

--- a/onetl/connection/db_connection/oracle/dialect.py
+++ b/onetl/connection/db_connection/oracle/dialect.py
@@ -48,7 +48,8 @@ class OracleDialect(JDBCDialect):
         return f"ora_hash({partition_column}, {num_partitions - 1})"
 
     def get_partition_column_mod(self, partition_column: str, num_partitions: int) -> str:
-        return f"MOD({partition_column}, {num_partitions})"
+        # Return positive value even for negative input
+        return f"ABS(MOD({partition_column}, {num_partitions}))"
 
     def _serialize_datetime(self, value: datetime) -> str:
         result = value.strftime("%Y-%m-%d %H:%M:%S")

--- a/onetl/connection/db_connection/postgres/dialect.py
+++ b/onetl/connection/db_connection/postgres/dialect.py
@@ -9,12 +9,14 @@ from onetl.connection.db_connection.jdbc_connection import JDBCDialect
 
 
 class PostgresDialect(NotSupportHint, JDBCDialect):
-    # https://stackoverflow.com/a/9812029
     def get_partition_column_hash(self, partition_column: str, num_partitions: int) -> str:
-        return f"('x'||right(md5('{partition_column}'), 16))::bit(32)::bigint % {num_partitions}"
+        # hashtext is about 3-5 times faster than MD5 (tested locally)
+        # https://postgrespro.com/list/thread-id/1506406
+        return f"abs(hashtext({partition_column}::text)) % {num_partitions}"
 
     def get_partition_column_mod(self, partition_column: str, num_partitions: int) -> str:
-        return f"{partition_column} % {num_partitions}"
+        # Return positive value even for negative input
+        return f"abs({partition_column} % {num_partitions})"
 
     def _serialize_datetime(self, value: datetime) -> str:
         result = value.isoformat()

--- a/onetl/connection/db_connection/teradata/dialect.py
+++ b/onetl/connection/db_connection/teradata/dialect.py
@@ -13,7 +13,8 @@ class TeradataDialect(JDBCDialect):
         return f"HASHAMP(HASHBUCKET(HASHROW({partition_column}))) mod {num_partitions}"
 
     def get_partition_column_mod(self, partition_column: str, num_partitions: int) -> str:
-        return f"{partition_column} mod {num_partitions}"
+        # Return positive value even for negative input
+        return f"ABS({partition_column} mod {num_partitions})"
 
     def _serialize_datetime(self, value: datetime) -> str:
         result = value.isoformat()

--- a/tests/fixtures/processing/base_processing.py
+++ b/tests/fixtures/processing/base_processing.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import secrets
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from datetime import date, datetime, timedelta
@@ -137,7 +138,7 @@ class BaseProcessing(ABC):
                 elif "float" in column_name:
                     values[column].append(float(f"{i}.{i}"))
                 elif "text" in column_name:
-                    values[column].append("This line is made to test the work")
+                    values[column].append(secrets.token_hex(16))
                 elif "datetime" in column_name:
                     rand_second = randint(0, i * time_multiplier)  # noqa: S311
                     values[column].append(self.current_datetime() + timedelta(seconds=rand_second))

--- a/tests/fixtures/processing/clickhouse.py
+++ b/tests/fixtures/processing/clickhouse.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import secrets
 from collections import defaultdict
 from datetime import date, datetime, timedelta
 from logging import getLogger
@@ -74,7 +75,7 @@ class ClickhouseProcessing(BaseProcessing):
                 elif "float" in column_name:
                     values[column_name].append(float(f"{i}.{i}"))
                 elif "text" in column_name:
-                    values[column_name].append("This line is made to test the work")
+                    values[column_name].append(secrets.token_hex(16))
                 elif "datetime" in column_name:
                     rand_second = randint(0, i * time_multiplier)  # noqa: S311
                     # Clickhouse DATETIME format has time range: 00:00:00 through 23:59:59

--- a/tests/fixtures/processing/mongodb.py
+++ b/tests/fixtures/processing/mongodb.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import secrets
 from collections import defaultdict
 from datetime import datetime, timedelta
 from logging import getLogger
@@ -149,7 +150,7 @@ class MongoDBProcessing(BaseProcessing):
                 elif "float" in column_name:
                     values[column_name].append(float(f"{i}.{i}"))
                 elif "text" in column_name:
-                    values[column_name].append("This line is made to test the work")
+                    values[column_name].append(secrets.token_hex(16))
                 elif "datetime" in column_name:
                     rand_second = randint(0, i * time_multiplier)  # noqa: S311
                     now = self.current_datetime() + timedelta(seconds=rand_second)

--- a/tests/tests_integration/tests_core_integration/tests_db_reader_integration/test_mssql_reader_integration.py
+++ b/tests/tests_integration/tests_core_integration/tests_db_reader_integration/test_mssql_reader_integration.py
@@ -7,6 +7,8 @@ try:
 except ImportError:
     pytest.skip("Missing pandas", allow_module_level=True)
 
+from onetl._util.spark import get_spark_version
+from onetl._util.version import Version
 from onetl.connection import MSSQL
 from onetl.db import DBReader
 from tests.util.rand import rand_str
@@ -39,15 +41,9 @@ def test_mssql_reader_snapshot(spark, processing, load_table_data):
     )
 
 
-@pytest.mark.parametrize(
-    "mode, column",
-    [
-        ("range", "id_int"),
-        ("hash", "text_string"),
-        ("mod", "id_int"),
-    ],
-)
-def test_mssql_reader_snapshot_partitioning_mode(mode, column, spark, processing, load_table_data):
+def test_mssql_reader_snapshot_with_partitioning_mode_range_int(spark, processing, load_table_data):
+    from pyspark.sql.functions import spark_partition_id
+
     mssql = MSSQL(
         host=processing.host,
         port=processing.port,
@@ -55,19 +51,18 @@ def test_mssql_reader_snapshot_partitioning_mode(mode, column, spark, processing
         password=processing.password,
         database=processing.database,
         spark=spark,
-        extra={"trustServerCertificate": "true"},  # avoid SSL problem
+        extra={"trustServerCertificate": "true"},
     )
 
     reader = DBReader(
         connection=mssql,
         source=load_table_data.full_name,
-        options=MSSQL.ReadOptions(
-            partitioning_mode=mode,
-            partition_column=column,
-            num_partitions=5,
-        ),
+        options={
+            "partitioning_mode": "range",
+            "partitionColumn": "hwm_int",
+            "numPartitions": 3,
+        },
     )
-
     table_df = reader.run()
 
     processing.assert_equal_df(
@@ -77,7 +72,303 @@ def test_mssql_reader_snapshot_partitioning_mode(mode, column, spark, processing
         order_by="id_int",
     )
 
-    assert table_df.rdd.getNumPartitions() == 5
+    assert table_df.rdd.getNumPartitions() == 3
+    # So just check that any partition has at least 0 rows
+    assert table_df.groupBy(spark_partition_id()).count().count() == 3
+
+    # 100 rows per 3 partitions -> each partition should contain about ~33 rows with very low variance.
+    average_count_per_partition = table_df.count() // table_df.rdd.getNumPartitions()
+    min_count_per_partition = average_count_per_partition - 1
+    max_count_per_partition = average_count_per_partition + 1
+
+    count_per_partition = table_df.groupBy(spark_partition_id()).count().collect()
+
+    for partition in count_per_partition:
+        assert min_count_per_partition <= partition["count"] <= max_count_per_partition
+
+
+@pytest.mark.parametrize(
+    "bounds",
+    [
+        pytest.param({"lowerBound": "50"}, id="lower_bound"),
+        pytest.param({"upperBound": "70"}, id="upper_bound"),
+        pytest.param({"lowerBound": "50", "upperBound": "70"}, id="both_bounds"),
+    ],
+)
+def test_mssql_reader_snapshot_with_partitioning_mode_range_int_explicit_bounds(
+    spark,
+    processing,
+    load_table_data,
+    bounds,
+):
+    from pyspark.sql.functions import spark_partition_id
+
+    mssql = MSSQL(
+        host=processing.host,
+        port=processing.port,
+        user=processing.user,
+        password=processing.password,
+        database=processing.database,
+        spark=spark,
+        extra={"trustServerCertificate": "true"},
+    )
+
+    reader = DBReader(
+        connection=mssql,
+        source=load_table_data.full_name,
+        options={
+            "partitioning_mode": "range",
+            "partitionColumn": "hwm_int",
+            "numPartitions": 3,
+            **bounds,
+        },
+    )
+    table_df = reader.run()
+
+    processing.assert_equal_df(
+        schema=load_table_data.schema,
+        table=load_table_data.table,
+        df=table_df,
+        order_by="id_int",
+    )
+
+    assert table_df.rdd.getNumPartitions() == 3
+    # So just check that any partition has at least 0 rows
+    assert table_df.groupBy(spark_partition_id()).count().count() == 3
+
+
+# sometimes fails with 'Conversion failed when converting date and/or time from character string.'
+@pytest.mark.flaky(reruns=10)
+@pytest.mark.parametrize(
+    "column",
+    [
+        "hwm_date",
+        "hwm_datetime",
+    ],
+)
+def test_mssql_reader_snapshot_with_partitioning_mode_range_date_datetime(spark, processing, load_table_data, column):
+    spark_version = get_spark_version(spark)
+    if spark_version < Version("2.4"):
+        # https://issues.apache.org/jira/browse/SPARK-22814
+        pytest.skip("partitionColumn of date/datetime is supported only since 2.4.0")
+
+    from pyspark.sql.functions import spark_partition_id
+
+    mssql = MSSQL(
+        host=processing.host,
+        port=processing.port,
+        user=processing.user,
+        password=processing.password,
+        database=processing.database,
+        spark=spark,
+        extra={"trustServerCertificate": "true"},
+    )
+
+    reader = DBReader(
+        connection=mssql,
+        source=load_table_data.full_name,
+        options={
+            "partitioning_mode": "range",
+            "partitionColumn": column,
+            "numPartitions": 3,
+        },
+    )
+    table_df = reader.run()
+
+    processing.assert_equal_df(
+        schema=load_table_data.schema,
+        table=load_table_data.table,
+        df=table_df,
+        order_by="id_int",
+    )
+
+    assert table_df.rdd.getNumPartitions() == 3
+    # So just check that any partition has at least 0 rows
+    assert table_df.groupBy(spark_partition_id()).count().count() == 3
+
+
+@pytest.mark.parametrize(
+    "column",
+    [
+        "float_value",
+        "text_string",
+    ],
+)
+def test_mssql_reader_snapshot_with_partitioning_mode_range_unsupported_column_type(
+    spark,
+    processing,
+    load_table_data,
+    column,
+):
+    mssql = MSSQL(
+        host=processing.host,
+        port=processing.port,
+        user=processing.user,
+        password=processing.password,
+        database=processing.database,
+        spark=spark,
+        extra={"trustServerCertificate": "true"},
+    )
+
+    reader = DBReader(
+        connection=mssql,
+        source=load_table_data.full_name,
+        options={
+            "partitioning_mode": "range",
+            "partitionColumn": column,
+            "numPartitions": 3,
+        },
+    )
+
+    with pytest.raises(Exception):
+        reader.run()
+
+
+@pytest.mark.parametrize(
+    "column",
+    [
+        # all column types are supported
+        "hwm_int",
+        "hwm_date",
+        "hwm_datetime",
+        "float_value",
+        "text_string",
+        # hash of the entire row is supported as well
+        "*",
+    ],
+)
+def test_mssql_reader_snapshot_with_partitioning_mode_hash(spark, processing, load_table_data, column):
+    from pyspark.sql.functions import spark_partition_id
+
+    mssql = MSSQL(
+        host=processing.host,
+        port=processing.port,
+        user=processing.user,
+        password=processing.password,
+        database=processing.database,
+        spark=spark,
+        extra={"trustServerCertificate": "true"},
+    )
+
+    reader = DBReader(
+        connection=mssql,
+        source=load_table_data.full_name,
+        options={
+            "partitioning_mode": "hash",
+            "partitionColumn": column,
+            "numPartitions": 3,
+        },
+    )
+    table_df = reader.run()
+
+    processing.assert_equal_df(
+        schema=load_table_data.schema,
+        table=load_table_data.table,
+        df=table_df,
+        order_by="id_int",
+    )
+
+    assert table_df.rdd.getNumPartitions() == 3
+    # So just check that any partition has at least 0 rows
+    assert table_df.groupBy(spark_partition_id()).count().count() == 3
+
+    # 100 rows per 3 partitions -> each partition should contain about ~33 rows,
+    # with some variance caused by randomness & hash distribution
+    min_count_per_partition = 10
+    max_count_per_partition = 50
+
+    count_per_partition = table_df.groupBy(spark_partition_id()).count().collect()
+
+    for partition in count_per_partition:
+        assert min_count_per_partition <= partition["count"] <= max_count_per_partition
+
+
+def test_mssql_reader_snapshot_with_partitioning_mode_mod(spark, processing, load_table_data):
+    from pyspark.sql.functions import spark_partition_id
+
+    mssql = MSSQL(
+        host=processing.host,
+        port=processing.port,
+        user=processing.user,
+        password=processing.password,
+        database=processing.database,
+        spark=spark,
+        extra={"trustServerCertificate": "true"},
+    )
+
+    reader = DBReader(
+        connection=mssql,
+        source=load_table_data.full_name,
+        options={
+            "partitioning_mode": "mod",
+            "partitionColumn": "hwm_int",
+            "numPartitions": 3,
+        },
+    )
+    table_df = reader.run()
+
+    processing.assert_equal_df(
+        schema=load_table_data.schema,
+        table=load_table_data.table,
+        df=table_df,
+        order_by="id_int",
+    )
+
+    assert table_df.rdd.getNumPartitions() == 3
+    # So just check that any partition has at least 0 rows
+    assert table_df.groupBy(spark_partition_id()).count().count() == 3
+
+    # 100 rows per 3 partitions -> each partition should contain about ~33 rows with very low variance.
+    average_count_per_partition = table_df.count() // table_df.rdd.getNumPartitions()
+    min_count_per_partition = average_count_per_partition - 1
+    max_count_per_partition = average_count_per_partition + 1
+
+    count_per_partition = table_df.groupBy(spark_partition_id()).count().collect()
+    for partition in count_per_partition:
+        assert min_count_per_partition <= partition["count"] <= max_count_per_partition
+
+
+@pytest.mark.parametrize(
+    "column",
+    [
+        "hwm_date",
+        "hwm_datetime",
+        "float_value",
+        "text_string",
+    ],
+)
+def test_mssql_reader_snapshot_with_partitioning_mode_mod_unsupported_column_type(
+    spark,
+    processing,
+    load_table_data,
+    column,
+):
+    mssql = MSSQL(
+        host=processing.host,
+        port=processing.port,
+        user=processing.user,
+        password=processing.password,
+        database=processing.database,
+        spark=spark,
+        extra={"trustServerCertificate": "true"},
+    )
+
+    reader = DBReader(
+        connection=mssql,
+        source=load_table_data.full_name,
+        options={
+            "partitioning_mode": "mod",
+            "partitionColumn": column,
+            "numPartitions": 3,
+        },
+    )
+
+    with pytest.raises(
+        Exception,
+        match=r"are incompatible in the modulo operator|Conversion failed .* to data type int",
+    ):
+        table_df = reader.run()
+        table_df.count()
 
 
 def test_mssql_reader_snapshot_with_columns(spark, processing, load_table_data):

--- a/tests/tests_integration/tests_core_integration/tests_db_reader_integration/test_mysql_reader_integration.py
+++ b/tests/tests_integration/tests_core_integration/tests_db_reader_integration/test_mysql_reader_integration.py
@@ -7,6 +7,8 @@ try:
 except ImportError:
     pytest.skip("Missing pandas", allow_module_level=True)
 
+from onetl._util.spark import get_spark_version
+from onetl._util.version import Version
 from onetl.connection import MySQL
 from onetl.db import DBReader
 from tests.util.rand import rand_str
@@ -39,15 +41,9 @@ def test_mysql_reader_snapshot(spark, processing, load_table_data):
     )
 
 
-@pytest.mark.parametrize(
-    "mode, column",
-    [
-        ("range", "id_int"),
-        ("hash", "text_string"),
-        ("mod", "id_int"),
-    ],
-)
-def test_mysql_reader_snapshot_partitioning_mode(mode, column, spark, processing, load_table_data):
+def test_mysql_reader_snapshot_with_partitioning_mode_range_int(spark, processing, load_table_data):
+    from pyspark.sql.functions import spark_partition_id
+
     mysql = MySQL(
         host=processing.host,
         port=processing.port,
@@ -60,13 +56,12 @@ def test_mysql_reader_snapshot_partitioning_mode(mode, column, spark, processing
     reader = DBReader(
         connection=mysql,
         source=load_table_data.full_name,
-        options=MySQL.ReadOptions(
-            partitioning_mode=mode,
-            partition_column=column,
-            num_partitions=5,
-        ),
+        options={
+            "partitioning_mode": "range",
+            "partitionColumn": "hwm_int",
+            "numPartitions": 3,
+        },
     )
-
     table_df = reader.run()
 
     processing.assert_equal_df(
@@ -76,7 +71,303 @@ def test_mysql_reader_snapshot_partitioning_mode(mode, column, spark, processing
         order_by="id_int",
     )
 
-    assert table_df.rdd.getNumPartitions() == 5
+    assert table_df.rdd.getNumPartitions() == 3
+    # So just check that any partition has at least 0 rows
+    assert table_df.groupBy(spark_partition_id()).count().count() == 3
+
+    # 100 rows per 3 partitions -> each partition should contain about ~33 rows with very low variance.
+    average_count_per_partition = table_df.count() // table_df.rdd.getNumPartitions()
+    min_count_per_partition = average_count_per_partition - 1
+    max_count_per_partition = average_count_per_partition + 1
+
+    count_per_partition = table_df.groupBy(spark_partition_id()).count().collect()
+
+    for partition in count_per_partition:
+        assert min_count_per_partition <= partition["count"] <= max_count_per_partition
+
+
+@pytest.mark.parametrize(
+    "bounds",
+    [
+        pytest.param({"lowerBound": "50"}, id="lower_bound"),
+        pytest.param({"upperBound": "70"}, id="upper_bound"),
+        pytest.param({"lowerBound": "50", "upperBound": "70"}, id="both_bounds"),
+    ],
+)
+def test_mysql_reader_snapshot_with_partitioning_mode_range_int_explicit_bounds(
+    spark,
+    processing,
+    load_table_data,
+    bounds,
+):
+    from pyspark.sql.functions import spark_partition_id
+
+    mysql = MySQL(
+        host=processing.host,
+        port=processing.port,
+        user=processing.user,
+        password=processing.password,
+        database=processing.database,
+        spark=spark,
+    )
+
+    reader = DBReader(
+        connection=mysql,
+        source=load_table_data.full_name,
+        options={
+            "partitioning_mode": "range",
+            "partitionColumn": "hwm_int",
+            "numPartitions": 3,
+            **bounds,
+        },
+    )
+    table_df = reader.run()
+
+    processing.assert_equal_df(
+        schema=load_table_data.schema,
+        table=load_table_data.table,
+        df=table_df,
+        order_by="id_int",
+    )
+
+    assert table_df.rdd.getNumPartitions() == 3
+    # So just check that any partition has at least 0 rows
+    assert table_df.groupBy(spark_partition_id()).count().count() == 3
+
+
+@pytest.mark.parametrize(
+    "column",
+    [
+        "hwm_date",
+        "hwm_datetime",
+    ],
+)
+def test_mysql_reader_snapshot_with_partitioning_mode_range_date_datetime(spark, processing, load_table_data, column):
+    spark_version = get_spark_version(spark)
+    if spark_version < Version("2.4"):
+        # https://issues.apache.org/jira/browse/SPARK-22814
+        pytest.skip("partitionColumn of date/datetime is supported only since 2.4.0")
+
+    from pyspark.sql.functions import spark_partition_id
+
+    mysql = MySQL(
+        host=processing.host,
+        port=processing.port,
+        user=processing.user,
+        password=processing.password,
+        database=processing.database,
+        spark=spark,
+    )
+
+    reader = DBReader(
+        connection=mysql,
+        source=load_table_data.full_name,
+        options={
+            "partitioning_mode": "range",
+            "partitionColumn": column,
+            "numPartitions": 3,
+        },
+    )
+    table_df = reader.run()
+
+    processing.assert_equal_df(
+        schema=load_table_data.schema,
+        table=load_table_data.table,
+        df=table_df,
+        order_by="id_int",
+    )
+
+    assert table_df.rdd.getNumPartitions() == 3
+    # So just check that any partition has at least 0 rows
+    assert table_df.groupBy(spark_partition_id()).count().count() == 3
+
+
+@pytest.mark.parametrize(
+    "column",
+    [
+        "float_value",
+        "text_string",
+    ],
+)
+def test_mysql_reader_snapshot_with_partitioning_mode_range_unsupported_column_type(
+    spark,
+    processing,
+    load_table_data,
+    column,
+):
+    mysql = MySQL(
+        host=processing.host,
+        port=processing.port,
+        user=processing.user,
+        password=processing.password,
+        database=processing.database,
+        spark=spark,
+    )
+
+    reader = DBReader(
+        connection=mysql,
+        source=load_table_data.full_name,
+        options={
+            "partitioning_mode": "range",
+            "partitionColumn": column,
+            "numPartitions": 3,
+        },
+    )
+
+    with pytest.raises(Exception):
+        reader.run()
+
+
+@pytest.mark.parametrize(
+    "column",
+    [
+        # all column types are supported
+        "hwm_int",
+        "hwm_date",
+        "hwm_datetime",
+        "float_value",
+        "text_string",
+    ],
+)
+def test_mysql_reader_snapshot_with_partitioning_mode_hash(spark, processing, load_table_data, column):
+    from pyspark.sql.functions import spark_partition_id
+
+    mysql = MySQL(
+        host=processing.host,
+        port=processing.port,
+        user=processing.user,
+        password=processing.password,
+        database=processing.database,
+        spark=spark,
+    )
+
+    reader = DBReader(
+        connection=mysql,
+        source=load_table_data.full_name,
+        options={
+            "partitioning_mode": "hash",
+            "partitionColumn": column,
+            "numPartitions": 3,
+        },
+    )
+    table_df = reader.run()
+
+    processing.assert_equal_df(
+        schema=load_table_data.schema,
+        table=load_table_data.table,
+        df=table_df,
+        order_by="id_int",
+    )
+
+    assert table_df.rdd.getNumPartitions() == 3
+    # So just check that any partition has at least 0 rows
+    assert table_df.groupBy(spark_partition_id()).count().count() == 3
+
+    # 100 rows per 3 partitions -> each partition should contain about ~33 rows,
+    # with some variance caused by randomness & hash distribution (+- 50% range is wide enough)
+    min_count_per_partition = 10
+    max_count_per_partition = 50
+
+    count_per_partition = table_df.groupBy(spark_partition_id()).count().collect()
+    for partition in count_per_partition:
+        assert min_count_per_partition <= partition["count"] <= max_count_per_partition
+
+
+@pytest.mark.parametrize(
+    "column",
+    [
+        "hwm_int",
+        "float_value",
+    ],
+)
+def test_mysql_reader_snapshot_with_partitioning_mode_mod_number(spark, processing, load_table_data, column):
+    from pyspark.sql.functions import spark_partition_id
+
+    mysql = MySQL(
+        host=processing.host,
+        port=processing.port,
+        user=processing.user,
+        password=processing.password,
+        database=processing.database,
+        spark=spark,
+    )
+
+    reader = DBReader(
+        connection=mysql,
+        source=load_table_data.full_name,
+        options={
+            "partitioning_mode": "mod",
+            "partitionColumn": column,
+            "numPartitions": 3,
+        },
+    )
+    table_df = reader.run()
+
+    processing.assert_equal_df(
+        schema=load_table_data.schema,
+        table=load_table_data.table,
+        df=table_df,
+        order_by="id_int",
+    )
+
+    assert table_df.rdd.getNumPartitions() == 3
+    # So just check that any partition has at least 0 rows
+    assert table_df.groupBy(spark_partition_id()).count().count() == 3
+
+    # 100 rows per 3 partitions -> each partition should contain about ~33 rows with very low variance.
+    average_count_per_partition = table_df.count() // table_df.rdd.getNumPartitions()
+    min_count_per_partition = average_count_per_partition - 1
+    max_count_per_partition = average_count_per_partition + 1
+
+    count_per_partition = table_df.groupBy(spark_partition_id()).count().collect()
+    for partition in count_per_partition:
+        assert min_count_per_partition <= partition["count"] <= max_count_per_partition
+
+
+# Apparently, MySQL supports modulus for any column type
+@pytest.mark.parametrize(
+    "column",
+    [
+        "hwm_date",
+        "hwm_datetime",
+        "text_string",
+    ],
+)
+def test_mysql_reader_snapshot_with_partitioning_mode_mod_other_column_type(spark, processing, load_table_data, column):
+    from pyspark.sql.functions import spark_partition_id
+
+    mysql = MySQL(
+        host=processing.host,
+        port=processing.port,
+        user=processing.user,
+        password=processing.password,
+        database=processing.database,
+        spark=spark,
+    )
+
+    reader = DBReader(
+        connection=mysql,
+        source=load_table_data.full_name,
+        options={
+            "partitioning_mode": "mod",
+            "partitionColumn": column,
+            "numPartitions": 3,
+        },
+    )
+    table_df = reader.run()
+
+    processing.assert_equal_df(
+        schema=load_table_data.schema,
+        table=load_table_data.table,
+        df=table_df,
+        order_by="id_int",
+    )
+
+    assert table_df.rdd.getNumPartitions() == 3
+    # So just check that any partition has at least 0 rows
+    assert table_df.groupBy(spark_partition_id()).count().count() == 3
+
+    # for some reason, `MOD(text_string, N)` result is very skewed, don't assert on that.
 
 
 def test_mysql_reader_snapshot_with_not_set_database(spark, processing, load_table_data):

--- a/tests/tests_integration/tests_core_integration/tests_db_reader_integration/test_oracle_reader_integration.py
+++ b/tests/tests_integration/tests_core_integration/tests_db_reader_integration/test_oracle_reader_integration.py
@@ -39,15 +39,9 @@ def test_oracle_reader_snapshot(spark, processing, load_table_data):
     )
 
 
-@pytest.mark.parametrize(
-    "mode, column",
-    [
-        ("range", "id_int"),
-        ("hash", "text_string"),
-        ("mod", "id_int"),
-    ],
-)
-def test_oracle_reader_snapshot_partitioning_mode(mode, column, spark, processing, load_table_data):
+def test_oracle_reader_snapshot_with_partitioning_mode_range_int(spark, processing, load_table_data):
+    from pyspark.sql.functions import spark_partition_id
+
     oracle = Oracle(
         host=processing.host,
         port=processing.port,
@@ -61,13 +55,12 @@ def test_oracle_reader_snapshot_partitioning_mode(mode, column, spark, processin
     reader = DBReader(
         connection=oracle,
         source=load_table_data.full_name,
-        options=Oracle.ReadOptions(
-            partitioning_mode=mode,
-            partition_column=column,
-            num_partitions=5,
-        ),
+        options={
+            "partitioning_mode": "range",
+            "partitionColumn": "hwm_int",
+            "numPartitions": 3,
+        },
     )
-
     table_df = reader.run()
 
     processing.assert_equal_df(
@@ -77,7 +70,258 @@ def test_oracle_reader_snapshot_partitioning_mode(mode, column, spark, processin
         order_by="id_int",
     )
 
-    assert table_df.rdd.getNumPartitions() == 5
+    assert table_df.rdd.getNumPartitions() == 3
+    # So just check that any partition has at least 0 rows
+    assert table_df.groupBy(spark_partition_id()).count().count() == 3
+
+    # 100 rows per 3 partitions -> each partition should contain about ~33 rows with very low variance.
+    average_count_per_partition = table_df.count() // table_df.rdd.getNumPartitions()
+    min_count_per_partition = average_count_per_partition - 1
+    max_count_per_partition = average_count_per_partition + 1
+
+    count_per_partition = table_df.groupBy(spark_partition_id()).count().collect()
+
+    for partition in count_per_partition:
+        assert min_count_per_partition <= partition["count"] <= max_count_per_partition
+
+
+@pytest.mark.parametrize(
+    "bounds",
+    [
+        pytest.param({"lowerBound": "50"}, id="lower_bound"),
+        pytest.param({"upperBound": "70"}, id="upper_bound"),
+        pytest.param({"lowerBound": "50", "upperBound": "70"}, id="both_bounds"),
+    ],
+)
+def test_oracle_reader_snapshot_with_partitioning_mode_range_int_explicit_bounds(
+    spark,
+    processing,
+    load_table_data,
+    bounds,
+):
+    from pyspark.sql.functions import spark_partition_id
+
+    oracle = Oracle(
+        host=processing.host,
+        port=processing.port,
+        user=processing.user,
+        password=processing.password,
+        spark=spark,
+        sid=processing.sid,
+        service_name=processing.service_name,
+    )
+
+    reader = DBReader(
+        connection=oracle,
+        source=load_table_data.full_name,
+        options={
+            "partitioning_mode": "range",
+            "partitionColumn": "hwm_int",
+            "numPartitions": 3,
+            **bounds,
+        },
+    )
+    table_df = reader.run()
+
+    processing.assert_equal_df(
+        schema=load_table_data.schema,
+        table=load_table_data.table,
+        df=table_df,
+        order_by="id_int",
+    )
+
+    assert table_df.rdd.getNumPartitions() == 3
+    # So just check that any partition has at least 0 rows
+    assert table_df.groupBy(spark_partition_id()).count().count() == 3
+
+
+@pytest.mark.parametrize(
+    "column",
+    [
+        "hwm_date",
+        "hwm_datetime",
+        "float_value",
+        "text_string",
+    ],
+)
+def test_oracle_reader_snapshot_with_partitioning_mode_range_unsupported_column_type(
+    spark,
+    processing,
+    load_table_data,
+    column,
+):
+    oracle = Oracle(
+        host=processing.host,
+        port=processing.port,
+        user=processing.user,
+        password=processing.password,
+        spark=spark,
+        sid=processing.sid,
+        service_name=processing.service_name,
+    )
+
+    reader = DBReader(
+        connection=oracle,
+        source=load_table_data.full_name,
+        options={
+            "partitioning_mode": "range",
+            "partitionColumn": column,
+            "numPartitions": 3,
+        },
+    )
+
+    with pytest.raises(Exception):
+        table_df = reader.run()
+        table_df.count()
+
+
+@pytest.mark.parametrize(
+    "column",
+    [
+        # all column types are supported
+        "hwm_int",
+        "hwm_date",
+        "hwm_datetime",
+        "float_value",
+        "text_string",
+    ],
+)
+def test_oracle_reader_snapshot_with_partitioning_mode_hash(spark, processing, load_table_data, column):
+    from pyspark.sql.functions import spark_partition_id
+
+    oracle = Oracle(
+        host=processing.host,
+        port=processing.port,
+        user=processing.user,
+        password=processing.password,
+        spark=spark,
+        sid=processing.sid,
+        service_name=processing.service_name,
+    )
+
+    reader = DBReader(
+        connection=oracle,
+        source=load_table_data.full_name,
+        options={
+            "partitioning_mode": "hash",
+            "partitionColumn": column,
+            "numPartitions": 3,
+        },
+    )
+    table_df = reader.run()
+
+    processing.assert_equal_df(
+        schema=load_table_data.schema,
+        table=load_table_data.table,
+        df=table_df,
+        order_by="id_int",
+    )
+
+    assert table_df.rdd.getNumPartitions() == 3
+    # So just check that any partition has at least 0 rows
+    assert table_df.groupBy(spark_partition_id()).count().count() == 3
+
+    # 100 rows per 3 partitions -> each partition should contain about ~33 rows,
+    # with some variance caused by randomness & hash distribution
+    min_count_per_partition = 10
+    max_count_per_partition = 50
+
+    count_per_partition = table_df.groupBy(spark_partition_id()).count().collect()
+
+    for partition in count_per_partition:
+        assert min_count_per_partition <= partition["count"] <= max_count_per_partition
+
+
+# Apparently, Oracle supports modulus for text columns type
+@pytest.mark.parametrize(
+    "column",
+    [
+        "hwm_int",
+        "float_value",
+    ],
+)
+def test_oracle_reader_snapshot_with_partitioning_mode_mod_number(spark, processing, load_table_data, column):
+    from pyspark.sql.functions import spark_partition_id
+
+    oracle = Oracle(
+        host=processing.host,
+        port=processing.port,
+        user=processing.user,
+        password=processing.password,
+        spark=spark,
+        sid=processing.sid,
+        service_name=processing.service_name,
+    )
+
+    reader = DBReader(
+        connection=oracle,
+        source=load_table_data.full_name,
+        options={
+            "partitioning_mode": "mod",
+            "partitionColumn": column,
+            "numPartitions": 3,
+        },
+    )
+    table_df = reader.run()
+
+    processing.assert_equal_df(
+        schema=load_table_data.schema,
+        table=load_table_data.table,
+        df=table_df,
+        order_by="id_int",
+    )
+
+    assert table_df.rdd.getNumPartitions() == 3
+    # So just check that any partition has at least 0 rows
+    assert table_df.groupBy(spark_partition_id()).count().count() == 3
+
+    # 100 rows per 3 partitions -> each partition should contain about ~33 rows with very low variance.
+    average_count_per_partition = table_df.count() // table_df.rdd.getNumPartitions()
+    min_count_per_partition = average_count_per_partition - 1
+    max_count_per_partition = average_count_per_partition + 1
+
+    count_per_partition = table_df.groupBy(spark_partition_id()).count().collect()
+    for partition in count_per_partition:
+        assert min_count_per_partition <= partition["count"] <= max_count_per_partition
+
+
+@pytest.mark.parametrize(
+    "column",
+    [
+        "hwm_date",
+        "hwm_datetime",
+        "text_string",
+    ],
+)
+def test_oracle_reader_snapshot_with_partitioning_mode_mod_unsupported_column_type(
+    spark,
+    processing,
+    load_table_data,
+    column,
+):
+    oracle = Oracle(
+        host=processing.host,
+        port=processing.port,
+        user=processing.user,
+        password=processing.password,
+        spark=spark,
+        sid=processing.sid,
+        service_name=processing.service_name,
+    )
+
+    reader = DBReader(
+        connection=oracle,
+        source=load_table_data.full_name,
+        options={
+            "partitioning_mode": "mod",
+            "partitionColumn": column,
+            "numPartitions": 3,
+        },
+    )
+
+    with pytest.raises(Exception):
+        table_df = reader.run()
+        table_df.count()
 
 
 def test_oracle_reader_snapshot_with_columns(spark, processing, load_table_data):

--- a/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_oracle.py
+++ b/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_oracle.py
@@ -123,6 +123,7 @@ def test_oracle_strategy_incremental(
         processing.assert_subset_df(df=second_df, other_frame=second_span)
 
 
+@pytest.mark.flaky
 def test_oracle_strategy_incremental_nothing_to_read(spark, processing, prepare_schema_table):
     oracle = Oracle(
         host=processing.host,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

* Fix issue when using `{"partitioning_mode": "hash", "partitionColumn": "integer_col"}` in MSSQL raised an error:
  ```
  com.microsoft.sqlserver.jdbc.SQLServerException: Argument data type int is invalid for argument 2 of hashbytes function.
  ```
  Now it supports any column type.

* Add tests for all combinations of `partitioning_mode` with `partitionColumn` types for all JDBC connectors (except Teradata).
* Use the fastest available hash function for `partitioning_mode=hash` - somewhere it is `MD5`, somewhere it is some kind of internal hash function which is used for hash indexes.
* Fix `partitioning_mode=mod` could return negative results for negative column values, and thus resulting a data skew (because all `mod(col, N) <= lowerBound` values are passed into first partition).

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
