### PR TITLE
[DOP-22428] Send client_info for MongoDB

### DIFF
--- a/docs/changelog/next_release/339.feature.rst
+++ b/docs/changelog/next_release/339.feature.rst
@@ -1,5 +1,5 @@
-Set up client info for Clickhouse, MSSQL, MySQL and Oracle. Update client info for Greenplum, Postgres, Kafka and SparkS3.
+Set up client info for Clickhouse, MongoDB, MSSQL, MySQL and Oracle. Update client info for Greenplum, Postgres, Kafka and SparkS3.
 
 Now all connectors have the same client info format: ``${spark.applicationId} ${spark.appName} onETL/${onetl.version} Spark/${spark.version}``
 
-The only DB sources not providing client info are Teradata and MongoDB, and FileConnections.
+The only connections not sending client info are Teradata and FileConnections.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

According to MongoDB Spark connector documentation, it is possible to pass `comment` option describing current operation, and it will be saved to some internal profiling collection for later analysis.

Now passing `client_info` to this field. It is supported only for MongoDB server 4.4+, so added a server version check as well.

I've tried to get this internal collection content, but it is always empty for some reason. So no tests for now.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
