### PR TITLE
[DOP-22130] Add support for FileModifiedTimeHWM

### DIFF
--- a/docs/changelog/next_release/331.dependency.rst
+++ b/docs/changelog/next_release/331.dependency.rst
@@ -1,0 +1,1 @@
+Minimal ``etl-entities`` version is now `2.5.0 <https://github.com/MobileTeleSystems/etl-entities/releases/tag/2.5.0>`_.

--- a/onetl/connection/file_connection/s3.py
+++ b/onetl/connection/file_connection/s3.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import io
 import os
 import textwrap
+from contextlib import suppress
 from logging import getLogger
 from typing import Optional
 
@@ -203,16 +204,14 @@ class S3(FileConnection):
     def _get_stat(self, path: RemotePath) -> RemotePathStat:
         path_str = self._delete_absolute_path_slash(path)
 
-        try:
-            stat = self.client.stat_object(self.bucket, path_str)
-            return RemotePathStat(
-                st_size=stat.size or 0,
-                st_mtime=stat.last_modified.timestamp() if stat.last_modified else None,
-                st_uid=stat.owner_name or stat.owner_id,
-            )
+        with suppress(Exception):
+            # for some reason, client.stat_object returns less precise st_mtime than client.list_objects
+            objects = self.client.list_objects(self.bucket, prefix=path_str)
+            for obj in objects:
+                if obj.object_name == path_str:
+                    return self._extract_stat_from_entry(path.parent, obj)
 
-        except Exception:  # noqa: B001,E722
-            return RemotePathStat()
+        return RemotePathStat()
 
     def _remove_file(self, remote_file_path: RemotePath) -> None:
         path_str = self._delete_absolute_path_slash(remote_file_path)

--- a/onetl/file/file_downloader/file_downloader.py
+++ b/onetl/file/file_downloader/file_downloader.py
@@ -206,7 +206,7 @@ class FileDownloader(FrozenModel):
         # and stop before downloading 101 file
         downloader.run()
 
-    Incremental download:
+    Incremental download (by tracking list of file paths):
 
     .. code:: python
 
@@ -222,12 +222,37 @@ class FileDownloader(FrozenModel):
             connection=sftp,
             source_path="/path/to/remote/source",
             local_path="/path/to/local",
-            hwm=FileListHWM(
-                name="my_unique_hwm_name", directory="/path/to/remote/source"
-            ),  # mandatory for IncrementalStrategy
+            hwm=FileListHWM(  # mandatory for IncrementalStrategy
+                name="my_unique_hwm_name",
+            ),
         )
 
-        # download files to "/path/to/local", but only new ones
+        # download files to "/path/to/local", but only added since previous run
+        with IncrementalStrategy():
+            downloader.run()
+
+    Incremental download (by tracking file modification time):
+
+    .. code:: python
+
+        from onetl.connection import SFTP
+        from onetl.file import FileDownloader
+        from onetl.strategy import IncrementalStrategy
+        from etl_entities.hwm import FileModifiedTimeHWM
+
+        sftp = SFTP(...)
+
+        # create downloader
+        downloader = FileDownloader(
+            connection=sftp,
+            source_path="/path/to/remote/source",
+            local_path="/path/to/local",
+            hwm=FileModifiedTimeHWM(  # mandatory for IncrementalStrategy
+                name="my_unique_hwm_name",
+            ),
+        )
+
+        # download files to "/path/to/local", but only modified/created since previous run
         with IncrementalStrategy():
             downloader.run()
 

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -1,4 +1,4 @@
-etl-entities>=2.2,<2.5
+etl-entities>=2.5,<2.6
 evacuator>=1.0,<1.1
 frozendict
 humanize

--- a/tests/fixtures/hwm_delta.py
+++ b/tests/fixtures/hwm_delta.py
@@ -1,65 +1,96 @@
 import secrets
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 
 import pytest
-from etl_entities.hwm import ColumnDateHWM, ColumnDateTimeHWM, ColumnIntHWM, FileListHWM
-
-
-@pytest.fixture(
-    params=[
-        (
-            ColumnIntHWM(
-                name=secrets.token_hex(5),
-                # no source
-                expression=secrets.token_hex(5),
-                value=10,
-            ),
-            5,
-        ),
-        (
-            ColumnIntHWM(
-                name=secrets.token_hex(5),
-                source=secrets.token_hex(5),
-                expression=secrets.token_hex(5),
-                value=10,
-            ),
-            5,
-        ),
-        (
-            ColumnDateHWM(
-                name=secrets.token_hex(5),
-                source=secrets.token_hex(5),
-                expression=secrets.token_hex(5),
-                value=date(year=2023, month=8, day=15),
-            ),
-            timedelta(days=31),
-        ),
-        (
-            ColumnDateTimeHWM(
-                name=secrets.token_hex(5),
-                source=secrets.token_hex(5),
-                expression=secrets.token_hex(5),
-                value=datetime(year=2023, month=8, day=15, hour=11, minute=22, second=33),
-            ),
-            timedelta(seconds=50),
-        ),
-        (
-            FileListHWM(
-                name=secrets.token_hex(5),
-                # not directory
-                value=["/some/path", "/another.file"],
-            ),
-            "/third.file",
-        ),
-        (
-            FileListHWM(
-                name=secrets.token_hex(5),
-                directory="/absolute/path",
-                value=["/absolute/path/file1", "/absolute/path/file2"],
-            ),
-            "/absolute/path/file3",
-        ),
-    ],
+from etl_entities.hwm import (
+    ColumnDateHWM,
+    ColumnDateTimeHWM,
+    ColumnIntHWM,
+    FileListHWM,
+    FileModifiedTimeHWM,
 )
+
+from onetl.impl.remote_file import RemoteFile
+from onetl.impl.remote_path import RemotePath
+from onetl.impl.remote_path_stat import RemotePathStat
+
+
+def file_with_mtime(mtime: datetime) -> RemoteFile:
+    return RemoteFile(path=RemotePath(secrets.token_hex(5)), stats=RemotePathStat(st_mtime=mtime.timestamp()))
+
+
+HWMS_WITH_VALUE = [
+    (
+        ColumnIntHWM(
+            name=secrets.token_hex(5),
+            # no source
+            expression=secrets.token_hex(5),
+            value=10,
+        ),
+        5,
+    ),
+    (
+        ColumnIntHWM(
+            name=secrets.token_hex(5),
+            source=secrets.token_hex(5),
+            expression=secrets.token_hex(5),
+            value=10,
+        ),
+        5,
+    ),
+    (
+        ColumnDateHWM(
+            name=secrets.token_hex(5),
+            source=secrets.token_hex(5),
+            expression=secrets.token_hex(5),
+            value=date(year=2023, month=8, day=15),
+        ),
+        timedelta(days=31),
+    ),
+    (
+        ColumnDateTimeHWM(
+            name=secrets.token_hex(5),
+            source=secrets.token_hex(5),
+            expression=secrets.token_hex(5),
+            value=datetime(year=2023, month=8, day=15, hour=11, minute=22, second=33),
+        ),
+        timedelta(seconds=50),
+    ),
+    (
+        FileListHWM(
+            name=secrets.token_hex(5),
+            # not directory
+            value=["/some/path", "/another.file"],
+        ),
+        "/third.file",
+    ),
+    (
+        FileListHWM(
+            name=secrets.token_hex(5),
+            directory="/absolute/path",
+            value=["/absolute/path/file1", "/absolute/path/file2"],
+        ),
+        "/absolute/path/file3",
+    ),
+    (
+        FileModifiedTimeHWM(
+            name=secrets.token_hex(5),
+            # no directory
+            value=datetime(2025, 1, 1, 11, 22, 33, 456789, tzinfo=timezone.utc),
+        ),
+        file_with_mtime(datetime(2025, 1, 1, 22, 33, 44, 567890, tzinfo=timezone.utc)),
+    ),
+    (
+        FileModifiedTimeHWM(
+            name=secrets.token_hex(5),
+            directory="/absolute/path",
+            value=datetime(2025, 1, 1, 11, 22, 33, 456789, tzinfo=timezone.utc),
+        ),
+        file_with_mtime(datetime(2025, 1, 1, 22, 33, 44, 567890, tzinfo=timezone.utc)),
+    ),
+]
+
+
+@pytest.fixture(params=HWMS_WITH_VALUE)
 def hwm_delta(request):
     return request.param

--- a/tests/tests_integration/tests_core_integration/test_file_downloader_integration.py
+++ b/tests/tests_integration/tests_core_integration/test_file_downloader_integration.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 from pathlib import Path, PurePosixPath
 
 import pytest
-from etl_entities.hwm import FileListHWM
+from etl_entities.hwm import FileListHWM, FileModifiedTimeHWM
 
 from onetl.exception import DirectoryNotFoundError, NotAFileError
 from onetl.file import FileDownloader
@@ -25,6 +25,8 @@ from onetl.strategy import (
     IncrementalStrategy,
     SnapshotBatchStrategy,
 )
+
+SUPPORTED_HWM_TYPES = [FileListHWM, FileModifiedTimeHWM]
 
 
 def test_file_downloader_view_file(file_connection_with_path_and_files):
@@ -978,9 +980,11 @@ def test_file_downloader_limit_applied_after_filter(file_connection_with_path_an
     assert len(download_result.successful) == 1
 
 
+@pytest.mark.parametrize("hwm_type", SUPPORTED_HWM_TYPES)
 def test_file_downloader_detect_hwm_type_snapshot_batch_strategy(
     file_connection_with_path,
     tmp_path_factory,
+    hwm_type,
 ):
     file_connection, remote_path = file_connection_with_path
     local_path = tmp_path_factory.mktemp("local_path")
@@ -989,7 +993,7 @@ def test_file_downloader_detect_hwm_type_snapshot_batch_strategy(
         connection=file_connection,
         local_path=local_path,
         source_path=remote_path,
-        hwm=FileListHWM(name=secrets.token_hex(5)),
+        hwm=hwm_type(name=secrets.token_hex(5)),
     )
 
     error_message = "FileDownloader(hwm=...) cannot be used with SnapshotBatchStrategy"
@@ -998,9 +1002,11 @@ def test_file_downloader_detect_hwm_type_snapshot_batch_strategy(
             downloader.run()
 
 
+@pytest.mark.parametrize("hwm_type", SUPPORTED_HWM_TYPES)
 def test_file_downloader_detect_hwm_type_incremental_batch_strategy(
     file_connection_with_path,
     tmp_path_factory,
+    hwm_type,
 ):
     file_connection, remote_path = file_connection_with_path
     local_path = tmp_path_factory.mktemp("local_path")
@@ -1009,7 +1015,7 @@ def test_file_downloader_detect_hwm_type_incremental_batch_strategy(
         connection=file_connection,
         local_path=local_path,
         source_path=remote_path,
-        hwm=FileListHWM(name=secrets.token_hex(5)),
+        hwm=hwm_type(name=secrets.token_hex(5)),
     )
 
     error_message = "FileDownloader(hwm=...) cannot be used with IncrementalBatchStrategy"
@@ -1020,10 +1026,11 @@ def test_file_downloader_detect_hwm_type_incremental_batch_strategy(
             downloader.run()
 
 
+@pytest.mark.parametrize("hwm_type", SUPPORTED_HWM_TYPES)
 def test_file_downloader_detect_hwm_type_snapshot_strategy(
     file_connection_with_path,
     tmp_path_factory,
-    caplog,
+    hwm_type,
 ):
     file_connection, remote_path = file_connection_with_path
     local_path = tmp_path_factory.mktemp("local_path")
@@ -1032,7 +1039,7 @@ def test_file_downloader_detect_hwm_type_snapshot_strategy(
         connection=file_connection,
         local_path=local_path,
         source_path=remote_path,
-        hwm=FileListHWM(name=secrets.token_hex(5)),
+        hwm=hwm_type(name=secrets.token_hex(5)),
     )
 
     error_message = "FileDownloader(hwm=...) cannot be used with SnapshotStrategy"
@@ -1040,10 +1047,11 @@ def test_file_downloader_detect_hwm_type_snapshot_strategy(
         downloader.run()
 
 
+@pytest.mark.parametrize("hwm_type", SUPPORTED_HWM_TYPES)
 def test_file_downloader_file_hwm_strategy_with_wrong_parameters(
     file_connection_with_path_and_files,
     tmp_path_factory,
-    caplog,
+    hwm_type,
 ):
     file_connection, remote_path, _ = file_connection_with_path_and_files
     local_path = tmp_path_factory.mktemp("local_path")
@@ -1052,7 +1060,7 @@ def test_file_downloader_file_hwm_strategy_with_wrong_parameters(
         connection=file_connection,
         local_path=local_path,
         source_path=remote_path,
-        hwm=FileListHWM(name=secrets.token_hex(5)),
+        hwm=hwm_type(name=secrets.token_hex(5)),
     )
 
     error_message = "FileDownloader(hwm=...) cannot be used with IncrementalStrategy(offset=1, ...)"
@@ -1064,9 +1072,11 @@ def test_file_downloader_file_hwm_strategy_with_wrong_parameters(
         downloader.run()
 
 
+@pytest.mark.parametrize("hwm_type", SUPPORTED_HWM_TYPES)
 def test_file_downloader_file_hwm_strategy(
     file_connection_with_path_and_files,
     tmp_path_factory,
+    hwm_type,
 ):
     file_connection, remote_path, _ = file_connection_with_path_and_files
     local_path = tmp_path_factory.mktemp("local_path")
@@ -1075,10 +1085,11 @@ def test_file_downloader_file_hwm_strategy(
         connection=file_connection,
         local_path=local_path,
         source_path=remote_path,
-        hwm=FileListHWM(name=secrets.token_hex(5)),
+        hwm=hwm_type(name=secrets.token_hex(5)),
     )
 
     with IncrementalStrategy():
+        # no errors, everything is fine
         downloader.run()
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

<!-- Please give a short summary of the changes. -->

Updated minimal `etl-entities` version to 2.5.0. Added tests and docstrings using new class `FileModifiedTimeHWM`.

Note that currently used FTP client calls method `LIST` which [returns `st_mtime` trucated to whole minutes](https://blog.rebex.net/file-modification-date-and-time-in-ftp) (not even seconds), so FTP/FTPS tests with FileModifiedTimeHWM are skipped for now.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [x] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
