### PR TITLE
[DOP-24322] Properly handle different table name cases in DBWriter(Hive)

### DIFF
--- a/docs/changelog/next_release/350.bugfix.rst
+++ b/docs/changelog/next_release/350.bugfix.rst
@@ -1,0 +1,3 @@
+In 0.13.0, using ``DBWriter(connection=hive, target="SOMEDB.SOMETABLE")`` lead to executing ``df.write.saveAsTable()``
+instead of ``df.write.insertInto()`` if target table already exist. This is caused by table name normalization (Hive uses lower-case names),
+which wasn't properly handled by method used for checking table existence.

--- a/onetl/connection/db_connection/hive/connection.py
+++ b/onetl/connection/db_connection/hive/connection.py
@@ -459,7 +459,7 @@ class Hive(DBConnection):
         return sorted(df_columns, key=lambda column: table_columns_normalized.index(column.casefold()))
 
     def _target_exist(self, name: str) -> bool:
-        from pyspark.sql.functions import col
+        from pyspark.sql.functions import col, lower
 
         log.info("|%s| Checking if table %r exists ...", self.__class__.__name__, name)
 
@@ -472,7 +472,8 @@ class Hive(DBConnection):
         log.debug("|%s| Executing SQL query:", self.__class__.__name__)
         log_lines(log, query, level=logging.DEBUG)
 
-        df = self._execute_sql(query).where(col("tableName") == table)
+        # Spark normalizes table names to lowercase, so we do the same
+        df = self._execute_sql(query).where(lower(col("tableName")) == table.lower())
         if df.take(1):
             log.info("|%s| Table %r exists.", self.__class__.__name__, name)
             return True


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

For Hive, table names `somedb.sometable` and `SOMEDB.SOMETABLE` are exactly the same, because it is case insensitive. But for `DBWriter(Hive)` it was not, and writing data to existing table with different case lead to recreating the entire table, even if user passed `Hive.WriteOptions(if_exists="append")`

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
