### PR TITLE
[DOP-22429] Prefer camelCase for Spark JDBC params

### DIFF
--- a/docs/changelog/next_release/352.doc.rst
+++ b/docs/changelog/next_release/352.doc.rst
@@ -1,0 +1,2 @@
+Prefer ``JDBC.ReadOptions(partitionColumn=..., numPartitions=..., queryTimeout=...)`` instead of ``JDBC.ReadOptions(partition_column=..., num_partitions=..., query_timeout=...)``,
+to match Spark documentation.

--- a/docs/connection/db_connection/clickhouse/execute.rst
+++ b/docs/connection/db_connection/clickhouse/execute.rst
@@ -50,7 +50,7 @@ Examples
 
     df = clickhouse.fetch(
         "SELECT value FROM some.reference_table WHERE key = 'some_constant'",
-        options=Clickhouse.FetchOptions(query_timeout=10),
+        options=Clickhouse.FetchOptions(queryTimeout=10),
     )
     clickhouse.close()
     value = df.collect()[0][0]  # get value from first row and first column
@@ -96,7 +96,7 @@ Examples
         ENGINE = MergeTree()
         ORDER BY id
         """,
-        options=Clickhouse.ExecuteOptions(query_timeout=10),
+        options=Clickhouse.ExecuteOptions(queryTimeout=10),
     )
 
 Notes

--- a/docs/connection/db_connection/clickhouse/read.rst
+++ b/docs/connection/db_connection/clickhouse/read.rst
@@ -41,7 +41,7 @@ Snapshot strategy:
         source="schema.table",
         columns=["id", "key", "CAST(value AS String) value", "updated_dt"],
         where="key = 'something'",
-        options=Clickhouse.ReadOptions(partition_column="id", num_partitions=10),
+        options=Clickhouse.ReadOptions(partitionColumn="id", numPartitions=10),
     )
     df = reader.run()
 
@@ -61,7 +61,7 @@ Incremental strategy:
         columns=["id", "key", "CAST(value AS String) value", "updated_dt"],
         where="key = 'something'",
         hwm=DBReader.AutoDetectHWM(name="clickhouse_hwm", expression="updated_dt"),
-        options=Clickhouse.ReadOptions(partition_column="id", num_partitions=10),
+        options=Clickhouse.ReadOptions(partitionColumn="id", numPartitions=10),
     )
 
     with IncrementalStrategy():

--- a/docs/connection/db_connection/clickhouse/sql.rst
+++ b/docs/connection/db_connection/clickhouse/sql.rst
@@ -44,10 +44,10 @@ Examples
             key = 'something'
         """,
         options=Clickhouse.SQLOptions(
-            partition_column="id",
-            num_partitions=10,
-            lower_bound=0,
-            upper_bound=1000,
+            partitionColumn="id",
+            numPartitions=10,
+            lowerBound=0,
+            upperBound=1000,
         ),
     )
 

--- a/docs/connection/db_connection/greenplum/execute.rst
+++ b/docs/connection/db_connection/greenplum/execute.rst
@@ -50,7 +50,7 @@ Examples
 
     df = greenplum.fetch(
         "SELECT value FROM some.reference_table WHERE key = 'some_constant'",
-        options=Greenplum.FetchOptions(query_timeout=10),
+        options=Greenplum.FetchOptions(queryTimeout=10),
     )
     greenplum.close()
     value = df.collect()[0][0]  # get value from first row and first column
@@ -97,7 +97,7 @@ Examples
         )
         DISTRIBUTED BY id
         """,
-        options=Greenplum.ExecuteOptions(query_timeout=10),
+        options=Greenplum.ExecuteOptions(queryTimeout=10),
     )
 
 Interaction schema

--- a/docs/connection/db_connection/greenplum/read.rst
+++ b/docs/connection/db_connection/greenplum/read.rst
@@ -275,11 +275,11 @@ In this case, custom column can be used instead:
         reader = DBReader(
             connection=greenplum,
             source="schema.view_with_partition_column",
-            options=Greenplum.Options(
+            options=Greenplum.ReadOptions(
                 # parallelize data using specified column
-                partition_column="part_column",
+                partitionColumn="part_column",
                 # create 10 Spark tasks, each will read only part of table data
-                num_partitions=10,
+                partitions=10,
             ),
         )
         df = reader.run()

--- a/docs/connection/db_connection/hive/write.rst
+++ b/docs/connection/db_connection/hive/write.rst
@@ -91,7 +91,7 @@ For example, dataframe with content like this:
 | US              | 2024-01-03          | 5678         | 3464574567  |
 +-----------------+---------------------+--------------+-------------+
 
-With ``partition_by=["country", "business_dt"]`` data will be stored as files in the following subfolders:
+With ``partitionBy=["country", "business_dt"]`` data will be stored as files in the following subfolders:
   * ``/country=RU/business_date=2024-01-01/``
   * ``/country=RU/business_date=2024-01-02/``
   * ``/country=US/business_date=2024-01-01/``

--- a/docs/connection/db_connection/mssql/execute.rst
+++ b/docs/connection/db_connection/mssql/execute.rst
@@ -49,7 +49,7 @@ Examples
 
     df = mssql.fetch(
         "SELECT value FROM some.reference_table WHERE key = 'some_constant'",
-        options=MSSQL.FetchOptions(query_timeout=10),
+        options=MSSQL.FetchOptions(queryTimeout=10),
     )
     mssql.close()
     value = df.collect()[0][0]  # get value from first row and first column
@@ -95,7 +95,7 @@ Examples
             value NUMBER
         )
         """,
-        options=MSSQL.ExecuteOptions(query_timeout=10),
+        options=MSSQL.ExecuteOptions(queryTimeout=10),
     )
 
 Options

--- a/docs/connection/db_connection/mssql/read.rst
+++ b/docs/connection/db_connection/mssql/read.rst
@@ -41,7 +41,7 @@ Snapshot strategy:
         source="schema.table",
         columns=["id", "key", "CAST(value AS text) value", "updated_dt"],
         where="key = 'something'",
-        options=MSSQL.ReadOptions(partition_column="id", num_partitions=10),
+        options=MSSQL.ReadOptions(partitionColumn="id", numPartitions=10),
     )
     df = reader.run()
 
@@ -61,7 +61,7 @@ Incremental strategy:
         columns=["id", "key", "CAST(value AS text) value", "updated_dt"],
         where="key = 'something'",
         hwm=DBReader.AutoDetectHWM(name="mssql_hwm", expression="updated_dt"),
-        options=MSSQL.ReadOptions(partition_column="id", num_partitions=10),
+        options=MSSQL.ReadOptions(partitionColumn="id", numPartitions=10),
     )
 
     with IncrementalStrategy():

--- a/docs/connection/db_connection/mssql/sql.rst
+++ b/docs/connection/db_connection/mssql/sql.rst
@@ -44,10 +44,10 @@ Examples
             key = 'something'
         """,
         options=MSSQL.SQLOptions(
-            partition_column="id",
-            num_partitions=10,
-            lower_bound=0,
-            upper_bound=1000,
+            partitionColumn="id",
+            numPartitions=10,
+            lowerBound=0,
+            upperBound=1000,
         ),
     )
 

--- a/docs/connection/db_connection/mysql/execute.rst
+++ b/docs/connection/db_connection/mysql/execute.rst
@@ -50,7 +50,7 @@ Examples
 
     df = mysql.fetch(
         "SELECT value FROM some.reference_table WHERE key = 'some_constant'",
-        options=MySQL.FetchOptions(query_timeout=10),
+        options=MySQL.FetchOptions(queryTimeout=10),
     )
     mysql.close()
     value = df.collect()[0][0]  # get value from first row and first column
@@ -96,7 +96,7 @@ Examples
         )
         ENGINE = InnoDB
         """,
-        options=MySQL.ExecuteOptions(query_timeout=10),
+        options=MySQL.ExecuteOptions(queryTimeout=10),
     )
 
 Options

--- a/docs/connection/db_connection/mysql/read.rst
+++ b/docs/connection/db_connection/mysql/read.rst
@@ -42,7 +42,7 @@ Snapshot strategy:
         columns=["id", "key", "CAST(value AS text) value", "updated_dt"],
         where="key = 'something'",
         hint="SKIP_SCAN(schema.table key_index)",
-        options=MySQL.ReadOptions(partition_column="id", num_partitions=10),
+        options=MySQL.ReadOptions(partitionColumn="id", numPartitions=10),
     )
     df = reader.run()
 
@@ -63,7 +63,7 @@ Incremental strategy:
         where="key = 'something'",
         hint="SKIP_SCAN(schema.table key_index)",
         hwm=DBReader.AutoDetectHWM(name="mysql_hwm", expression="updated_dt"),
-        options=MySQL.ReadOptions(partition_column="id", num_partitions=10),
+        options=MySQL.ReadOptions(partitionColumn="id", numPartitions=10),
     )
 
     with IncrementalStrategy():

--- a/docs/connection/db_connection/mysql/sql.rst
+++ b/docs/connection/db_connection/mysql/sql.rst
@@ -45,10 +45,10 @@ Examples
             key = 'something'
         """,
         options=MySQL.SQLOptions(
-            partition_column="id",
-            num_partitions=10,
-            lower_bound=0,
-            upper_bound=1000,
+            partitionColumn="id",
+            numPartitions=10,
+            lowerBound=0,
+            upperBound=1000,
         ),
     )
 

--- a/docs/connection/db_connection/oracle/execute.rst
+++ b/docs/connection/db_connection/oracle/execute.rst
@@ -50,7 +50,7 @@ Examples
 
     df = oracle.fetch(
         "SELECT value FROM some.reference_table WHERE key = 'some_constant'",
-        options=Oracle.FetchOptions(query_timeout=10),
+        options=Oracle.FetchOptions(queryTimeout=10),
     )
     oracle.close()
     value = df.collect()[0][0]  # get value from first row and first column
@@ -96,7 +96,7 @@ Examples
             value NUMBER
         )
         """,
-        options=Oracle.ExecuteOptions(query_timeout=10),
+        options=Oracle.ExecuteOptions(queryTimeout=10),
     )
 
 Options

--- a/docs/connection/db_connection/oracle/read.rst
+++ b/docs/connection/db_connection/oracle/read.rst
@@ -42,7 +42,7 @@ Snapshot strategy:
         columns=["id", "key", "CAST(value AS VARCHAR2(4000)) value", "updated_dt"],
         where="key = 'something'",
         hint="INDEX(schema.table key_index)",
-        options=Oracle.ReadOptions(partition_column="id", num_partitions=10),
+        options=Oracle.ReadOptions(partitionColumn="id", numPartitions=10),
     )
     df = reader.run()
 
@@ -63,7 +63,7 @@ Incremental strategy:
         where="key = 'something'",
         hint="INDEX(schema.table key_index)",
         hwm=DBReader.AutoDetectHWM(name="oracle_hwm", expression="updated_dt"),
-        options=Oracle.ReadOptions(partition_column="id", num_partitions=10),
+        options=Oracle.ReadOptions(partitionColumn="id", numPartitions=10),
     )
 
     with IncrementalStrategy():

--- a/docs/connection/db_connection/oracle/sql.rst
+++ b/docs/connection/db_connection/oracle/sql.rst
@@ -45,10 +45,10 @@ Examples
             key = 'something'
         """,
         options=Oracle.SQLOptions(
-            partition_column="id",
-            num_partitions=10,
-            lower_bound=0,
-            upper_bound=1000,
+            partitionColumn="id",
+            numPartitions=10,
+            lowerBound=0,
+            upperBound=1000,
         ),
     )
 

--- a/docs/connection/db_connection/postgres/execute.rst
+++ b/docs/connection/db_connection/postgres/execute.rst
@@ -48,7 +48,7 @@ Examples
 
     df = postgres.fetch(
         "SELECT value FROM some.reference_table WHERE key = 'some_constant'",
-        options=Postgres.FetchOptions(query_timeout=10),
+        options=Postgres.FetchOptions(queryTimeout=10),
     )
     postgres.close()
     value = df.collect()[0][0]  # get value from first row and first column
@@ -94,7 +94,7 @@ Examples
             value real
         )
         """,
-        options=Postgres.ExecuteOptions(query_timeout=10),
+        options=Postgres.ExecuteOptions(queryTimeout=10),
     )
 
 Options

--- a/docs/connection/db_connection/postgres/read.rst
+++ b/docs/connection/db_connection/postgres/read.rst
@@ -41,7 +41,7 @@ Snapshot strategy:
         source="schema.table",
         columns=["id", "key", "CAST(value AS text) value", "updated_dt"],
         where="key = 'something'",
-        options=Postgres.ReadOptions(partition_column="id", num_partitions=10),
+        options=Postgres.ReadOptions(partitionColumn="id", numPartitions=10),
     )
     df = reader.run()
 
@@ -61,7 +61,7 @@ Incremental strategy:
         columns=["id", "key", "CAST(value AS text) value", "updated_dt"],
         where="key = 'something'",
         hwm=DBReader.AutoDetectHWM(name="postgres_hwm", expression="updated_dt"),
-        options=Postgres.ReadOptions(partition_column="id", num_partitions=10),
+        options=Postgres.ReadOptions(partitionColumn="id", numPartitions=10),
     )
 
     with IncrementalStrategy():

--- a/docs/connection/db_connection/postgres/sql.rst
+++ b/docs/connection/db_connection/postgres/sql.rst
@@ -44,10 +44,10 @@ Examples
             key = 'something'
         """,
         options=Postgres.SQLOptions(
-            partition_column="id",
-            num_partitions=10,
-            lower_bound=0,
-            upper_bound=1000,
+            partitionColumn="id",
+            numPartitions=10,
+            lowerBound=0,
+            upperBound=1000,
         ),
     )
 

--- a/docs/connection/db_connection/teradata/execute.rst
+++ b/docs/connection/db_connection/teradata/execute.rst
@@ -45,7 +45,7 @@ Examples
 
     df = teradata.fetch(
         "SELECT value FROM some.reference_table WHERE key = 'some_constant'",
-        options=Teradata.FetchOptions(query_timeout=10),
+        options=Teradata.FetchOptions(queryTimeout=10),
     )
     teradata.close()
     value = df.collect()[0][0]  # get value from first row and first column
@@ -93,7 +93,7 @@ Examples
         )
         NO PRIMARY INDEX
         """,
-        options=Teradata.ExecuteOptions(query_timeout=10),
+        options=Teradata.ExecuteOptions(queryTimeout=10),
     )
 
 Options

--- a/docs/connection/db_connection/teradata/read.rst
+++ b/docs/connection/db_connection/teradata/read.rst
@@ -38,9 +38,9 @@ Snapshot strategy:
         columns=["id", "key", "CAST(value AS VARCHAR) value", "updated_dt"],
         where="key = 'something'",
         options=Teradata.ReadOptions(
-            partition_column="id",
-            num_partitions=10,
             partitioning_mode="hash",
+            partitionColumn="id",
+            numPartitions=10,
         ),
     )
     df = reader.run()
@@ -62,9 +62,9 @@ Incremental strategy:
         where="key = 'something'",
         hwm=DBReader.AutoDetectHWM(name="teradata_hwm", expression="updated_dt"),
         options=Teradata.ReadOptions(
-            partition_column="id",
-            num_partitions=10,
             partitioning_mode="hash",
+            partitionColumn="id",
+            numPartitions=10,
         ),
     )
 
@@ -89,7 +89,7 @@ Especially if there are indexes or partitions for columns used in ``where`` clau
 Read data in parallel
 ~~~~~~~~~~~~~~~~~~~~~
 
-``DBReader`` can read data in multiple parallel connections by passing ``Teradata.ReadOptions(num_partitions=..., partition_column=...)``.
+``DBReader`` can read data in multiple parallel connections by passing ``Teradata.ReadOptions(numPartitions=..., partitionColumn=...)``.
 
 In the example above, Spark opens 10 parallel connections, and data is evenly distributed between all these connections using expression
 ``HASHAMP(HASHBUCKET(HASHROW({partition_column}))) MOD {num_partitions}``.

--- a/docs/connection/db_connection/teradata/sql.rst
+++ b/docs/connection/db_connection/teradata/sql.rst
@@ -42,10 +42,10 @@ Examples
             key = 'something'
         """,
         options=Teradata.SQLOptions(
-            partition_column="part_column",
-            num_partitions=10,
-            lower_bound=0,
-            upper_bound=9,
+            partitionColumn="id",
+            numPartitions=10,
+            lowerBound=0,
+            upperBound=1000,
         ),
     )
 

--- a/onetl/connection/db_connection/greenplum/options.py
+++ b/onetl/connection/db_connection/greenplum/options.py
@@ -94,8 +94,8 @@ class GreenplumReadOptions(JDBCOptions):
     .. code:: python
 
         Greenplum.ReadOptions(
-            partition_column="reg_id",
-            num_partitions=10,
+            partitionColumn="reg_id",
+            partitions=10,
         )
     """
 
@@ -181,8 +181,8 @@ class GreenplumReadOptions(JDBCOptions):
     .. code:: python
 
         Greenplum.ReadOptions(
-            partition_column="id_column",
-            num_partitions=10,
+            partitionColumn="id_column",
+            partitions=10,
         )
     """
 

--- a/onetl/connection/db_connection/hive/options.py
+++ b/onetl/connection/db_connection/hive/options.py
@@ -83,7 +83,7 @@ class HiveWriteOptions(GenericOptions):
 
         options = Hive.WriteOptions(
             if_exists="append",
-            partition_by="reg_id",
+            partitionBy="reg_id",
             customOption="value",
         )
     """
@@ -217,7 +217,7 @@ class HiveWriteOptions(GenericOptions):
 
         options = Hive.WriteOptions(
             if_exists="append",
-            partition_by="reg_id",
+            partitionBy="reg_id",
             format="orc",
         )
 
@@ -227,7 +227,7 @@ class HiveWriteOptions(GenericOptions):
 
         options = Hive.WriteOptions(
             if_exists="append",
-            partition_by="reg_id",
+            partitionBy="reg_id",
             format=ORC(compression="snappy"),
         )
 

--- a/onetl/connection/db_connection/jdbc_connection/options.py
+++ b/onetl/connection/db_connection/jdbc_connection/options.py
@@ -131,10 +131,10 @@ class JDBCReadOptions(JDBCFetchOptions):
     .. code:: python
 
         options = JDBC.ReadOptions(
-            partition_column="reg_id",
-            num_partitions=10,
-            lower_bound=0,
-            upper_bound=1000,
+            partitionColumn="reg_id",
+            numPartitions=10,
+            lowerBound=0,
+            upperBound=1000,
             customOption="value",
         )
     """
@@ -343,13 +343,13 @@ class JDBCReadOptions(JDBCFetchOptions):
 
         JDBC.ReadOptions(
             partitioning_mode="range",  # default mode, can be omitted
-            partition_column="id_column",
-            num_partitions=10,
+            partitionColumn="id_column",
+            numPartitions=10,
             # if you're using DBReader, options below can be omitted
             # because they are calculated by automatically as
             # MIN and MAX values of `partition_column`
-            lower_bound=0,
-            upper_bound=100_000,
+            lowerBound=0,
+            upperBound=100_000,
         )
 
     Read data in 10 parallel jobs by hash of values in ``some_column`` column:
@@ -358,8 +358,8 @@ class JDBCReadOptions(JDBCFetchOptions):
 
         JDBC.ReadOptions(
             partitioning_mode="hash",
-            partition_column="some_column",
-            num_partitions=10,
+            partitionColumn="some_column",
+            numPartitions=10,
             # lower_bound and upper_bound are automatically set to `0` and `9`
         )
 
@@ -369,8 +369,8 @@ class JDBCReadOptions(JDBCFetchOptions):
 
         JDBC.ReadOptions(
             partitioning_mode="mod",
-            partition_column="id_column",
-            num_partitions=10,
+            partitionColumn="id_column",
+            numPartitions=10,
             # lower_bound and upper_bound are automatically set to `0` and `9`
         )
     """
@@ -586,7 +586,7 @@ class JDBCSQLOptions(GenericOptions):
 
     .. code-block:: sql
 
-        -- If partition_column is 'id', with num_partitions=4, lower_bound=1, and upper_bound=100:
+        -- If partition_column is 'id', with numPartitions=4, lowerBound=1, and upperBound=100:
         -- Executor 1 processes IDs from 1 to 25
         SELECT ... FROM table WHERE id >= 1 AND id < 26
         -- Executor 2 processes IDs from 26 to 50
@@ -599,9 +599,9 @@ class JDBCSQLOptions(GenericOptions):
 
         -- General case for Executor N
         SELECT ... FROM table
-        WHERE partition_column >= (lower_bound + (N-1) * stride)
-          AND partition_column <= upper_bound
-        -- Where ``stride`` is calculated as ``(upper_bound - lower_bound) / num_partitions``.
+        WHERE partition_column >= (lowerBound + (N-1) * stride)
+          AND partition_column <= upperBound
+        -- Where ``stride`` is calculated as ``(upperBound - lowerBound) / numPartitions``.
     """
 
     num_partitions: Optional[int] = Field(default=None, alias="numPartitions")
@@ -663,7 +663,7 @@ class JDBCSQLOptions(GenericOptions):
         prohibited_options = GENERIC_PROHIBITED_OPTIONS | WRITE_OPTIONS | {"partitioning_mode"}
         extra = "allow"
 
-    @root_validator(pre=True)
+    @root_validator
     def _check_partition_fields(cls, values):
         num_partitions = values.get("num_partitions")
         lower_bound = values.get("lower_bound")
@@ -671,7 +671,7 @@ class JDBCSQLOptions(GenericOptions):
 
         if num_partitions is not None and num_partitions > 1:
             if lower_bound is None or upper_bound is None:
-                raise ValueError("lower_bound and upper_bound must be set if num_partitions > 1")
+                raise ValueError("lowerBound and upperBound must be set if numPartitions > 1")
         return values
 
 

--- a/onetl/file/file_df_writer/options.py
+++ b/onetl/file/file_df_writer/options.py
@@ -57,7 +57,7 @@ class FileDFWriterOptions(FileDFWriteOptions, GenericOptions):
         from onetl.file import FileDFWriter
 
         options = FileDFWriter.Options(
-            partition_by="month",
+            partitionBy="month",
             if_exists="replace_overlapping_partitions",
         )
     """

--- a/tests/tests_integration/tests_core_integration/test_file_df_writer_integration/test_common_file_df_writer_integration.py
+++ b/tests/tests_integration/tests_core_integration/test_file_df_writer_integration/test_common_file_df_writer_integration.py
@@ -126,7 +126,7 @@ def test_file_df_writer_run_if_exists_replace_overlapping_partitions_target_not_
         connection=file_df_connection,
         format=CSV(),
         target_path=csv_root,
-        options=FileDFWriter.Options(partition_by="str_value", if_exists="replace_overlapping_partitions"),
+        options=FileDFWriter.Options(partitionBy="str_value", if_exists="replace_overlapping_partitions"),
     )
 
     writer.run(df1)
@@ -190,7 +190,7 @@ def test_file_df_writer_run_if_exists_replace_overlapping_partitions_to_differen
         connection=file_df_connection,
         format=CSV(),
         target_path=csv_root,
-        options=FileDFWriter.Options(partition_by="id"),
+        options=FileDFWriter.Options(partitionBy="id"),
     )
 
     writer1.run(df)
@@ -199,7 +199,7 @@ def test_file_df_writer_run_if_exists_replace_overlapping_partitions_to_differen
         connection=file_df_connection,
         format=CSV(),
         target_path=csv_root,
-        options=FileDFWriter.Options(partition_by="str_value", if_exists="replace_overlapping_partitions"),
+        options=FileDFWriter.Options(partitionBy="str_value", if_exists="replace_overlapping_partitions"),
     )
 
     # this can create conflicting partitioning schemas, which then cannot be read by Spark
@@ -234,7 +234,7 @@ def test_file_df_writer_run_if_exists_replace_overlapping_partitions_to_overlapp
         connection=file_df_connection,
         format=CSV(),
         target_path=csv_root,
-        options=FileDFWriter.Options(partition_by="str_value", if_exists="replace_overlapping_partitions"),
+        options=FileDFWriter.Options(partitionBy="str_value", if_exists="replace_overlapping_partitions"),
     )
 
     writer.run(df1)
@@ -355,7 +355,7 @@ def test_file_df_writer_run_if_exists_append_target_not_partitioned_df_is(
         connection=file_df_connection,
         format=CSV(),
         target_path=csv_root,
-        options=FileDFWriter.Options(partition_by="str_value"),
+        options=FileDFWriter.Options(partitionBy="str_value"),
     )
     writer2.run(df2)
 
@@ -390,7 +390,7 @@ def test_file_df_writer_run_if_exists_append_target_partitioned_df_is_not(
         connection=file_df_connection,
         format=CSV(),
         target_path=csv_root,
-        options=FileDFWriter.Options(partition_by="str_value"),
+        options=FileDFWriter.Options(partitionBy="str_value"),
     )
 
     writer1.run(df1)
@@ -433,7 +433,7 @@ def test_file_df_writer_run_if_exists_append_to_different_partitioning_schema(
         connection=file_df_connection,
         format=CSV(),
         target_path=csv_root,
-        options=FileDFWriter.Options(partition_by="id"),
+        options=FileDFWriter.Options(partitionBy="id"),
     )
 
     writer1.run(df1)
@@ -442,7 +442,7 @@ def test_file_df_writer_run_if_exists_append_to_different_partitioning_schema(
         connection=file_df_connection,
         format=CSV(),
         target_path=csv_root,
-        options=FileDFWriter.Options(partition_by="str_value"),
+        options=FileDFWriter.Options(partitionBy="str_value"),
     )
 
     # this can create conflicting partitioning schemas, which then cannot be read by Spark
@@ -477,7 +477,7 @@ def test_file_df_writer_run_if_exists_append_to_overlapping_partitions(
         connection=file_df_connection,
         format=CSV(),
         target_path=csv_root,
-        options=FileDFWriter.Options(partition_by="str_value"),
+        options=FileDFWriter.Options(partitionBy="str_value"),
     )
 
     writer.run(df1)

--- a/tests/tests_integration/tests_core_integration/tests_db_reader_integration/test_postgres_reader_integration.py
+++ b/tests/tests_integration/tests_core_integration/tests_db_reader_integration/test_postgres_reader_integration.py
@@ -64,8 +64,8 @@ def test_postgres_reader_snapshot_partitioning_mode(mode, column, spark, process
         source=load_table_data.full_name,
         options=Postgres.ReadOptions(
             partitioning_mode=mode,
-            partition_column=column,
-            num_partitions=5,
+            partitionColumn=column,
+            numPartitions=5,
         ),
     )
 

--- a/tests/tests_integration/tests_core_integration/tests_db_writer_integration/test_hive_writer_integration.py
+++ b/tests/tests_integration/tests_core_integration/tests_db_writer_integration/test_hive_writer_integration.py
@@ -633,7 +633,7 @@ def test_hive_writer_insert_into_replace_overlapping_partitions_in_non_partition
     writer2 = DBWriter(
         connection=hive,
         target=new_table_name,
-        options=Hive.WriteOptions(if_exists="replace_overlapping_partitions", partition_by="id_int"),
+        options=Hive.WriteOptions(if_exists="replace_overlapping_partitions", partitionBy="id_int"),
     )
 
     with caplog.at_level(logging.INFO):
@@ -689,7 +689,7 @@ def test_hive_writer_insert_into_replace_overlapping_partitions_in_partitioned_t
     writer1 = DBWriter(
         connection=hive,
         target=get_schema_table.full_name,
-        options=Hive.WriteOptions(partition_by="id_int"),
+        options=Hive.WriteOptions(partitionBy="id_int"),
     )
 
     # create & fill up the table with some data
@@ -701,7 +701,7 @@ def test_hive_writer_insert_into_replace_overlapping_partitions_in_partitioned_t
     writer2 = DBWriter(
         connection=hive,
         target=new_table_name,
-        options=Hive.WriteOptions(if_exists="replace_overlapping_partitions", partition_by=partition_by),
+        options=Hive.WriteOptions(if_exists="replace_overlapping_partitions", partitionBy=partition_by),
     )
 
     writer2.run(df1.union(df3))
@@ -753,7 +753,7 @@ def test_hive_writer_insert_into_replace_overlapping_partitions_in_partitioned_t
     writer1 = DBWriter(
         connection=hive,
         target=get_schema_table.full_name,
-        options=Hive.WriteOptions(partition_by="id_int"),
+        options=Hive.WriteOptions(partitionBy="id_int"),
     )
 
     # create & fill up the table with some data
@@ -766,7 +766,7 @@ def test_hive_writer_insert_into_replace_overlapping_partitions_in_partitioned_t
     writer2 = DBWriter(
         connection=hive,
         target=new_table_name,
-        options=Hive.WriteOptions(if_exists="replace_overlapping_partitions", partition_by=partition_by),
+        options=Hive.WriteOptions(if_exists="replace_overlapping_partitions", partitionBy=partition_by),
     )
 
     writer2.run(empty_df)

--- a/tests/tests_integration/tests_db_connection_integration/test_postgres_integration.py
+++ b/tests/tests_integration/tests_db_connection_integration/test_postgres_integration.py
@@ -1066,7 +1066,7 @@ def test_postgres_connection_execute_with_legacy_jdbc_options(spark, processing,
         spark=spark,
     )
 
-    options = Postgres.JDBCOptions(query_timeout=30)
+    options = Postgres.JDBCOptions(queryTimeout=30)
 
     with caplog.at_level(logging.INFO):
         postgres.execute("DROP TABLE IF EXISTS temp_table;", options=options)

--- a/tests/tests_unit/tests_db_connection_unit/test_jdbc_options_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_jdbc_options_unit.py
@@ -330,9 +330,9 @@ def test_jdbc_write_options_mode_wrong(options_class, options):
 @pytest.mark.parametrize(
     "options, expected_message",
     [
-        ({"num_partitions": 2}, "lower_bound and upper_bound must be set if num_partitions > 1"),
-        ({"num_partitions": 2, "lower_bound": 0}, "lower_bound and upper_bound must be set if num_partitions > 1"),
-        ({"num_partitions": 2, "upper_bound": 10}, "lower_bound and upper_bound must be set if num_partitions > 1"),
+        ({"numPartitions": 2}, "lowerBound and upperBound must be set if numPartitions > 1"),
+        ({"numPartitions": 2, "lowerBound": 0}, "lowerBound and upperBound must be set if numPartitions > 1"),
+        ({"numPartitions": 2, "upperBound": 10}, "lowerBound and upperBound must be set if numPartitions > 1"),
     ],
 )
 def test_jdbc_sql_options_partition_bounds(options, expected_message):
@@ -377,4 +377,4 @@ def test_jdbc_deprecated_jdbcoptions():
     deprecated_warning = "Deprecated in 0.11.0 and will be removed in 1.0.0. Use FetchOptions or ExecuteOptions instead"
 
     with pytest.warns(DeprecationWarning, match=deprecated_warning):
-        Postgres.JDBCOptions(fetchsize=10, query_timeout=30)
+        Postgres.JDBCOptions(fetchsize=10, queryTimeout=30)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

There is a difference between onETL-only fields(`if_exists`, `partitioning_mode`) and Spark-only fields (`partitionColumn`, `numPartitions`). Highlight this difference by using camelCase for Spark, and snake_case for onETL.

camelCase aliases are already preferred by IDE:
![Снимок экрана_20250313_172725](https://github.com/user-attachments/assets/b2db5f87-5901-49fb-b0b1-9859c3046b72)


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [X] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
