### PR TITLE
[DOP-23969] Fix Greenplum parallel connections warning for master=local[N]

### DIFF
--- a/docs/changelog/next_release/342.bugfix.rst
+++ b/docs/changelog/next_release/342.bugfix.rst
@@ -1,0 +1,2 @@
+Fix a false warning about a lof of parallel connections to Grenplum is opened while using ``DBReader`` or ``DBWriter`` with ``SparkSession.Builder.master("local[N]")``,
+like ``local[1]``. This warning should be shown only if ``N > 30``.

--- a/tests/fixtures/spark_mock.py
+++ b/tests/fixtures/spark_mock.py
@@ -11,13 +11,26 @@ def spark_stopped():
     import pyspark
     from pyspark.sql import SparkSession
 
+    spark_conf = {}
+
+    spark_context = Mock()
+    spark_context.appName = "abc"
+    spark_context.applicationId = "local-123"
+    spark_context.getConf = Mock(return_value=spark_conf)
+    spark_context._gateway = Mock()
+
     spark = Mock(spec=SparkSession)
     spark.sparkContext = Mock()
     spark.sparkContext.appName = "abc"
     spark.sparkContext.applicationId = "local-123"
     spark.version = pyspark.__version__
-    spark._sc = Mock()
-    spark._sc._gateway = Mock()
+    spark.sparkContext = spark_context
+    spark._sc = spark_context
+    spark._conf = spark_conf
+
+    spark._jsc = Mock()
+    spark._jsc.sc = Mock()
+    spark._jsc.sc().isStopped = Mock(return_value=True)
     return spark
 
 
@@ -29,11 +42,23 @@ def spark_no_packages():
     import pyspark
     from pyspark.sql import SparkSession
 
+    spark_conf = {}
+
+    spark_context = Mock()
+    spark_context.appName = "abc"
+    spark_context.applicationId = "local-123"
+    spark_context.getConf = Mock(return_value=spark_conf)
+    spark_context._gateway = Mock()
+
     spark = Mock(spec=SparkSession)
     spark.sparkContext = Mock()
     spark.sparkContext.appName = "abc"
     spark.sparkContext.applicationId = "local-123"
     spark.version = pyspark.__version__
+    spark.sparkContext = spark_context
+    # no spark._sc
+    spark._conf = spark_conf
+
     spark._jsc = Mock()
     spark._jsc.sc = Mock()
     spark._jsc.sc().isStopped = Mock(return_value=False)
@@ -48,13 +73,23 @@ def spark_mock():
     import pyspark
     from pyspark.sql import SparkSession
 
+    spark_conf = {}
+
+    spark_context = Mock()
+    spark_context.appName = "abc"
+    spark_context.applicationId = "local-123"
+    spark_context.getConf = Mock(return_value=spark_conf)
+    spark_context._gateway = Mock()
+
     spark = Mock(spec=SparkSession)
     spark.sparkContext = Mock()
     spark.sparkContext.appName = "abc"
     spark.sparkContext.applicationId = "local-123"
     spark.version = pyspark.__version__
-    spark._sc = Mock()
-    spark._sc._gateway = Mock()
+    spark.sparkContext = spark_context
+    spark._sc = spark_context
+    spark._conf = spark_conf
+
     spark._jsc = Mock()
     spark._jsc.sc = Mock()
     spark._jsc.sc().isStopped = Mock(return_value=False)

--- a/tests/tests_unit/test_db/test_db_reader_unit/test_greenplum_reader_unit.py
+++ b/tests/tests_unit/test_db/test_db_reader_unit/test_greenplum_reader_unit.py
@@ -1,7 +1,14 @@
+import logging
+from unittest.mock import Mock
+
 import pytest
 
 from onetl.connection import Greenplum
+from onetl.connection.db_connection.greenplum.connection_limit import (
+    GreenplumConnectionLimit,
+)
 from onetl.db import DBReader
+from onetl.exception import TooManyParallelJobsError
 
 pytestmark = pytest.mark.greenplum
 
@@ -72,3 +79,291 @@ def test_greenplum_reader_wrong_where_type(spark_mock):
             where={"col1": 1},
             table="schema.table",
         )
+
+
+@pytest.mark.parametrize(
+    ["df_partitions", "spark_config"],
+    [
+        (30, {"spark.master": "local[200]"}),
+        (200, {"spark.master": "local[30]"}),
+        (30, {"spark.master": "yarn", "spark.executor.instances": 200, "spark.executor.cores": 1}),
+        (200, {"spark.master": "yarn", "spark.executor.instances": 30, "spark.executor.cores": 1}),
+        (30, {"spark.master": "yarn", "spark.executor.instances": 20, "spark.executor.cores": 10}),
+        (200, {"spark.master": "yarn", "spark.executor.instances": 3, "spark.executor.cores": 10}),
+        (
+            30,
+            {
+                "spark.master": "yarn",
+                "spark.dynamicAllocation.enabled": "true",
+                "spark.dynamicAllocation.maxExecutors": 20,
+                "spark.executor.cores": 10,
+            },
+        ),
+        (
+            200,
+            {
+                "spark.master": "yarn",
+                "spark.dynamicAllocation.enabled": "true",
+                "spark.dynamicAllocation.maxExecutors": 3,
+                "spark.executor.cores": 10,
+            },
+        ),
+        (
+            30,
+            {
+                "spark.master": "yarn",
+                "spark.dynamicAllocation.enabled": "true",
+                "spark.dynamicAllocation.maxExecutors": 20,
+                "spark.executor.cores": 5,
+                "spark.dynamicAllocation.executorAllocationRatio": 2,
+            },
+        ),
+        (
+            200,
+            {
+                "spark.master": "yarn",
+                "spark.dynamicAllocation.enabled": "true",
+                "spark.dynamicAllocation.maxExecutors": 3,
+                "spark.executor.cores": 5,
+                "spark.dynamicAllocation.executorAllocationRatio": 2,
+            },
+        ),
+    ],
+)
+def test_greenplum_reader_number_of_connections_less_than_warning_threshold(
+    mocker,
+    spark_mock,
+    caplog,
+    df_partitions,
+    spark_config,
+):
+    greenplum = Greenplum(host="some_host", user="user", database="database", password="passwd", spark=spark_mock)
+    mocker.patch.object(Greenplum, "check")
+    mocker.patch.object(Greenplum, "_get_connections_limits")
+    greenplum._get_connections_limits.return_value = GreenplumConnectionLimit(maximum=100, reserved=10, occupied=5)
+
+    reader = DBReader(
+        connection=greenplum,
+        table="schema.table",
+    )
+
+    conf = spark_mock.sparkContext.getConf()
+    conf.update(spark_config)
+
+    if "local" in conf["spark.master"]:
+        parallelism = conf["spark.master"].replace("local[", "").replace("]", "")
+        spark_mock.sparkContext.defaultParallelism = int(parallelism)
+
+    df = spark_mock.read.format().options().load()
+    df.rdd.getNumPartitions = Mock(return_value=df_partitions)
+
+    with caplog.at_level(logging.WARNING):
+        df = reader.run()
+
+    assert not caplog.records
+
+
+@pytest.mark.parametrize(
+    ["df_partitions", "spark_config", "parallel_connections"],
+    [
+        (31, {"spark.master": "local[200]"}, 31),
+        (200, {"spark.master": "local[31]"}, 31),
+        (99, {"spark.master": "local[200]"}, 99),
+        (200, {"spark.master": "local[99]"}, 99),
+        (31, {"spark.master": "yarn", "spark.executor.instances": 200, "spark.executor.cores": 1}, 31),
+        (200, {"spark.master": "yarn", "spark.executor.instances": 31, "spark.executor.cores": 1}, 31),
+        (99, {"spark.master": "yarn", "spark.executor.instances": 200, "spark.executor.cores": 1}, 99),
+        (200, {"spark.master": "yarn", "spark.executor.instances": 99, "spark.executor.cores": 1}, 99),
+        (31, {"spark.master": "yarn", "spark.executor.instances": 20, "spark.executor.cores": 10}, 31),
+        (200, {"spark.master": "yarn", "spark.executor.instances": 4, "spark.executor.cores": 10}, 40),
+        (
+            31,
+            {
+                "spark.master": "yarn",
+                "spark.dynamicAllocation.enabled": "true",
+                "spark.dynamicAllocation.maxExecutors": 20,
+                "spark.executor.cores": 10,
+            },
+            31,
+        ),
+        (
+            99,
+            {
+                "spark.master": "yarn",
+                "spark.dynamicAllocation.enabled": "true",
+                "spark.dynamicAllocation.maxExecutors": 20,
+                "spark.executor.cores": 10,
+            },
+            99,
+        ),
+        (
+            200,
+            {
+                "spark.master": "yarn",
+                "spark.dynamicAllocation.enabled": "true",
+                "spark.dynamicAllocation.maxExecutors": 4,
+                "spark.executor.cores": 10,
+            },
+            40,
+        ),
+        (
+            31,
+            {
+                "spark.master": "yarn",
+                "spark.dynamicAllocation.enabled": "true",
+                "spark.dynamicAllocation.maxExecutors": 20,
+                "spark.executor.cores": 5,
+                "spark.dynamicAllocation.executorAllocationRatio": 2,
+            },
+            31,
+        ),
+        (
+            200,
+            {
+                "spark.master": "yarn",
+                "spark.dynamicAllocation.enabled": "true",
+                "spark.dynamicAllocation.maxExecutors": 4,
+                "spark.executor.cores": 5,
+                "spark.dynamicAllocation.executorAllocationRatio": 2,
+            },
+            40,
+        ),
+    ],
+)
+def test_greenplum_reader_number_of_connections_higher_than_warning_threshold(
+    mocker,
+    spark_mock,
+    caplog,
+    df_partitions,
+    spark_config,
+    parallel_connections,
+):
+    greenplum = Greenplum(host="some_host", user="user", database="database", password="passwd", spark=spark_mock)
+    mocker.patch.object(Greenplum, "check")
+    mocker.patch.object(Greenplum, "_get_connections_limits")
+    greenplum._get_connections_limits.return_value = GreenplumConnectionLimit(maximum=100, reserved=10, occupied=5)
+
+    reader = DBReader(
+        connection=greenplum,
+        table="schema.table",
+    )
+
+    conf = spark_mock.sparkContext.getConf()
+    conf.update(spark_config)
+
+    if "local" in conf["spark.master"]:
+        parallelism = conf["spark.master"].replace("local[", "").replace("]", "")
+        spark_mock.sparkContext.defaultParallelism = int(parallelism)
+
+    df = spark_mock.read.format().options().load()
+    df.rdd.getNumPartitions = Mock(return_value=df_partitions)
+
+    with caplog.at_level(logging.WARNING):
+        df = reader.run()
+
+    assert f"Each parallel job of {parallel_connections} opens a separate connection" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ["df_partitions", "spark_config", "parallel_connections"],
+    [
+        (100, {"spark.master": "local[200]"}, 100),
+        (200, {"spark.master": "local[100]"}, 100),
+        (100, {"spark.master": "yarn", "spark.executor.instances": 200, "spark.executor.cores": 1}, 100),
+        (200, {"spark.master": "yarn", "spark.executor.instances": 100, "spark.executor.cores": 1}, 100),
+        (100, {"spark.master": "yarn", "spark.executor.instances": 20, "spark.executor.cores": 10}, 100),
+        (200, {"spark.master": "yarn", "spark.executor.instances": 10, "spark.executor.cores": 10}, 100),
+        (
+            100,
+            {
+                "spark.master": "yarn",
+                "spark.dynamicAllocation.enabled": "true",
+                "spark.dynamicAllocation.maxExecutors": 20,
+                "spark.executor.cores": 10,
+            },
+            100,
+        ),
+        (
+            200,
+            {
+                "spark.master": "yarn",
+                "spark.dynamicAllocation.enabled": "true",
+                "spark.dynamicAllocation.maxExecutors": 10,
+                "spark.executor.cores": 10,
+            },
+            100,
+        ),
+        (
+            100,
+            {
+                "spark.master": "yarn",
+                "spark.dynamicAllocation.enabled": "true",
+                "spark.dynamicAllocation.maxExecutors": 20,
+                "spark.executor.cores": 5,
+                "spark.dynamicAllocation.executorAllocationRatio": 2,
+            },
+            100,
+        ),
+        (
+            200,
+            {
+                "spark.master": "yarn",
+                "spark.dynamicAllocation.enabled": "true",
+                "spark.dynamicAllocation.maxExecutors": 10,
+                "spark.executor.cores": 5,
+                "spark.dynamicAllocation.executorAllocationRatio": 2,
+            },
+            100,
+        ),
+        (
+            100,
+            {
+                "spark.master": "yarn",
+                "spark.dynamicAllocation.enabled": "true",
+                "spark.dynamicAllocation.maxExecutors": "infinity",
+            },
+            100,
+        ),
+        (
+            200,
+            {
+                "spark.master": "yarn",
+                "spark.dynamicAllocation.enabled": "true",
+                "spark.dynamicAllocation.maxExecutors": "infinity",
+            },
+            200,
+        ),
+    ],
+)
+def test_greenplum_reader_number_of_connections_higher_than_exception_threshold(
+    mocker,
+    spark_mock,
+    df_partitions,
+    spark_config,
+    parallel_connections,
+):
+    greenplum = Greenplum(host="some_host", user="user", database="database", password="passwd", spark=spark_mock)
+    mocker.patch.object(Greenplum, "check")
+    mocker.patch.object(Greenplum, "_get_connections_limits")
+    greenplum._get_connections_limits.return_value = GreenplumConnectionLimit(maximum=100, reserved=10, occupied=5)
+
+    reader = DBReader(
+        connection=greenplum,
+        table="schema.table",
+    )
+
+    conf = spark_mock.sparkContext.getConf()
+    conf.update(spark_config)
+
+    if "local" in conf["spark.master"]:
+        parallelism = conf["spark.master"].replace("local[", "").replace("]", "")
+        spark_mock.sparkContext.defaultParallelism = int(parallelism)
+
+    df = spark_mock.read.format().options().load()
+    df.rdd.getNumPartitions = Mock(return_value=df_partitions)
+
+    with pytest.raises(
+        TooManyParallelJobsError,
+        match=f"Each parallel job of {parallel_connections} opens a separate connection",
+    ):
+        df = reader.run()

--- a/tests/tests_unit/test_db/test_db_writer_unit/test_greenplum_writer_unit.py
+++ b/tests/tests_unit/test_db/test_db_writer_unit/test_greenplum_writer_unit.py
@@ -1,7 +1,14 @@
+import logging
+from unittest.mock import Mock
+
 import pytest
 
 from onetl.connection import Greenplum
+from onetl.connection.db_connection.greenplum.connection_limit import (
+    GreenplumConnectionLimit,
+)
 from onetl.db import DBWriter
+from onetl.exception import TooManyParallelJobsError
 
 pytestmark = pytest.mark.greenplum
 
@@ -14,3 +21,300 @@ def test_greenplum_writer_wrong_table_name(spark_mock):
             connection=greenplum,
             table="table",  # Required format: table="schema.table"
         )
+
+
+@pytest.mark.parametrize(
+    ["df_partitions", "spark_config"],
+    [
+        (30, {"spark.master": "local[200]"}),
+        (200, {"spark.master": "local[30]"}),
+        (30, {"spark.master": "yarn", "spark.executor.instances": 200, "spark.executor.cores": 1}),
+        (200, {"spark.master": "yarn", "spark.executor.instances": 30, "spark.executor.cores": 1}),
+        (30, {"spark.master": "yarn", "spark.executor.instances": 20, "spark.executor.cores": 10}),
+        (200, {"spark.master": "yarn", "spark.executor.instances": 3, "spark.executor.cores": 10}),
+        (
+            30,
+            {
+                "spark.master": "yarn",
+                "spark.dynamicAllocation.enabled": "true",
+                "spark.dynamicAllocation.maxExecutors": 20,
+                "spark.executor.cores": 10,
+            },
+        ),
+        (
+            200,
+            {
+                "spark.master": "yarn",
+                "spark.dynamicAllocation.enabled": "true",
+                "spark.dynamicAllocation.maxExecutors": 3,
+                "spark.executor.cores": 10,
+            },
+        ),
+        (
+            30,
+            {
+                "spark.master": "yarn",
+                "spark.dynamicAllocation.enabled": "true",
+                "spark.dynamicAllocation.maxExecutors": 20,
+                "spark.executor.cores": 5,
+                "spark.dynamicAllocation.executorAllocationRatio": 2,
+            },
+        ),
+        (
+            200,
+            {
+                "spark.master": "yarn",
+                "spark.dynamicAllocation.enabled": "true",
+                "spark.dynamicAllocation.maxExecutors": 3,
+                "spark.executor.cores": 5,
+                "spark.dynamicAllocation.executorAllocationRatio": 2,
+            },
+        ),
+    ],
+)
+def test_greenplum_writer_number_of_connections_less_than_warning_threshold(
+    mocker,
+    spark_mock,
+    caplog,
+    df_partitions,
+    spark_config,
+):
+    greenplum = Greenplum(host="some_host", user="user", database="database", password="passwd", spark=spark_mock)
+    mocker.patch.object(Greenplum, "check")
+    mocker.patch.object(Greenplum, "_get_connections_limits")
+    greenplum._get_connections_limits.return_value = GreenplumConnectionLimit(maximum=100, reserved=10, occupied=5)
+
+    mocker.patch("onetl.db.db_writer.db_writer.SparkMetricsRecorder")
+
+    writer = DBWriter(
+        connection=greenplum,
+        table="schema.table",
+    )
+
+    conf = spark_mock.sparkContext.getConf()
+    conf.update(spark_config)
+
+    if "local" in conf["spark.master"]:
+        parallelism = conf["spark.master"].replace("local[", "").replace("]", "")
+        spark_mock.sparkContext.defaultParallelism = int(parallelism)
+
+    df = spark_mock.read.format().options().load()
+    df.isStreaming = False
+    df.rdd.getNumPartitions = Mock(return_value=df_partitions)
+
+    with caplog.at_level(logging.WARNING):
+        writer.run(df)
+
+    assert not caplog.records
+
+
+@pytest.mark.parametrize(
+    ["df_partitions", "spark_config", "parallel_connections"],
+    [
+        (31, {"spark.master": "local[200]"}, 31),
+        (200, {"spark.master": "local[31]"}, 31),
+        (99, {"spark.master": "local[200]"}, 99),
+        (200, {"spark.master": "local[99]"}, 99),
+        (31, {"spark.master": "yarn", "spark.executor.instances": 200, "spark.executor.cores": 1}, 31),
+        (200, {"spark.master": "yarn", "spark.executor.instances": 31, "spark.executor.cores": 1}, 31),
+        (99, {"spark.master": "yarn", "spark.executor.instances": 200, "spark.executor.cores": 1}, 99),
+        (200, {"spark.master": "yarn", "spark.executor.instances": 99, "spark.executor.cores": 1}, 99),
+        (31, {"spark.master": "yarn", "spark.executor.instances": 20, "spark.executor.cores": 10}, 31),
+        (200, {"spark.master": "yarn", "spark.executor.instances": 4, "spark.executor.cores": 10}, 40),
+        (
+            31,
+            {
+                "spark.master": "yarn",
+                "spark.dynamicAllocation.enabled": "true",
+                "spark.dynamicAllocation.maxExecutors": 20,
+                "spark.executor.cores": 10,
+            },
+            31,
+        ),
+        (
+            99,
+            {
+                "spark.master": "yarn",
+                "spark.dynamicAllocation.enabled": "true",
+                "spark.dynamicAllocation.maxExecutors": 20,
+                "spark.executor.cores": 10,
+            },
+            99,
+        ),
+        (
+            200,
+            {
+                "spark.master": "yarn",
+                "spark.dynamicAllocation.enabled": "true",
+                "spark.dynamicAllocation.maxExecutors": 4,
+                "spark.executor.cores": 10,
+            },
+            40,
+        ),
+        (
+            31,
+            {
+                "spark.master": "yarn",
+                "spark.dynamicAllocation.enabled": "true",
+                "spark.dynamicAllocation.maxExecutors": 20,
+                "spark.executor.cores": 5,
+                "spark.dynamicAllocation.executorAllocationRatio": 2,
+            },
+            31,
+        ),
+        (
+            200,
+            {
+                "spark.master": "yarn",
+                "spark.dynamicAllocation.enabled": "true",
+                "spark.dynamicAllocation.maxExecutors": 4,
+                "spark.executor.cores": 5,
+                "spark.dynamicAllocation.executorAllocationRatio": 2,
+            },
+            40,
+        ),
+    ],
+)
+def test_greenplum_writer_number_of_connections_higher_than_warning_threshold(
+    mocker,
+    spark_mock,
+    caplog,
+    df_partitions,
+    spark_config,
+    parallel_connections,
+):
+    greenplum = Greenplum(host="some_host", user="user", database="database", password="passwd", spark=spark_mock)
+    mocker.patch.object(Greenplum, "check")
+    mocker.patch.object(Greenplum, "_get_connections_limits")
+    greenplum._get_connections_limits.return_value = GreenplumConnectionLimit(maximum=100, reserved=10, occupied=5)
+
+    mocker.patch("onetl.db.db_writer.db_writer.SparkMetricsRecorder")
+
+    writer = DBWriter(
+        connection=greenplum,
+        table="schema.table",
+    )
+
+    conf = spark_mock.sparkContext.getConf()
+    conf.update(spark_config)
+
+    if "local" in conf["spark.master"]:
+        parallelism = conf["spark.master"].replace("local[", "").replace("]", "")
+        spark_mock.sparkContext.defaultParallelism = int(parallelism)
+
+    df = spark_mock.read.format().options().load()
+    df.isStreaming = False
+    df.rdd.getNumPartitions = Mock(return_value=df_partitions)
+
+    with caplog.at_level(logging.WARNING):
+        writer.run(df)
+
+    assert f"Each parallel job of {parallel_connections} opens a separate connection" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ["df_partitions", "spark_config", "parallel_connections"],
+    [
+        (100, {"spark.master": "local[200]"}, 100),
+        (200, {"spark.master": "local[100]"}, 100),
+        (100, {"spark.master": "yarn", "spark.executor.instances": 200, "spark.executor.cores": 1}, 100),
+        (200, {"spark.master": "yarn", "spark.executor.instances": 100, "spark.executor.cores": 1}, 100),
+        (100, {"spark.master": "yarn", "spark.executor.instances": 20, "spark.executor.cores": 10}, 100),
+        (200, {"spark.master": "yarn", "spark.executor.instances": 10, "spark.executor.cores": 10}, 100),
+        (
+            100,
+            {
+                "spark.master": "yarn",
+                "spark.dynamicAllocation.enabled": "true",
+                "spark.dynamicAllocation.maxExecutors": 20,
+                "spark.executor.cores": 10,
+            },
+            100,
+        ),
+        (
+            200,
+            {
+                "spark.master": "yarn",
+                "spark.dynamicAllocation.enabled": "true",
+                "spark.dynamicAllocation.maxExecutors": 10,
+                "spark.executor.cores": 10,
+            },
+            100,
+        ),
+        (
+            100,
+            {
+                "spark.master": "yarn",
+                "spark.dynamicAllocation.enabled": "true",
+                "spark.dynamicAllocation.maxExecutors": 20,
+                "spark.executor.cores": 5,
+                "spark.dynamicAllocation.executorAllocationRatio": 2,
+            },
+            100,
+        ),
+        (
+            200,
+            {
+                "spark.master": "yarn",
+                "spark.dynamicAllocation.enabled": "true",
+                "spark.dynamicAllocation.maxExecutors": 10,
+                "spark.executor.cores": 5,
+                "spark.dynamicAllocation.executorAllocationRatio": 2,
+            },
+            100,
+        ),
+        (
+            100,
+            {
+                "spark.master": "yarn",
+                "spark.dynamicAllocation.enabled": "true",
+                "spark.dynamicAllocation.maxExecutors": "infinity",
+            },
+            100,
+        ),
+        (
+            200,
+            {
+                "spark.master": "yarn",
+                "spark.dynamicAllocation.enabled": "true",
+                "spark.dynamicAllocation.maxExecutors": "infinity",
+            },
+            200,
+        ),
+    ],
+)
+def test_greenplum_writer_number_of_connections_higher_than_exception_threshold(
+    mocker,
+    spark_mock,
+    df_partitions,
+    spark_config,
+    parallel_connections,
+):
+    greenplum = Greenplum(host="some_host", user="user", database="database", password="passwd", spark=spark_mock)
+    mocker.patch.object(Greenplum, "check")
+    mocker.patch.object(Greenplum, "_get_connections_limits")
+    greenplum._get_connections_limits.return_value = GreenplumConnectionLimit(maximum=100, reserved=10, occupied=5)
+
+    mocker.patch("onetl.db.db_writer.db_writer.SparkMetricsRecorder")
+
+    writer = DBWriter(
+        connection=greenplum,
+        table="schema.table",
+    )
+
+    conf = spark_mock.sparkContext.getConf()
+    conf.update(spark_config)
+
+    if "local" in conf["spark.master"]:
+        parallelism = conf["spark.master"].replace("local[", "").replace("]", "")
+        spark_mock.sparkContext.defaultParallelism = int(parallelism)
+
+    df = spark_mock.read.format().options().load()
+    df.isStreaming = False
+    df.rdd.getNumPartitions = Mock(return_value=df_partitions)
+
+    with pytest.raises(
+        TooManyParallelJobsError,
+        match=f"Each parallel job of {parallel_connections} opens a separate connection",
+    ):
+        writer.run(df)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Java's `Runtime.availableProcessors()` return number of _available_ processors in the system, but starting Spark session with `master=local[N]` applies the hard limit for the number of executor threads. So even if system has a lot of processor cores available, only some of them will be used by Spark.
This lead to showing a warning that the number of Greenplum connections is high even if Spark session was started with `master=local[1]` or `master=local[10]` (max 10 executors, so max 10 connections to GP, warning threshold is 30).

Fixed, added a bunch of unit tests, using mocks to cover different cases (master=local, master=yarn with static allocation, master=yarn with dynamic allocation).

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [x] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
