### PR TITLE
[DOP-23742] Fix writing to Postgres and Greenplum behind PGBouncer

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -5,7 +5,7 @@ ONETL_GP_HOST=greenplum
 ONETL_GP_PORT=5432
 ONETL_GP_DATABASE=postgres
 ONETL_GP_USER=gpadmin
-ONETL_GP_PASSWORD=
+ONETL_GP_PASSWORD=123UsedForTestOnly@!
 
 # ClickHouse
 ONETL_CH_HOST=clickhouse

--- a/.env.local
+++ b/.env.local
@@ -5,7 +5,7 @@ export ONETL_GP_HOST=localhost
 export ONETL_GP_PORT=5433
 export ONETL_GP_DATABASE=postgres
 export ONETL_GP_USER=gpadmin
-export ONETL_GP_PASSWORD=
+export ONETL_GP_PASSWORD=123UsedForTestOnly@!
 
 # ClickHouse
 export ONETL_CH_HOST=localhost

--- a/.github/workflows/test-greenplum.yml
+++ b/.github/workflows/test-greenplum.yml
@@ -47,6 +47,19 @@ jobs:
           - 5433:5432
         # TODO: remove after https://github.com/andruche/docker-greenplum/pull/2
         options: --sysctl net.ipv6.conf.all.disable_ipv6=1
+      pgbouncer-transaction-gp:
+        image: bitnami/pgbouncer:latest
+        env:
+          TZ: UTC
+          PGBOUNCER_DATABASE: postgres
+          PGBOUNCER_POOL_MODE: transaction
+          POSTGRESQL_HOST: greenplum
+          POSTGRESQL_PORT: 5432
+          POSTGRESQL_DATABASE: postgres
+          POSTGRESQL_USERNAME: gpadmin
+          POSTGRESQL_PASSWORD: 123UsedForTestOnly@!
+        ports:
+          - 6433:6432
 
     steps:
       - name: Checkout code
@@ -118,11 +131,24 @@ jobs:
           GREENPLUM_PACKAGES_USER: ${{ secrets.GREENPLUM_PACKAGES_USER }}
           GREENPLUM_PACKAGES_PASSWORD: ${{ secrets.GREENPLUM_PACKAGES_PASSWORD }}
 
+      - name: Run tests with PGBouncer
+        run: |
+          mkdir reports/ || echo "Directory exists"
+          sed '/^$/d' ./.env.local | sed '/^#/d' | sed 's/^/export /' > ./env
+          source ./env
+          export ONETL_GP_PACKAGE_VERSION=${{ inputs.package-version }}
+          export ONETL_GP_PORT=6433
+          # Run only some basic tests
+          ./pytest_runner.sh -m greenplum  -k "tests_core_integration or tests_db_connection_integration"
+        env:
+          GREENPLUM_PACKAGES_USER: ${{ secrets.GREENPLUM_PACKAGES_USER }}
+          GREENPLUM_PACKAGES_PASSWORD: ${{ secrets.GREENPLUM_PACKAGES_PASSWORD }}
+
       - name: Dump Greenplum logs on failure
         if: failure()
         uses: jwalton/gh-docker-logs@v2
         with:
-          images: andruche/greenplum
+          images: andruche/greenplum,bitnami/pgbouncer
           dest: ./logs
 
       - name: Upload Greenplum logs

--- a/.github/workflows/test-postgres.yml
+++ b/.github/workflows/test-postgres.yml
@@ -39,6 +39,19 @@ jobs:
           POSTGRES_PASSWORD: 123UsedForTestOnly@!
         ports:
           - 5432:5432
+      pgbouncer-transaction-pg:
+        image: bitnami/pgbouncer:latest
+        env:
+          TZ: UTC
+          PGBOUNCER_DATABASE: onetl
+          PGBOUNCER_POOL_MODE: transaction
+          POSTGRESQL_HOST: postgres
+          POSTGRESQL_PORT: 5432
+          POSTGRESQL_DATABASE: onetl
+          POSTGRESQL_USERNAME: onetl
+          POSTGRESQL_PASSWORD: 123UsedForTestOnly@!
+        ports:
+          - 6432:6432
 
     steps:
       - name: Checkout code
@@ -89,11 +102,20 @@ jobs:
           source ./env
           ./pytest_runner.sh -m postgres
 
+      - name: Run tests with PGBouncer
+        run: |
+          mkdir reports/ || echo "Directory exists"
+          sed '/^$/d' ./.env.local | sed '/^#/d' | sed 's/^/export /' > ./env
+          source ./env
+          export ONETL_PG_PORT=6432
+          # Run only some basic tests
+          ./pytest_runner.sh -m postgres  -k "tests_core_integration or tests_db_connection_integration"
+
       - name: Dump Postgres logs on failure
         if: failure()
         uses: jwalton/gh-docker-logs@v2
         with:
-          images: postgres
+          images: postgres,bitnami/pgbouncer
           dest: ./logs
 
       - name: Upload Postgres logs

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -110,13 +110,13 @@ Start all containers with dependencies:
 
 .. code:: bash
 
-    docker-compose up -d
+    docker-compose --profile all up -d
 
 You can run limited set of dependencies:
 
 .. code:: bash
 
-    docker-compose up -d mongodb
+    docker-compose --profile mongodb up -d
 
 Run tests:
 
@@ -148,7 +148,7 @@ Stop all containers and remove created volumes:
 
 .. code:: bash
 
-    docker-compose down -v
+    docker-compose --profile all down -v
 
 Without docker-compose
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -189,13 +189,13 @@ Start all containers with dependencies:
 
 .. code:: bash
 
-    docker-compose up -d
+    docker-compose --profile all up -d
 
 You can run limited set of dependencies:
 
 .. code:: bash
 
-    docker-compose up -d mongodb
+    docker-compose --profile mongodb up -d
 
 Load environment variables with connection properties:
 
@@ -219,7 +219,7 @@ Stop all containers and remove created volumes:
 
 .. code:: bash
 
-    docker-compose down -v
+    docker-compose --profile all down -v
 
 
 Build documentation

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
         soft: 10000
         hard: 10000
     # no dependencies from other containers to allow running limited set of tests instead of all
+    profiles: [onetl]
 
   greenplum:
     image: ${GREENPLUM_IMAGE:-andruche/greenplum:6}
@@ -37,6 +38,25 @@ services:
     # TODO: remove after https://github.com/andruche/docker-greenplum/pull/2
     sysctls:
       - net.ipv6.conf.all.disable_ipv6=1
+    profiles: [greenplum, db, all]
+
+  pgbouncer-transaction-gp:
+    image: ${PGBOUNCER_IMAGE:-bitnami/pgbouncer:latest}
+    restart: unless-stopped
+    environment:
+      TZ: UTC
+      PGBOUNCER_DATABASE: postgres
+      PGBOUNCER_POOL_MODE: transaction
+      POSTGRESQL_HOST: greenplum
+      POSTGRESQL_PORT: 5432
+      POSTGRESQL_DATABASE: postgres
+      POSTGRESQL_USERNAME: gpadmin
+      POSTGRESQL_PASSWORD: 123UsedForTestOnly@!
+    ports:
+      - 6433:6432
+    networks:
+      - onetl
+    profiles: [greenplum, db, all]
 
   clickhouse:
     image: ${CLICKHOUSE_IMAGE:-clickhouse/clickhouse-server:latest-alpine}
@@ -55,6 +75,7 @@ services:
       - onetl
     sysctls:
       - net.ipv6.conf.all.disable_ipv6=1
+    profiles: [clickhouse, jdbc, db, all]
 
   zookeeper:
     image: ${ZOOKEEPER_IMAGE:-bitnami/zookeeper:3.8}
@@ -70,6 +91,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    profiles: [kafka, db, all]
 
   kafka:
     image: ${KAFKA_IMAGE:-bitnami/kafka:latest}
@@ -101,6 +123,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    profiles: [kafka, db, all]
 
   mongodb:
     image: ${MONGODB_IMAGE:-mongo:latest}
@@ -113,6 +136,7 @@ services:
       MONGO_INITDB_ROOT_PASSWORD: 123UsedForTestOnly@!
     networks:
       - onetl
+    profiles: [mongodb, db, all]
 
   mssql:
     image: ${MSSQL_IMAGE:-mcr.microsoft.com/mssql/server:latest}
@@ -136,6 +160,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    profiles: [mssql, jdbc, db, all]
 
   mysql:
     image: ${MYSQL_IMAGE:-mysql:latest}
@@ -151,6 +176,7 @@ services:
     networks:
       - onetl
     platform: linux/amd64
+    profiles: [mysql, jdbc, db, all]
 
   postgres:
     image: ${POSTGRES_IMAGE:-postgres:alpine}
@@ -164,6 +190,25 @@ services:
       - 5432:5432
     networks:
       - onetl
+    profiles: [postgres, jdbc, db, all]
+
+  pgbouncer-transaction-pg:
+    image: ${PGBOUNCER_IMAGE:-bitnami/pgbouncer:latest}
+    restart: unless-stopped
+    environment:
+      TZ: UTC
+      PGBOUNCER_DATABASE: onetl
+      PGBOUNCER_POOL_MODE: transaction
+      POSTGRESQL_HOST: postgres
+      POSTGRESQL_PORT: 5432
+      POSTGRESQL_DATABASE: onetl
+      POSTGRESQL_USERNAME: onetl
+      POSTGRESQL_PASSWORD: 123UsedForTestOnly@!
+    ports:
+      - 6432:6432
+    networks:
+      - onetl
+    profiles: [postgres, jdbc, db, all]
 
   hdfs:
     image: ${HDFS_IMAGE:-mtsrus/hadoop:hadoop2-hdfs}
@@ -179,6 +224,7 @@ services:
       - ./docker/hdfs/conf/hadoop/:/var/hadoop/conf/
     networks:
       - onetl
+    profiles: [hdfs, file_df, file, all]
 
   oracle:
     image: ${ORACLE_IMAGE:-gvenzl/oracle-free:23.3-slim-faststart}
@@ -198,6 +244,7 @@ services:
       timeout: 5s
       retries: 10
     platform: linux/amd64
+    profiles: [oracle, jdbc, db, all]
 
   ftp:
     image: ${FTP_IMAGE:-chonjay21/ftps:latest}
@@ -218,6 +265,7 @@ services:
       - ./docker/ftp/on_post_init.sh:/sources/ftps/eventscripts/on_post_init.sh
     networks:
       - onetl
+    profiles: [ftp, file, all]
 
   ftps:
     image: ${FTPS_IMAGE:-chonjay21/ftps:latest}
@@ -238,6 +286,7 @@ services:
       - ./docker/ftp/on_post_init.sh:/sources/ftps/eventscripts/on_post_init.sh
     networks:
       - onetl
+    profiles: [fts, file, all]
 
   samba:
     image: ${SAMBA_IMAGE:-elswork/samba}
@@ -252,6 +301,7 @@ services:
     entrypoint: ["/custom_entrypoint.sh"]
     networks:
       - onetl
+    profiles: [samba, file, all]
 
   s3:
     image: ${S3_IMAGE:-bitnami/minio:latest}
@@ -269,6 +319,7 @@ services:
       - 9011:9001
     networks:
       - onetl
+    profiles: [s3, file_df, file, all]
 
   sftp:
     image: ${SFTP_IMAGE:-linuxserver/openssh-server}
@@ -285,6 +336,7 @@ services:
       - 2222:2222
     networks:
       - onetl
+    profiles: [sftp, file, all]
 
   webdav:
     image: ${WEBDAV_IMAGE:-chonjay21/webdav:latest}
@@ -302,6 +354,7 @@ services:
       - ./docker/webdav/on_post_init.sh:/sources/webdav/eventscripts/on_post_init.sh
     networks:
       - onetl
+    profiles: [webdav, file, all]
 
 networks:
   onetl:

--- a/docs/changelog/next_release/336.bugfix.rst
+++ b/docs/changelog/next_release/336.bugfix.rst
@@ -1,0 +1,30 @@
+Fix using onETL to write data to PostgreSQL or Greenplum instances behind *pgbouncer* with ``pool_mode=transaction``.
+
+Previously ``connection.check()`` opened a read-only transaction, pgbouncer changed the entire connection type from read-write to read-only,
+and when ``DBWriter.run(df)`` executed in read-only connection, producing errors like:
+
+.. code::
+
+    org.postgresql.util.PSQLException: ERROR: cannot execute INSERT in a read-only transaction
+
+Added a workaround by passing ``readOnly=True`` to JDBC params for read-only connections, so pgbouncer may differ read-only and read-write connections properly.
+
+Note that this may affect behavior of ``connection.fetch("SELECT func()")`` if ``func()`` executes DML/DDL operations in the database, like ``INSERT`` or ``DROP``.
+Before 0.13.0 calling those functions raised an exception, but now it will not.
+
+This is because by default Postgres JDBC driver option ``readOnlyMode=transaction`` is applied only if ``autoCommit=False``, which is not the case here.
+To make truly read-only connection, use the following code:
+
+.. code:: python
+
+    postgres = Postgres(
+        host=...,
+        port=...,
+        database=...,
+        user=...,
+        password=...,
+        extra={"readOnly": True, "readOnlyMode": "always"},
+        spark=spark,
+    )
+
+See `Postgres JDBC driver documentation <https://jdbc.postgresql.org/documentation/use/>`_.

--- a/tests/tests_integration/tests_db_connection_integration/test_greenplum_integration.py
+++ b/tests/tests_integration/tests_db_connection_integration/test_greenplum_integration.py
@@ -895,11 +895,16 @@ def test_greenplum_connection_execute_function_ddl(
     table_finalizer()
 
     df = greenplum.execute(f"{{call {func}()}}")
+    result_df = pandas.DataFrame([[1]], columns=["result"])
     processing.assert_equal_df(df=df, other_frame=result_df)
+    table_finalizer()
 
-    # fetch is read-only
-    with pytest.raises(Exception):
-        greenplum.fetch(f"SELECT {func}() AS result")
+    # works with readOnlyMode=transaction, because autoCommit is true:
+    # https://jdbc.postgresql.org/documentation/use/
+    # fails with readOnlyMode=always, but it is not compatible with pgbouncer
+    df = greenplum.fetch(f"SELECT {func}() AS result")
+    result_df = pandas.DataFrame([[1]], columns=["result"])
+    processing.assert_equal_df(df=df, other_frame=result_df)
 
 
 @pytest.mark.parametrize("suffix", ["", ";"])
@@ -952,6 +957,9 @@ def test_greenplum_connection_execute_function_dml(
     result_df = pandas.DataFrame([[1]], columns=["result"])
     processing.assert_equal_df(df=df, other_frame=result_df)
 
-    # fetch is read-only
-    with pytest.raises(Exception):
-        greenplum.fetch(f"SELECT {func}(1, 'abc') AS result")
+    # works with readOnlyMode=transaction, because autoCommit is true:
+    # https://jdbc.postgresql.org/documentation/use/
+    # fails with readOnlyMode=always, but it is not compatible with pgbouncer
+    df = greenplum.fetch(f"SELECT {func}(2, 'cde') AS result")
+    result_df = pandas.DataFrame([[2]], columns=["result"])
+    processing.assert_equal_df(df=df, other_frame=result_df)

--- a/tests/tests_integration/tests_db_connection_integration/test_postgres_integration.py
+++ b/tests/tests_integration/tests_db_connection_integration/test_postgres_integration.py
@@ -902,15 +902,20 @@ def test_postgres_connection_execute_function_ddl(
     table_finalizer()
 
     df = postgres.execute(f"{{call {func}()}}")
+    result_df = pandas.DataFrame([[1]], columns=["result"])
     processing.assert_equal_df(df=df, other_frame=result_df)
     table_finalizer()
 
-    # fetch is read-only
-    with pytest.raises(Exception):
-        postgres.fetch(f"SELECT {func}() AS result")
+    # works with readOnlyMode=transaction, because autoCommit is true:
+    # https://jdbc.postgresql.org/documentation/use/
+    # fails with readOnlyMode=always, but it is not compatible with pgbouncer
+    df = postgres.fetch(f"SELECT {func}() AS result")
+    result_df = pandas.DataFrame([[1]], columns=["result"])
+    processing.assert_equal_df(df=df, other_frame=result_df)
+    table_finalizer()
 
-    # unfortunately, we cannot pass read-only flag to spark.read.jdbc
     df = postgres.sql(f"SELECT {func}() AS result")
+    result_df = pandas.DataFrame([[1]], columns=["result"])
     processing.assert_equal_df(df=df, other_frame=result_df)
 
 
@@ -949,6 +954,7 @@ def test_postgres_connection_execute_function_dml(
         BEGIN
             INSERT INTO {table} VALUES(idd, text);
             RETURN idd;
+            COMMIT;
         END;
         $$ LANGUAGE PLPGSQL{suffix}
         """,
@@ -963,13 +969,15 @@ def test_postgres_connection_execute_function_dml(
     result_df = pandas.DataFrame([[1]], columns=["result"])
     processing.assert_equal_df(df=df, other_frame=result_df)
 
-    # fetch is read-only
-    with pytest.raises(Exception):
-        postgres.fetch(f"SELECT {func}(1, 'abc') AS result")
-
-    # unfortunately, we cannot pass read-only flag to spark.read.jdbc
-    df = postgres.sql(f"SELECT {func}(2, 'cde') AS result")
+    # works with readOnlyMode=transaction, because autoCommit is true:
+    # https://jdbc.postgresql.org/documentation/use/
+    # fails with readOnlyMode=always, but it is not compatible with pgbouncer
+    df = postgres.fetch(f"SELECT {func}(2, 'cde') AS result")
     result_df = pandas.DataFrame([[2]], columns=["result"])
+    processing.assert_equal_df(df=df, other_frame=result_df)
+
+    df = postgres.sql(f"SELECT {func}(3, 'def') AS result")
+    result_df = pandas.DataFrame([[3]], columns=["result"])
     processing.assert_equal_df(df=df, other_frame=result_df)
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Depends on #337.

Fixed issue with writing data to PG/GP instances behind pgbouncer with `pool_mode=transaction`, caused by https://github.com/pgjdbc/pgjdbc/issues/848. Added PGBouncer to docker-compose and CI workflows, running tests on PG/GP with and without PGBouncer.

Behavior is almost the same as before, except rare case of Postgres/Greenplum calling `connection.fetch("SELECT function()")` where `function` calls DML/DDL - previously this failed due to read-only connection, now it's not. This was sacrificed for pgbounce support.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [x] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
