### PR TITLE
Add AutoDetectHWM.reset

### DIFF
--- a/onetl/hwm/auto_hwm.py
+++ b/onetl/hwm/auto_hwm.py
@@ -35,6 +35,9 @@ class AutoDetectHWM(HWM):
         """Update current HWM value with some implementation-specific logic, and return HWM"""
         raise NotImplementedError("update method should be implemented in auto detected subclasses")
 
+    def reset(self: AutoDetectHWM) -> AutoDetectHWM:
+        raise NotImplementedError
+
     def dict(self, **kwargs):
         serialized_data = super().dict(**kwargs)
         # as in HWM classes default value for 'value' may be any structure,


### PR DESCRIPTION
## Change Summary

Added a stub for `reset()` method in `AutoDetectHWM` since `HWM` now has an abstract `reset()` method  

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
