### PR TITLE
[DOP-23797] Fix FileDownloader with several filters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.11
+  python: python3.12
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/docs/changelog/next_release/338.bugfix.rst
+++ b/docs/changelog/next_release/338.bugfix.rst
@@ -1,0 +1,1 @@
+Remove sorting of the filters collection in logging to avoid issues due to missing comparison methods. Now ``FileDownloader`` and ``FileMover`` work properly with several filters.

--- a/onetl/log.py
+++ b/onetl/log.py
@@ -380,7 +380,7 @@ def log_collection(
     nested_indent = " " * (BASE_LOG_INDENT + indent + 4)
     _log(logger, "%s%s = %s", base_indent, name, start_bracket, level=level, stacklevel=stacklevel)
 
-    for i, item in enumerate(sorted(collection), start=1):
+    for i, item in enumerate(collection, start=1):
         if max_items and i > max_items and level > logging.DEBUG:
             _log(
                 logger,


### PR DESCRIPTION
## Change Summary

- Removed sorting of the `filters` collection in logging to avoid issues due to missing comparison methods
- Added an integration test cases to validate behavior when multiple filters are passed to `FileDownloader(filters=[...])` and `FileMover(filters[...])`.

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
