### PR TITLE
[DOP-22427] Do not keep open JDBC connection on Spark driver

### DIFF
--- a/docs/changelog/next_release/334.feature.rst
+++ b/docs/changelog/next_release/334.feature.rst
@@ -1,0 +1,6 @@
+Since now all JDBC connections opened by ``connection.fetch(...)``, ``connection.execute(...)`` or ``connection.check()``
+are immediately closed after the statements is executed.
+
+Previously Spark session with ``master=local[1]`` opened 3 connections to target DB - one for ``.check()``,
+another for Spark driver interaction with DB to create tables, and last one for Spark executor. Now only 2 connections are opened.
+This is important for RDBMS like Postgres or Greenplum where number of connections is strictly limited and limit is usually quite low.

--- a/onetl/connection/db_connection/greenplum/connection.py
+++ b/onetl/connection/db_connection/greenplum/connection.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 import logging
 import os
 import textwrap
-import threading
 import warnings
-from typing import TYPE_CHECKING, Any, ClassVar, Optional
+from typing import TYPE_CHECKING, Any, ClassVar
 from urllib.parse import quote, urlencode, urlparse, urlunparse
 
 from etl_entities.instance import Host
@@ -15,9 +14,9 @@ from etl_entities.instance import Host
 from onetl.connection.db_connection.jdbc_connection.options import JDBCReadOptions
 
 try:
-    from pydantic.v1 import PrivateAttr, SecretStr, validator
+    from pydantic.v1 import SecretStr, validator
 except (ImportError, AttributeError):
-    from pydantic import validator, SecretStr, PrivateAttr  # type: ignore[no-redef, assignment]
+    from pydantic import validator, SecretStr  # type: ignore[no-redef, assignment]
 
 from onetl._util.classproperty import classproperty
 from onetl._util.java import try_import_java_class
@@ -182,7 +181,6 @@ class Greenplum(JDBCMixin, DBConnection):  # noqa: WPS338
     CONNECTIONS_EXCEPTION_LIMIT: ClassVar[int] = 100
 
     _CHECK_QUERY: ClassVar[str] = "SELECT 1"
-    _last_connection_and_options: Optional[threading.local] = PrivateAttr(default=None)
 
     @slot
     @classmethod

--- a/onetl/connection/db_connection/jdbc_connection/connection.py
+++ b/onetl/connection/db_connection/jdbc_connection/connection.py
@@ -4,14 +4,13 @@ from __future__ import annotations
 
 import logging
 import secrets
-import threading
 import warnings
-from typing import TYPE_CHECKING, Any, ClassVar, Optional
+from typing import TYPE_CHECKING, Any, ClassVar
 
 try:
-    from pydantic.v1 import PrivateAttr, SecretStr, validator
+    from pydantic.v1 import SecretStr, validator
 except (ImportError, AttributeError):
-    from pydantic import PrivateAttr, SecretStr, validator  # type: ignore[no-redef, assignment]
+    from pydantic import SecretStr, validator  # type: ignore[no-redef, assignment]
 
 from onetl._util.java import try_import_java_class
 from onetl._util.spark import override_job_description
@@ -65,7 +64,6 @@ class JDBCConnection(JDBCMixin, DBConnection):  # noqa: WPS338
 
     DRIVER: ClassVar[str]
     _CHECK_QUERY: ClassVar[str] = "SELECT 1"
-    _last_connection_and_options: Optional[threading.local] = PrivateAttr(default=None)
 
     JDBCOptions = JDBCMixinOptions
     FetchOptions = JDBCFetchOptions


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Do not keep open JDBC connection as thread-local object attribute. Instead, open connection, execute statement, load result into Spark (if any) and then close connection immediately. This keeps the number of opened DB connections as low as possible, which is crucial for PG/GP.
This may increase the time of each statement being executed, but as I see, tests took just the same time as in `develop` branch.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
