### PR TITLE
[DOP-23979] Change default FileDFWriter.Options(if_exists) to APPEND

### DIFF
--- a/docs/changelog/next_release/343.breaking.rst
+++ b/docs/changelog/next_release/343.breaking.rst
@@ -1,0 +1,1 @@
+Change default value for ``FileDFWriter.Options(if_exists=...)`` from ``error`` to ``append``, to make it consistent with other ``.Options()`` classes within onETL.

--- a/onetl/file/file_df_writer/options.py
+++ b/onetl/file/file_df_writer/options.py
@@ -65,14 +65,18 @@ class FileDFWriterOptions(FileDFWriteOptions, GenericOptions):
     class Config:
         extra = "allow"
 
-    if_exists: FileDFExistBehavior = FileDFExistBehavior.ERROR
+    if_exists: FileDFExistBehavior = FileDFExistBehavior.APPEND
     """Behavior for existing target directory.
 
     If target directory does not exist, it will be created.
     But if it does exist, then behavior is different for each value.
 
+    .. versionchanged:: 0.13.0
+
+        Default value was changed from ``error`` to ``append``
+
     Possible values:
-        * ``error`` (default)
+        * ``error``
             If folder already exists, raise an exception.
 
             Same as Spark's ``df.write.mode("error").save()``.
@@ -82,7 +86,7 @@ class FileDFWriterOptions(FileDFWriteOptions, GenericOptions):
 
             Same as Spark's ``df.write.mode("ignore").save()``.
 
-        * ``append``
+        * ``append`` (default)
             Appends data into existing directory.
 
             .. dropdown:: Behavior in details

--- a/onetl/file/file_downloader/options.py
+++ b/onetl/file/file_downloader/options.py
@@ -23,8 +23,8 @@ class FileDownloaderOptions(GenericOptions):
     How to handle existing files in the local directory.
 
     Possible values:
-        * ``error`` (default) - do nothing, mark file as failed
-        * ``ignore`` - do nothing, mark file as ignored
+        * ``error`` (default) - mark file as failed
+        * ``ignore`` - mark file as skipped
         * ``replace_file`` - replace existing file with a new one
         * ``replace_entire_directory`` - delete local directory content before downloading files
 

--- a/onetl/file/file_mover/options.py
+++ b/onetl/file/file_mover/options.py
@@ -23,8 +23,8 @@ class FileMoverOptions(GenericOptions):
     How to handle existing files in the local directory.
 
     Possible values:
-        * ``error`` (default) - do nothing, mark file as failed
-        * ``ignore`` - do nothing, mark file as ignored
+        * ``error`` (default) - mark file as failed
+        * ``ignore`` - mark file as skipped
         * ``replace_file`` - replace existing file with a new one
         * ``replace_entire_directory`` - delete directory content before moving files
 

--- a/onetl/file/file_uploader/options.py
+++ b/onetl/file/file_uploader/options.py
@@ -23,8 +23,8 @@ class FileUploaderOptions(GenericOptions):
     How to handle existing files in the target directory.
 
     Possible values:
-        * ``error`` (default) - do nothing, mark file as failed
-        * ``ignore`` - do nothing, mark file as ignored
+        * ``error`` (default) - mark file as failed
+        * ``ignore`` - mark file as skipped
         * ``replace_file`` - replace existing file with a new one
         * ``replace_entire_directory`` - delete local directory content before downloading files
 

--- a/tests/tests_integration/tests_core_integration/test_file_df_writer_integration/test_common_file_df_writer_integration.py
+++ b/tests/tests_integration/tests_core_integration/test_file_df_writer_integration/test_common_file_df_writer_integration.py
@@ -70,6 +70,7 @@ def test_file_df_writer_run_if_exists_error(
         connection=file_df_connection,
         format=CSV(),
         target_path=csv_root,
+        options=FileDFWriter.Options(if_exists="error"),
     )
 
     with pytest.raises(Exception, match="already exists"):
@@ -347,7 +348,6 @@ def test_file_df_writer_run_if_exists_append_target_not_partitioned_df_is(
         connection=file_df_connection,
         format=CSV(),
         target_path=csv_root,
-        options=FileDFWriter.Options(if_exists="append"),
     )
     writer1.run(df1)
 
@@ -355,7 +355,7 @@ def test_file_df_writer_run_if_exists_append_target_not_partitioned_df_is(
         connection=file_df_connection,
         format=CSV(),
         target_path=csv_root,
-        options=FileDFWriter.Options(partition_by="str_value", if_exists="append"),
+        options=FileDFWriter.Options(partition_by="str_value"),
     )
     writer2.run(df2)
 
@@ -390,7 +390,7 @@ def test_file_df_writer_run_if_exists_append_target_partitioned_df_is_not(
         connection=file_df_connection,
         format=CSV(),
         target_path=csv_root,
-        options=FileDFWriter.Options(partition_by="str_value", if_exists="append"),
+        options=FileDFWriter.Options(partition_by="str_value"),
     )
 
     writer1.run(df1)
@@ -399,7 +399,6 @@ def test_file_df_writer_run_if_exists_append_target_partitioned_df_is_not(
         connection=file_df_connection,
         format=CSV(),
         target_path=csv_root,
-        options=FileDFWriter.Options(if_exists="append"),
     )
 
     writer2.run(df2)
@@ -443,7 +442,7 @@ def test_file_df_writer_run_if_exists_append_to_different_partitioning_schema(
         connection=file_df_connection,
         format=CSV(),
         target_path=csv_root,
-        options=FileDFWriter.Options(partition_by="str_value", if_exists="append"),
+        options=FileDFWriter.Options(partition_by="str_value"),
     )
 
     # this can create conflicting partitioning schemas, which then cannot be read by Spark
@@ -478,7 +477,7 @@ def test_file_df_writer_run_if_exists_append_to_overlapping_partitions(
         connection=file_df_connection,
         format=CSV(),
         target_path=csv_root,
-        options=FileDFWriter.Options(partition_by="str_value", if_exists="append"),
+        options=FileDFWriter.Options(partition_by="str_value"),
     )
 
     writer.run(df1)

--- a/tests/tests_unit/test_file/test_file_df_writer_unit.py
+++ b/tests/tests_unit/test_file/test_file_df_writer_unit.py
@@ -8,7 +8,7 @@ from onetl.file import FileDFWriter
 @pytest.mark.parametrize(
     "option, value",
     [
-        ("if_exists", "error"),
+        ("if_exists", "append"),
         ("partition_by", "month"),
         ("partition_by", ["year", "month"]),
         ("unknown", "abc"),
@@ -22,7 +22,7 @@ def test_file_df_writer_options(option, value):
 def test_file_df_writer_options_mode_prohibited():
     msg = re.escape("Parameter `mode` is not allowed. Please use `if_exists` parameter instead.")
     with pytest.raises(ValueError, match=msg):
-        FileDFWriter.Options(mode="error")
+        FileDFWriter.Options(mode="append")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Make default value of `FileDFWriter.Options(if_exists=...)` consistent with DB connections, which use `APPEND`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [x] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
