### PR TITLE
[DOP-23742] Fix using conn.setReadOnly(...) for MySQL, MSSQL

### DIFF
--- a/docs/changelog/next_release/337.bugfix.rst
+++ b/docs/changelog/next_release/337.bugfix.rst
@@ -1,0 +1,4 @@
+Previously ``MSSQL.fetch(...)`` and ``MySQL.fetch(...)`` opened a read-write connection, despite documentation said that is should be read-only.
+Now this is fixed:
+* ``MSSQL.fetch(...)`` establishes connection with ``ApplicationIntent=ReadOnly``.
+* ``MySQL.fetch(...)`` calls ``SET SESSION TRANSACTION READ ONLY`` statement.

--- a/tests/tests_integration/tests_db_connection_integration/test_clickhouse_integration.py
+++ b/tests/tests_integration/tests_db_connection_integration/test_clickhouse_integration.py
@@ -132,6 +132,10 @@ def test_clickhouse_connection_fetch(spark, processing, load_table_data, suffix,
     with pytest.raises(Exception):
         clickhouse.fetch(f"SELEC 1{suffix}")
 
+    # fetch is always read-only
+    with pytest.raises(Exception):
+        clickhouse.fetch(f"DROP TABLE {table}{suffix}")
+
 
 @pytest.mark.parametrize("suffix", ["", ";"])
 def test_clickhouse_connection_execute_ddl(spark, processing, get_schema_table, suffix):

--- a/tests/tests_integration/tests_db_connection_integration/test_greenplum_integration.py
+++ b/tests/tests_integration/tests_db_connection_integration/test_greenplum_integration.py
@@ -92,6 +92,10 @@ def test_greenplum_connection_fetch(spark, processing, load_table_data, suffix):
     with pytest.raises(Exception):
         greenplum.fetch(f"SELEC 1{suffix}")
 
+    # fetch is read-only
+    with pytest.raises(Exception):
+        greenplum.fetch(f"DROP TABLE {table}{suffix}")
+
 
 @pytest.mark.parametrize("suffix", ["", ";"])
 def test_greenplum_connection_ddl(spark, processing, get_schema_table, suffix):

--- a/tests/tests_integration/tests_db_connection_integration/test_mssql_integration.py
+++ b/tests/tests_integration/tests_db_connection_integration/test_mssql_integration.py
@@ -131,6 +131,10 @@ def test_mssql_connection_fetch(spark, processing, load_table_data, suffix):
     with pytest.raises(Exception):
         mssql.fetch(f"SELEC 1{suffix}")
 
+    # fetch is always read-only
+    with pytest.raises(Exception):
+        mssql.fetch(f"DROP TABLE {table}{suffix}")
+
 
 @pytest.mark.parametrize("suffix", ["", ";"])
 def test_mssql_connection_execute_ddl(spark, processing, get_schema_table, suffix):

--- a/tests/tests_integration/tests_db_connection_integration/test_mysql_integration.py
+++ b/tests/tests_integration/tests_db_connection_integration/test_mysql_integration.py
@@ -130,6 +130,10 @@ def test_mysql_connection_fetch(spark, processing, load_table_data, suffix):
     with pytest.raises(Exception):
         mysql.fetch(f"SELEC 1{suffix}")
 
+    # fetch is always read-only
+    with pytest.raises(Exception):
+        mysql.fetch(f"DROP TABLE {table}{suffix}")
+
 
 @pytest.mark.parametrize("suffix", ["", ";"])
 def test_mysql_connection_execute_ddl(spark, processing, get_schema_table, suffix):

--- a/tests/tests_integration/tests_db_connection_integration/test_oracle_integration.py
+++ b/tests/tests_integration/tests_db_connection_integration/test_oracle_integration.py
@@ -132,6 +132,10 @@ def test_oracle_connection_fetch(spark, processing, load_table_data, suffix):
     filtered_df = table_df[table_df.ID_INT < 50]
     processing.assert_equal_df(df=df, other_frame=filtered_df, order_by="id_int")
 
+    # fetch is always read-only
+    with pytest.raises(Exception):
+        oracle.fetch(f"DROP TABLE {table}{suffix}")
+
     # not supported by JDBC, use SELECT * FROM v$tables
     with pytest.raises(Exception):
         oracle.fetch(f"SHOW TABLES{suffix}")

--- a/tests/tests_integration/tests_db_connection_integration/test_postgres_integration.py
+++ b/tests/tests_integration/tests_db_connection_integration/test_postgres_integration.py
@@ -113,9 +113,13 @@ def test_postgres_connection_fetch(spark, processing, load_table_data, suffix, c
     with pytest.raises(Exception):
         postgres.fetch(f"SELEC 1{suffix}")
 
+    # fetch is read-only
+    with pytest.raises(Exception):
+        postgres.fetch(f"DROP TABLE {table}{suffix}")
+
 
 @pytest.mark.parametrize("suffix", ["", ";"])
-def test_postgres_connection_ddl(spark, processing, get_schema_table, suffix):
+def test_postgres_connection_execute_ddl(spark, processing, get_schema_table, suffix):
     postgres = Postgres(
         host=processing.host,
         port=processing.port,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Some JDBC drivers respect `java_jdbc_connection.setReadOnly(...)` (Oracle, Clickhouse, Postgres, Greenplum), some don't (MySQL, MSSQL). Fixing this by adding few workarounds for these RDBMS.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
