### PR TITLE
[DOP-22425] Run DB.check() on both driver and executor

### DIFF
--- a/docs/changelog/next_release/346.feature.rst
+++ b/docs/changelog/next_release/346.feature.rst
@@ -1,0 +1,2 @@
+Now ``DB.check()`` will test connection availability not only on Spark driver, but also from some Spark executor.
+This allows to fail immediately if Spark driver host has network access to target DB, but Spark executors haven't.

--- a/onetl/connection/db_connection/hive/connection.py
+++ b/onetl/connection/db_connection/hive/connection.py
@@ -180,7 +180,7 @@ class Hive(DBConnection):
 
         try:
             with override_job_description(self.spark, f"{self}.check()"):
-                self._execute_sql(self._CHECK_QUERY).limit(1).collect()
+                self._execute_sql(self._CHECK_QUERY).take(1)
             log.info("|%s| Connection is available.", self.__class__.__name__)
         except Exception as e:
             log.exception("|%s| Connection is unavailable", self.__class__.__name__)
@@ -379,7 +379,7 @@ class Hive(DBConnection):
             hint=hint,
         )
 
-        log.info("|%s| Executing SQL query (on driver):", self.__class__.__name__)
+        log.info("|%s| Executing SQL query:", self.__class__.__name__)
         log_lines(log, query)
 
         df = self._execute_sql(query)

--- a/onetl/connection/db_connection/jdbc_mixin/connection.py
+++ b/onetl/connection/db_connection/jdbc_mixin/connection.py
@@ -77,7 +77,6 @@ class JDBCMixin:
     ExecuteOptions = JDBCExecuteOptions
 
     DRIVER: ClassVar[str]
-    _CHECK_QUERY: ClassVar[str] = "SELECT 1"
 
     @property
     @abstractmethod
@@ -140,23 +139,6 @@ class JDBCMixin:
 
     def __exit__(self, _exc_type, _exc_value, _traceback):  # noqa: U101
         self.close()
-
-    @slot
-    def check(self):
-        log.info("|%s| Checking connection availability...", self.__class__.__name__)
-        self._log_parameters()  # type: ignore
-
-        log.debug("|%s| Executing SQL query (on driver):", self.__class__.__name__)
-        log_lines(log, self._CHECK_QUERY, level=logging.DEBUG)
-
-        try:
-            self._query_optional_on_driver(self._CHECK_QUERY, self.FetchOptions(fetchsize=1))
-            log.info("|%s| Connection is available.", self.__class__.__name__)
-        except Exception as e:
-            log.exception("|%s| Connection is unavailable", self.__class__.__name__)
-            raise RuntimeError("Connection is unavailable") from e
-
-        return self
 
     @slot
     def fetch(

--- a/onetl/db/db_writer/db_writer.py
+++ b/onetl/db/db_writer/db_writer.py
@@ -152,16 +152,15 @@ class DBWriter(FrozenModel):
 
         entity_boundary_log(log, msg=f"{self.__class__.__name__}.run() starts")
 
-        job_description = f"{self.__class__.__name__}.run({self.target}) -> {self.connection}"
-        with override_job_description(self.connection.spark, job_description):
-            if not self._connection_checked:
-                self._log_parameters()
-                log_dataframe_schema(log, df)
-                self.connection.check()
-                self._connection_checked = True
+        if not self._connection_checked:
+            self._log_parameters()
+            log_dataframe_schema(log, df)
+            self.connection.check()
+            self._connection_checked = True
 
         with SparkMetricsRecorder(self.connection.spark) as recorder:
             try:
+                job_description = f"{self.__class__.__name__}.run({self.target}) -> {self.connection}"
                 with override_job_description(self.connection.spark, job_description):
                     self.connection.write_df_to_target(
                         df=df,

--- a/onetl/file/file_df_reader/file_df_reader.py
+++ b/onetl/file/file_df_reader/file_df_reader.py
@@ -209,6 +209,8 @@ class FileDFReader(FrozenModel):
 
         if not self._connection_checked:
             self._log_parameters(files)
+            self.connection.check()
+            self._connection_checked = True
 
         if files:
             job_description = f"{self.connection} -> {self.__class__.__name__}.run([..files..])"
@@ -221,11 +223,6 @@ class FileDFReader(FrozenModel):
                 paths = FileSet(self._validate_files(files))
             elif self.source_path:
                 paths = FileSet([self.source_path])
-
-            if not self._connection_checked:
-                self.connection.check()
-                log_with_indent(log, "")
-                self._connection_checked = True
 
             df = self._read_files(paths)
 

--- a/onetl/file/file_df_writer/file_df_writer.py
+++ b/onetl/file/file_df_writer/file_df_writer.py
@@ -123,15 +123,14 @@ class FileDFWriter(FrozenModel):
         if df.isStreaming:
             raise ValueError(f"DataFrame is streaming. {self.__class__.__name__} supports only batch DataFrames.")
 
-        job_description = f"{self.__class__.__name__}.run({self.target_path}) -> {self.connection}"
-        with override_job_description(self.connection.spark, job_description):
-            if not self._connection_checked:
-                self._log_parameters(df)
-                self.connection.check()
-                self._connection_checked = True
+        if not self._connection_checked:
+            self._log_parameters(df)
+            self.connection.check()
+            self._connection_checked = True
 
         with SparkMetricsRecorder(self.connection.spark) as recorder:
             try:
+                job_description = f"{self.__class__.__name__}.run({self.target_path}) -> {self.connection}"
                 with override_job_description(self.connection.spark, job_description):
                     self.connection.write_df_as_files(
                         df=df,

--- a/tests/tests_integration/test_metrics/test_spark_metrics_recorder_postgres.py
+++ b/tests/tests_integration/test_metrics/test_spark_metrics_recorder_postgres.py
@@ -38,7 +38,8 @@ def test_spark_metrics_recorder_postgres_read(spark, processing, load_table_data
 
         time.sleep(0.1)  # sleep to fetch late metrics from SparkListener
         metrics = recorder.metrics()
-        assert metrics.input.read_rows == rows
+        # +1 is just postgres.check()
+        assert metrics.input.read_rows == rows + 1
         # JDBC does not provide information about data size
         assert not metrics.input.read_bytes
 
@@ -64,7 +65,8 @@ def test_spark_metrics_recorder_postgres_read_empty_source(spark, processing, pr
 
         time.sleep(0.1)  # sleep to fetch late metrics from SparkListener
         metrics = recorder.metrics()
-        assert not metrics.input.read_rows
+        # 1 is just postgres.check()
+        assert metrics.input.read_rows == 1
 
 
 def test_spark_metrics_recorder_postgres_read_no_data_after_filter(spark, processing, load_table_data):
@@ -89,7 +91,8 @@ def test_spark_metrics_recorder_postgres_read_no_data_after_filter(spark, proces
 
         time.sleep(0.1)  # sleep to fetch late metrics from SparkListener
         metrics = recorder.metrics()
-        assert not metrics.input.read_rows
+        # 1 is just postgres.check()
+        assert metrics.input.read_rows == 1
 
 
 def test_spark_metrics_recorder_postgres_sql(spark, processing, load_table_data):

--- a/tests/tests_integration/tests_db_connection_integration/test_oracle_integration.py
+++ b/tests/tests_integration/tests_db_connection_integration/test_oracle_integration.py
@@ -103,7 +103,7 @@ def test_oracle_connection_sql(spark, processing, load_table_data, suffix):
     filtered_df = table_df[table_df.ID_INT < 50]
     processing.assert_equal_df(df=df, other_frame=filtered_df, order_by="id_int")
 
-    # client info is expectedc
+    # client info is expected
     df = oracle.sql(f"SELECT program FROM v$session WHERE program LIKE '%onETL%'{suffix}")
     client_info = df.collect()[0][0]
     assert client_info.startswith("local-")
@@ -142,7 +142,7 @@ def test_oracle_connection_fetch(spark, processing, load_table_data, suffix):
     filtered_df = table_df[table_df.ID_INT < 50]
     processing.assert_equal_df(df=df, other_frame=filtered_df, order_by="id_int")
 
-    # client info is expectedc
+    # client info is expected
     df = oracle.fetch(f"SELECT program FROM v$session WHERE program LIKE '%onETL%'{suffix}")
     client_info = df.collect()[0][0]
     assert client_info.startswith("local-")

--- a/tests/tests_integration/tests_db_connection_integration/test_teradata_integration.py
+++ b/tests/tests_integration/tests_db_connection_integration/test_teradata_integration.py
@@ -16,6 +16,7 @@ def test_teradata_connection_check(spark, mocker, caplog):
     password = secrets.token_hex()
 
     mocker.patch.object(Teradata, "_query_optional_on_driver")
+    mocker.patch.object(Teradata, "_query_on_executor")
 
     teradata = Teradata(
         host=host,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Now all `DB.check()` methods ping database both from Spark driver and at least one Spark executor, to be sure that next operations (e.g. check+write) will not fail on executor side.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [ ] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
