### PR TITLE
[DOP-22429] Prefer ipc_port and webhdfs_port instead alias

### DIFF
--- a/docs/changelog/next_release/353.doc.rst
+++ b/docs/changelog/next_release/353.doc.rst
@@ -1,0 +1,1 @@
+Prefer ``SparkHDFS(ipc_port=...)`` and ``HDFS(webhdfs_port=...)`` instead ``port=...``

--- a/onetl/connection/db_connection/db_connection/connection.py
+++ b/onetl/connection/db_connection/db_connection/connection.py
@@ -54,6 +54,6 @@ class DBConnection(BaseDBConnection, FrozenModel):
 
     def _log_parameters(self):
         log.info("|%s| Using connection parameters:", self.__class__.__name__)
-        parameters = self.dict(exclude_none=True, exclude={"spark"})
+        parameters = self.dict(exclude_none=True, by_alias=True, exclude={"spark"})
         for attr, value in parameters.items():
             log_with_indent(log, "%s = %r", attr, value)

--- a/onetl/connection/file_connection/file_connection.py
+++ b/onetl/connection/file_connection/file_connection.py
@@ -751,7 +751,7 @@ class FileConnection(BaseFileConnection, FrozenModel):
 
     def _log_parameters(self):
         log.info("|%s| Using connection parameters:", self.__class__.__name__)
-        parameters = self.dict(exclude_none=True)
+        parameters = self.dict(exclude_none=True, by_alias=True)
         for attr, value in parameters.items():
             if isinstance(value, os.PathLike):
                 log_with_indent(log, "%s = %s", attr, path_repr(value))

--- a/onetl/connection/file_connection/hdfs/connection.py
+++ b/onetl/connection/file_connection/hdfs/connection.py
@@ -195,7 +195,7 @@ class HDFS(FileConnection, RenameDirMixin):
 
     cluster: Optional[Cluster] = None
     host: Optional[Host] = None
-    webhdfs_port: int = Field(alias="port", default=50070)
+    port: int = Field(alias="webhdfs_port", default=50070)
     user: Optional[str] = None
     password: Optional[SecretStr] = None
     keytab: Optional[FilePath] = None
@@ -257,12 +257,12 @@ class HDFS(FileConnection, RenameDirMixin):
     def instance_url(self) -> str:
         if self.cluster:
             return self.cluster
-        return f"hdfs://{self.host}:{self.webhdfs_port}"
+        return f"hdfs://{self.host}:{self.port}"
 
     def __str__(self):
         if self.cluster:
             return f"{self.__class__.__name__}[{self.cluster}]"
-        return f"{self.__class__.__name__}[{self.host}:{self.webhdfs_port}]"
+        return f"{self.__class__.__name__}[{self.host}:{self.port}]"
 
     @slot
     def path_exists(self, path: os.PathLike | str) -> bool:
@@ -347,7 +347,7 @@ class HDFS(FileConnection, RenameDirMixin):
 
         return namenode
 
-    @validator("webhdfs_port", always=True)
+    @validator("port", always=True)
     def _validate_port_number(cls, port, values):
         cluster = values.get("cluster")
         if cluster:
@@ -419,7 +419,7 @@ class HDFS(FileConnection, RenameDirMixin):
         # cache active host to reduce number of requests.
         if not self._active_host:
             self._active_host = self._get_host()
-        return f"http://{self._active_host}:{self.webhdfs_port}"
+        return f"http://{self._active_host}:{self.port}"
 
     def _get_client(self) -> Client:
         if self.user and (self.keytab or self.password):

--- a/onetl/connection/file_df_connection/spark_file_df_connection.py
+++ b/onetl/connection/file_df_connection/spark_file_df_connection.py
@@ -182,6 +182,6 @@ class SparkFileDFConnection(BaseFileDFConnection, FrozenModel):
 
     def _log_parameters(self):
         log.info("|%s| Using connection parameters:", self.__class__.__name__)
-        parameters = self.dict(exclude_none=True, exclude={"spark"})
+        parameters = self.dict(exclude_none=True, by_alias=True, exclude={"spark"})
         for attr, value in parameters.items():
             log_with_indent(log, "%s = %r", attr, value)

--- a/onetl/connection/file_df_connection/spark_hdfs/connection.py
+++ b/onetl/connection/file_df_connection/spark_hdfs/connection.py
@@ -155,7 +155,7 @@ class SparkHDFS(SparkFileDFConnection):
 
     cluster: Cluster
     host: Optional[Host] = None
-    ipc_port: int = Field(default=8020, alias="port")
+    port: int = Field(default=8020, alias="ipc_port")
 
     _active_host: Optional[Host] = PrivateAttr(default=None)
 
@@ -295,7 +295,7 @@ class SparkHDFS(SparkFileDFConnection):
 
         return namenode
 
-    @validator("ipc_port", always=True)
+    @validator("port", always=True)
     def _validate_port_number(cls, port, values):
         cluster = values.get("cluster")
         if cluster:
@@ -348,7 +348,7 @@ class SparkHDFS(SparkFileDFConnection):
         # cache active host to reduce number of requests.
         if not self._active_host:
             self._active_host = self._get_host()
-        return f"hdfs://{self._active_host}:{self.ipc_port}"
+        return f"hdfs://{self._active_host}:{self.port}"
 
     def _convert_to_url(self, path: PurePathProtocol) -> str:
         # example "hdfs://namenode:8020/absolute/path"

--- a/tests/tests_integration/test_file_df_connection_integration/test_spark_hdfs_integration.py
+++ b/tests/tests_integration/test_file_df_connection_integration/test_spark_hdfs_integration.py
@@ -18,7 +18,7 @@ def test_spark_hdfs_check(hdfs_file_df_connection, caplog):
     assert "|SparkHDFS|" in caplog.text
     assert f"cluster = '{hdfs.cluster}'" in caplog.text
     assert f"host = '{hdfs.host}'" in caplog.text
-    assert f"ipc_port = {hdfs.ipc_port}" in caplog.text
+    assert f"ipc_port = {hdfs.port}" in caplog.text
 
     assert "Connection is available." in caplog.text
 
@@ -52,7 +52,7 @@ def test_spark_hdfs_file_connection_check_with_hooks(spark, request, hdfs_server
     SparkHDFS(
         cluster="rnd-dwh",
         host=hdfs_server.host,
-        port=hdfs_server.ipc_port,
+        ipc_port=hdfs_server.ipc_port,
         spark=spark,
     ).check()
 

--- a/tests/tests_integration/tests_file_connection_integration/test_hdfs_file_connection_integration.py
+++ b/tests/tests_integration/tests_file_connection_integration/test_hdfs_file_connection_integration.py
@@ -19,7 +19,7 @@ def test_hdfs_file_connection_check_anonymous(hdfs_file_connection, caplog):
 
     assert "|HDFS|" in caplog.text
     assert f"host = '{hdfs.host}'" in caplog.text
-    assert f"webhdfs_port = {hdfs.webhdfs_port}" in caplog.text
+    assert f"webhdfs_port = {hdfs.port}" in caplog.text
     assert "timeout = 10" in caplog.text
     assert "user = " not in caplog.text
     assert "keytab =" not in caplog.text
@@ -45,14 +45,14 @@ def test_hdfs_file_connection_check_with_keytab(mocker, hdfs_server, caplog, req
 
     request.addfinalizer(finalizer)
 
-    hdfs = HDFS(host=hdfs_server.host, port=hdfs_server.webhdfs_port, user=getuser(), keytab=keytab)
+    hdfs = HDFS(host=hdfs_server.host, webhdfs_port=hdfs_server.webhdfs_port, user=getuser(), keytab=keytab)
 
     with caplog.at_level(logging.INFO):
         assert hdfs.check()
 
     assert "|HDFS|" in caplog.text
     assert f"host = '{hdfs.host}'" in caplog.text
-    assert f"webhdfs_port = {hdfs.webhdfs_port}" in caplog.text
+    assert f"webhdfs_port = {hdfs.port}" in caplog.text
     assert f"user = '{hdfs.user}'" in caplog.text
     assert "timeout = 10" in caplog.text
     assert f"keytab = '{keytab}' (kind='file'" in caplog.text
@@ -67,14 +67,14 @@ def test_hdfs_file_connection_check_with_password(mocker, hdfs_server, caplog):
 
     mocker.patch.object(connection, "kinit")
 
-    hdfs = HDFS(host=hdfs_server.host, port=hdfs_server.webhdfs_port, user=getuser(), password="somepass")
+    hdfs = HDFS(host=hdfs_server.host, webhdfs_port=hdfs_server.webhdfs_port, user=getuser(), password="somepass")
 
     with caplog.at_level(logging.INFO):
         assert hdfs.check()
 
     assert "|HDFS|" in caplog.text
     assert f"host = '{hdfs.host}'" in caplog.text
-    assert f"webhdfs_port = {hdfs.webhdfs_port}" in caplog.text
+    assert f"webhdfs_port = {hdfs.port}" in caplog.text
     assert "timeout = 10" in caplog.text
     assert f"user = '{hdfs.user}'" in caplog.text
     assert "keytab =" not in caplog.text
@@ -101,7 +101,7 @@ def test_hdfs_file_connection_check_with_hooks(request, hdfs_server):
 
     request.addfinalizer(is_namenode_active.disable)
 
-    HDFS(host=hdfs_server.host, port=hdfs_server.webhdfs_port).check()  # no exception
+    HDFS(host=hdfs_server.host, webhdfs_port=hdfs_server.webhdfs_port).check()  # no exception
 
     with pytest.raises(RuntimeError, match="Host 'some-node2.domain.com' is not an active namenode"):
         HDFS(host="some-node2.domain.com").check()

--- a/tests/tests_unit/tests_file_connection_unit/test_hdfs_unit.py
+++ b/tests/tests_unit/tests_file_connection_unit/test_hdfs_unit.py
@@ -18,7 +18,7 @@ def test_hdfs_connection_with_host():
     conn = HDFS(host="some-host.domain.com")
     assert isinstance(conn, FileConnection)
     assert conn.host == "some-host.domain.com"
-    assert conn.webhdfs_port == 50070
+    assert conn.port == 50070
     assert not conn.user
     assert not conn.password
     assert not conn.keytab
@@ -31,7 +31,7 @@ def test_hdfs_connection_with_cluster():
 
     conn = HDFS(cluster="rnd-dwh")
     assert conn.cluster == "rnd-dwh"
-    assert conn.webhdfs_port == 50070
+    assert conn.port == 50070
     assert not conn.user
     assert not conn.password
     assert not conn.keytab
@@ -54,7 +54,7 @@ def test_hdfs_connection_with_host_and_port():
 
     conn = HDFS(host="some-host.domain.com", port=9080)
     assert conn.host == "some-host.domain.com"
-    assert conn.webhdfs_port == 9080
+    assert conn.port == 9080
     assert conn.instance_url == "hdfs://some-host.domain.com:9080"
     assert str(conn) == "HDFS[some-host.domain.com:9080]"
 
@@ -64,7 +64,7 @@ def test_hdfs_connection_with_user():
 
     conn = HDFS(host="some-host.domain.com", user="some_user")
     assert conn.host == "some-host.domain.com"
-    assert conn.webhdfs_port == 50070
+    assert conn.port == 50070
     assert conn.user == "some_user"
     assert not conn.password
     assert not conn.keytab
@@ -75,7 +75,7 @@ def test_hdfs_connection_with_password():
 
     conn = HDFS(host="some-host.domain.com", user="some_user", password="pwd")
     assert conn.host == "some-host.domain.com"
-    assert conn.webhdfs_port == 50070
+    assert conn.port == 50070
     assert conn.user == "some_user"
     assert conn.password != "pwd"
     assert conn.password.get_secret_value() == "pwd"
@@ -236,11 +236,11 @@ def test_hdfs_get_webhdfs_port_hook(request):
 
     request.addfinalizer(get_webhdfs_port.disable)
 
-    assert HDFS(cluster="rnd-dwh").webhdfs_port == 9080
-    assert HDFS(cluster="rnd-prod").webhdfs_port == 50070
+    assert HDFS(cluster="rnd-dwh").port == 9080
+    assert HDFS(cluster="rnd-prod").port == 50070
 
-    assert HDFS(host="some-node.domain.com").webhdfs_port == 50070
-    assert HDFS(host="some-node.domain.com", cluster="rnd-dwh").webhdfs_port == 9080
+    assert HDFS(host="some-node.domain.com").port == 50070
+    assert HDFS(host="some-node.domain.com", cluster="rnd-dwh").port == 9080
 
 
 def test_hdfs_known_get_current(request):

--- a/tests/tests_unit/tests_file_df_connection_unit/test_spark_hdfs_unit.py
+++ b/tests/tests_unit/tests_file_df_connection_unit/test_spark_hdfs_unit.py
@@ -16,7 +16,7 @@ def test_spark_hdfs_with_cluster(spark_mock):
     assert isinstance(conn, BaseFileDFConnection)
     assert conn.cluster == "rnd-dwh"
     assert conn.host is None
-    assert conn.ipc_port == 8020
+    assert conn.port == 8020
     assert conn.instance_url == "rnd-dwh"
     assert str(conn) == "HDFS[rnd-dwh]"
 
@@ -26,6 +26,7 @@ def test_spark_hdfs_with_cluster_and_host(spark_mock):
     assert isinstance(conn, BaseFileDFConnection)
     assert conn.cluster == "rnd-dwh"
     assert conn.host == "some-host.domain.com"
+    assert conn.port == 8020
     assert conn.instance_url == "rnd-dwh"
     assert str(conn) == "HDFS[rnd-dwh]"
 
@@ -34,7 +35,7 @@ def test_spark_hdfs_with_port(spark_mock):
     conn = SparkHDFS(cluster="rnd-dwh", port=9020, spark=spark_mock)
     assert isinstance(conn, BaseFileDFConnection)
     assert conn.cluster == "rnd-dwh"
-    assert conn.ipc_port == 9020
+    assert conn.port == 9020
     assert conn.instance_url == "rnd-dwh"
     assert str(conn) == "HDFS[rnd-dwh]"
 
@@ -127,8 +128,8 @@ def test_spark_hdfs_get_ipc_port_hook(request, spark_mock):
 
     request.addfinalizer(get_ipc_port.disable)
 
-    assert SparkHDFS(cluster="rnd-dwh", spark=spark_mock).ipc_port == 9020
-    assert SparkHDFS(cluster="rnd-prod", spark=spark_mock).ipc_port == 8020
+    assert SparkHDFS(cluster="rnd-dwh", spark=spark_mock).port == 9020
+    assert SparkHDFS(cluster="rnd-prod", spark=spark_mock).port == 8020
 
 
 def test_spark_hdfs_known_get_current(request, spark_mock):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

SparkHDFS and HDFS have different port numbers, and this is denoted by having different field names `ipc_port` vs `webhdfs_port`.

But now both Sphinx and VSCode prefer using alias `port` instead of original field name:
![Снимок экрана_20250313_174013](https://github.com/user-attachments/assets/73320ac7-0663-48cf-80b8-5973f8fa39a5)
![Снимок экрана_20250313_173934](https://github.com/user-attachments/assets/5e2b3e89-24ba-4959-81da-8a42b8841266)

Fixed:
![Снимок экрана_20250313_174041](https://github.com/user-attachments/assets/a869de9a-68b4-4da8-84a4-edb3b441eee3)
![Снимок экрана_20250313_173913](https://github.com/user-attachments/assets/10cc89c2-8660-4a55-a658-cf4e818b980b)

This is breaking

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Commit message and PR title is comprehensive
* [ ] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [ ] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [ ] My PR is ready to review.
