### PR TITLE
[DOP-23968] Add .get_exlude_packages() to SparkS3 and Kafka

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -552,9 +552,11 @@ Read files directly from S3 path, convert them to dataframe, transform it and th
 
     # Initialize new SparkSession with Hadoop AWS libraries and Postgres driver loaded
     maven_packages = SparkS3.get_packages(spark_version="3.5.4") + Postgres.get_packages()
+    exclude_packages = SparkS3.get_exclude_packages()
     spark = (
         SparkSession.builder.appName("spark_app_onetl_demo")
         .config("spark.jars.packages", ",".join(maven_packages))
+        .config("spark.jars.excludes", ",".join(exclude_packages))
         .getOrCreate()
     )
 

--- a/docs/changelog/next_release/341.feature.rst
+++ b/docs/changelog/next_release/341.feature.rst
@@ -1,0 +1,18 @@
+Add ``SparkS3.get_exclude_packages()`` and ``Kafka.get_exclude_packages()`` methods.
+Using them allows to skip downloading dependencies not required by this specific connector, or which are already a part of Spark/PySpark:
+
+.. code:: python
+
+    from onetl.connection import SparkS3, Kafka
+
+    maven_packages = [
+        *SparkS3.get_packages(spark_version="3.5.4"),
+        *Kafka.get_packages(spark_version="3.5.4"),
+    ]
+    exclude_packages = SparkS3.get_exclude_packages() + Kafka.get_exclude_packages()
+    spark = (
+        SparkSession.builder.appName("spark_app_onetl_demo")
+        .config("spark.jars.packages", ",".join(maven_packages))
+        .config("spark.jars.excludes", ",".join(exclude_packages))
+        .getOrCreate()
+    )

--- a/docs/connection/db_connection/kafka/connection.rst
+++ b/docs/connection/db_connection/kafka/connection.rst
@@ -6,4 +6,4 @@ Kafka Connection
 .. currentmodule:: onetl.connection.db_connection.kafka.connection
 
 .. autoclass:: Kafka
-    :members: get_packages, check, close
+    :members: get_packages, get_packages, check, close

--- a/docs/connection/file_df_connection/spark_s3/connection.rst
+++ b/docs/connection/file_df_connection/spark_s3/connection.rst
@@ -6,4 +6,4 @@ Spark S3 Connection
 .. currentmodule:: onetl.connection.file_df_connection.spark_s3.connection
 
 .. autoclass:: SparkS3
-    :members: check, close, get_packages
+    :members: check, close, get_packages, get_packages

--- a/tests/fixtures/spark.py
+++ b/tests/fixtures/spark.py
@@ -121,12 +121,11 @@ def maven_packages(request):
 
 @pytest.fixture(scope="session")
 def excluded_packages():
-    # These packages are a part of org.apache.spark:spark-hadoop-cloud, but not used in tests
+    from onetl.connection import Kafka, SparkS3
+
     return [
-        "com.google.cloud.bigdataoss:gcs-connector",
-        "org.apache.hadoop:hadoop-aliyun",
-        "org.apache.hadoop:hadoop-azure-datalake",
-        "org.apache.hadoop:hadoop-azure",
+        *SparkS3.get_exclude_packages(),
+        *Kafka.get_exclude_packages(),
     ]
 
 

--- a/tests/tests_unit/test_db/test_db_reader_unit/test_greenplum_reader_unit.py
+++ b/tests/tests_unit/test_db/test_db_reader_unit/test_greenplum_reader_unit.py
@@ -46,7 +46,7 @@ def test_greenplum_reader_wrong_table_name(spark_mock):
         )
 
 
-def test_postgres_reader_hint_unsupported(spark_mock):
+def test_greenplum_reader_hint_unsupported(spark_mock):
     greenplum = Greenplum(host="some_host", user="user", database="database", password="passwd", spark=spark_mock)
 
     with pytest.raises(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

`SparkS3.get_packages()` and `Kafka.get_packages()` return list of packages with compile dependency on hadoop client packages which are already a part of Spark/PySpark bundle. Also, `SparkS3` uses `spark-cloud` package depending on lots of cloud clients, like GCP, Azure and so on, which are not required here.

Added `.get_exclude_packages()` method to both of these classes. Using `spark.jar.excludes` mechanism to tell Ivy2 that some transitive packages should be excluded.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [x] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
