### PR TITLE
[DOP-22144] Change logic of applying limits

### DIFF
--- a/docs/changelog/next_release/327.breaking.rst
+++ b/docs/changelog/next_release/327.breaking.rst
@@ -1,0 +1,2 @@
+Change the logic of ``FileConnection.walk`` and ``FileConnection.list_dir`` to exclude file what returned ``True`` from ``limit.stops_at(path)``,
+instead of stopping just *after* this file (possibly exceeding the limit).

--- a/onetl/base/base_file_connection.py
+++ b/onetl/base/base_file_connection.py
@@ -435,11 +435,11 @@ class BaseFileConnection(BaseConnection):
             If ``True``, walk in top-down order, otherwise walk in bottom-up order.
 
         filters : list of :obj:`BaseFileFilter <onetl.base.base_file_filter.BaseFileFilter>`, optional
-            Return only files/directories matching these filters. See :ref:`file-filters`
+            Return only files/directories matching these filters. See :ref:`file-filters`.
 
         limits : list of :obj:`BaseFileLimit <onetl.base.base_file_limit.BaseFileLimit>`, optional
-            Apply limits to the list of files/directories, and stop if one of the limits is reached.
-            See :ref:`file-limits`
+            Apply limits to the list of files/directories, and immediately stop if any of these limits is reached.
+            See :ref:`file-limits`.
 
         Returns
         -------

--- a/onetl/core/file_limit/file_limit.py
+++ b/onetl/core/file_limit/file_limit.py
@@ -67,7 +67,7 @@ class FileLimit(BaseFileLimit, FrozenModel):
 
     @property
     def is_reached(self) -> bool:
-        return self._counter >= self.count_limit
+        return self._counter > self.count_limit
 
     @validator("count_limit")
     def _deprecated(cls, value):

--- a/onetl/file/limit/limits_reached.py
+++ b/onetl/file/limit/limits_reached.py
@@ -35,9 +35,11 @@ def limits_reached(limits: Iterable[BaseFileLimit]) -> bool:
     >>> limits = [MaxFilesCount(2)]
     >>> limits_reached(limits)
     False
-    >>> limits_stop_at(LocalPath("/path/to/file.csv"), limits)
+    >>> limits_stop_at(LocalPath("/path/to/file1.csv"), limits)
     False
-    >>> limits_stop_at(LocalPath("/path/to/file.csv"), limits)
+    >>> limits_stop_at(LocalPath("/path/to/file2.csv"), limits)
+    False
+    >>> limits_stop_at(LocalPath("/path/to/file3.csv"), limits)
     True
     >>> limits_reached(limits)
     True

--- a/onetl/file/limit/limits_stop_at.py
+++ b/onetl/file/limit/limits_stop_at.py
@@ -36,9 +36,11 @@ def limits_stop_at(path: PathProtocol, limits: Iterable[BaseFileLimit]) -> bool:
     >>> from onetl.file.limit import MaxFilesCount, limits_stop_at
     >>> from onetl.impl import LocalPath
     >>> limits = [MaxFilesCount(2)]
-    >>> limits_stop_at(LocalPath("/path/to/file.csv"), limits)
+    >>> limits_stop_at(LocalPath("/path/to/file1.csv"), limits)
     False
-    >>> limits_stop_at(LocalPath("/path/to/file.csv"), limits)
+    >>> limits_stop_at(LocalPath("/path/to/file2.csv"), limits)
+    False
+    >>> limits_stop_at(LocalPath("/path/to/file3.csv"), limits)
     True
     """
     reached = []

--- a/onetl/file/limit/max_files_count.py
+++ b/onetl/file/limit/max_files_count.py
@@ -76,4 +76,4 @@ class MaxFilesCount(BaseFileLimit, FrozenModel):
 
     @property
     def is_reached(self) -> bool:
-        return self._handled >= self.limit
+        return self._handled > self.limit

--- a/onetl/file/limit/reset_limits.py
+++ b/onetl/file/limit/reset_limits.py
@@ -35,7 +35,9 @@ def reset_limits(limits: Iterable[BaseFileLimit]) -> list[BaseFileLimit]:
     >>> limits_reached(limits)
     False
     >>> # do something
-    >>> limits_stop_at(LocalPath("/path/to/file.csv"), limits)
+    >>> limits_stop_at(LocalPath("/path/to/file1.csv"), limits)
+    False
+    >>> limits_stop_at(LocalPath("/path/to/file2.csv"), limits)
     True
     >>> limits_reached(limits)
     True

--- a/onetl/file/limit/total_files_size.py
+++ b/onetl/file/limit/total_files_size.py
@@ -85,4 +85,4 @@ class TotalFilesSize(BaseFileLimit, FrozenModel):
 
     @property
     def is_reached(self) -> bool:
-        return self._handled >= self.limit
+        return self._handled > self.limit

--- a/tests/tests_integration/tests_core_integration/test_file_downloader_integration.py
+++ b/tests/tests_integration/tests_core_integration/test_file_downloader_integration.py
@@ -790,7 +790,7 @@ def test_file_downloader_run_input_is_not_file(request, file_connection, tmp_pat
         downloader.run([not_a_file])
 
 
-def test_file_downloader_with_file_limit(file_connection_with_path_and_files, tmp_path_factory, caplog):
+def test_file_downloader_with_limit(file_connection_with_path_and_files, tmp_path_factory, caplog):
     file_connection, remote_path, _ = file_connection_with_path_and_files
     limit = 2
     local_path = tmp_path_factory.mktemp("local_path")
@@ -814,7 +814,7 @@ def test_file_downloader_with_file_limit(file_connection_with_path_and_files, tm
     assert len(download_result.successful) == limit
 
 
-def test_file_downloader_file_limit_is_ignored_by_user_input(
+def test_file_downloader_limit_is_ignored_by_user_input(
     file_connection_with_path_and_files,
     tmp_path_factory,
 ):

--- a/tests/tests_unit/test_file/test_file_limit_unit.py
+++ b/tests/tests_unit/test_file/test_file_limit_unit.py
@@ -44,10 +44,10 @@ def test_file_limit():
     assert not file_limit.stops_at(directory)
     assert not file_limit.is_reached
 
-    # limit is reached - all check are True, input does not matter
-    assert file_limit.stops_at(file3)
-    assert file_limit.is_reached
+    assert not file_limit.stops_at(file3)
+    assert not file_limit.is_reached
 
+    # limit is reached - all check are True, input does not matter
     assert file_limit.stops_at(file4)
     assert file_limit.is_reached
 
@@ -64,5 +64,8 @@ def test_file_limit():
     assert not file_limit.stops_at(file1)
     assert not file_limit.is_reached
 
-    assert file_limit.stops_at(file1)
+    assert not file_limit.stops_at(file2)
+    assert not file_limit.is_reached
+
+    assert file_limit.stops_at(file3)
     assert file_limit.is_reached

--- a/tests/tests_unit/test_file/test_limit/test_limits_are_reached.py
+++ b/tests/tests_unit/test_file/test_limit/test_limits_are_reached.py
@@ -18,6 +18,9 @@ def test_limits_reached(caplog):
     assert not limit1.stops_at(file)
     assert not limits_reached(limits)
 
+    assert not limit1.stops_at(file)
+    assert not limits_reached(limits)
+
     # limit is reached - all check are True, input does not matter
     with caplog.at_level(logging.DEBUG):
         assert limit1.stops_at(file)

--- a/tests/tests_unit/test_file/test_limit/test_limits_stop_at.py
+++ b/tests/tests_unit/test_file/test_limit/test_limits_stop_at.py
@@ -19,6 +19,10 @@ def test_limits_stop_at(caplog):
     assert not limit1.is_reached
     assert not limit2.is_reached
 
+    assert not limits_stop_at(file, limits)
+    assert not limit1.is_reached
+    assert not limit2.is_reached
+
     # limit is reached - all check are True, input does not matter
     with caplog.at_level(logging.DEBUG):
         assert limits_stop_at(file, limits)

--- a/tests/tests_unit/test_file/test_limit/test_max_files_count.py
+++ b/tests/tests_unit/test_file/test_limit/test_max_files_count.py
@@ -36,10 +36,10 @@ def test_max_files_count():
     assert not limit.stops_at(directory)
     assert not limit.is_reached
 
-    # limit is reached - all check are True, input does not matter
-    assert limit.stops_at(file3)
-    assert limit.is_reached
+    assert not limit.stops_at(file3)
+    assert not limit.is_reached
 
+    # limit is reached - all check are True, input does not matter
     assert limit.stops_at(file4)
     assert limit.is_reached
 
@@ -56,5 +56,8 @@ def test_max_files_count():
     assert not limit.stops_at(file1)
     assert not limit.is_reached
 
-    assert limit.stops_at(file1)
+    assert not limit.stops_at(file3)
+    assert not limit.is_reached
+
+    assert limit.stops_at(file4)
     assert limit.is_reached

--- a/tests/tests_unit/test_file/test_limit/test_reset_limits.py
+++ b/tests/tests_unit/test_file/test_limit/test_reset_limits.py
@@ -9,7 +9,7 @@ def test_reset_limits():
 
     file = RemoteFile(path="file1.csv", stats=RemotePathStat(st_size=10 * 1024, st_mtime=50))
 
-    for _ in range(3):
+    for _ in range(4):
         limit1.stops_at(file)
         limit2.stops_at(file)
 

--- a/tests/tests_unit/test_file/test_limit/test_total_files_size.py
+++ b/tests/tests_unit/test_file/test_limit/test_total_files_size.py
@@ -77,5 +77,5 @@ def test_total_files_size():
     assert not limit.stops_at(file1)
     assert not limit.is_reached
 
-    assert limit.stops_at(file1)
+    assert limit.stops_at(file3)
     assert limit.is_reached


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

After thinking on https://github.com/MobileTeleSystems/onetl/pull/326#pullrequestreview-2546569010, I've desided that `FileConnection.walk` and `FileConnection.listdir` implementation should be changed.

Previously: iterate over all files in the directory, include file to resulting list, stop if limit is reached.
Now: iterate over all files in the directory, check if limit is reached, include file only if it is not.

This is because if user have files list:
* file1.txt (10KB)
* file2.txt (20KB)
* file3.txt (30KB)

and set limit `TotalFileSize("15KB")`, FileDownloader/FileMover should download only file1.txt and skip both file2.txt and file3.txt (because 10KB+20KB already exceeds the limit of 15KB). Previous implementation lead to downloading file2.txt (as limit internal stage recorded 10KB which is less than the limit), and skipping only file3.txt.

This is a possibly breaking change for developers of custom file limits, as now `.is_reached` should return `True` after limit is reached, and not before.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
