### PR TITLE
[DOP-22429] Prefer if_exists=... over mode=...

### DIFF
--- a/docs/changelog/next_release/354.doc.rst
+++ b/docs/changelog/next_release/354.doc.rst
@@ -1,0 +1,1 @@
+Prefer ``WriteOptions(if_exists=...)`` instead of ``WriteOptions(mode=...)`` for IDE suggestions.

--- a/docs/connection/db_connection/clickhouse/types.rst
+++ b/docs/connection/db_connection/clickhouse/types.rst
@@ -77,7 +77,7 @@ So instead of relying on Spark to create tables:
 
         writer = DBWriter(
             connection=clickhouse,
-            table="default.target_tbl",
+            target="default.target_tbl",
             options=Clickhouse.WriteOptions(
                 if_exists="append",
                 # ENGINE is required by Clickhouse
@@ -105,7 +105,7 @@ Always prefer creating tables with specific types **BEFORE WRITING DATA**:
 
         writer = DBWriter(
             connection=clickhouse,
-            table="default.target_tbl",
+            target="default.target_tbl",
             options=Clickhouse.WriteOptions(if_exists="append"),
         )
         writer.run(df)
@@ -375,7 +375,7 @@ For parsing JSON columns in ClickHouse, :obj:`JSON.parse_column <onetl.file.form
 
     reader = DBReader(
         connection=clickhouse,
-        table="default.source_tbl",
+        target="default.source_tbl",
         columns=[
             "id",
             "toJSONString(array_column) array_column",

--- a/docs/connection/db_connection/greenplum/read.rst
+++ b/docs/connection/db_connection/greenplum/read.rst
@@ -348,8 +348,8 @@ and then read this table using ``DBReader``:
 
     .. code-block:: python
 
-        df1 = DBReader(connection=greenplum, table="public.table1", ...).run()
-        df2 = DBReader(connection=greenplum, table="public.table2", ...).run()
+        df1 = DBReader(connection=greenplum, target="public.table1", ...).run()
+        df2 = DBReader(connection=greenplum, target="public.table2", ...).run()
 
         joined_df = df1.join(df2, on="col")
 

--- a/docs/connection/db_connection/greenplum/types.rst
+++ b/docs/connection/db_connection/greenplum/types.rst
@@ -66,7 +66,7 @@ So instead of relying on Spark to create tables:
 
         writer = DBWriter(
             connection=greenplum,
-            table="public.table",
+            target="public.table",
             options=Greenplum.WriteOptions(
                 if_exists="append",
                 # by default distribution is random
@@ -96,7 +96,7 @@ Always prefer creating table with desired DDL **BEFORE WRITING DATA**:
 
         writer = DBWriter(
             connection=greenplum,
-            table="public.table",
+            target="public.table",
             options=Greenplum.WriteOptions(if_exists="append"),
         )
         writer.run(df)

--- a/docs/connection/db_connection/mssql/types.rst
+++ b/docs/connection/db_connection/mssql/types.rst
@@ -69,7 +69,7 @@ So instead of relying on Spark to create tables:
 
         writer = DBWriter(
             connection=mssql,
-            table="myschema.target_tbl",
+            target="myschema.target_tbl",
             options=MSSQL.WriteOptions(
                 if_exists="append",
             ),
@@ -94,7 +94,7 @@ Always prefer creating tables with specific types **BEFORE WRITING DATA**:
 
         writer = DBWriter(
             connection=mssql,
-            table="myschema.target_tbl",
+            target="myschema.target_tbl",
             options=MSSQL.WriteOptions(if_exists="append"),
         )
         writer.run(df)

--- a/docs/connection/db_connection/mysql/types.rst
+++ b/docs/connection/db_connection/mysql/types.rst
@@ -63,7 +63,7 @@ So instead of relying on Spark to create tables:
 
         writer = DBWriter(
             connection=mysql,
-            table="myschema.target_tbl",
+            target="myschema.target_tbl",
             options=MySQL.WriteOptions(
                 if_exists="append",
                 createTableOptions="ENGINE = InnoDB",
@@ -90,7 +90,7 @@ Always prefer creating tables with specific types **BEFORE WRITING DATA**:
 
         writer = DBWriter(
             connection=mysql,
-            table="myschema.target_tbl",
+            target="myschema.target_tbl",
             options=MySQL.WriteOptions(if_exists="append"),
         )
         writer.run(df)

--- a/docs/connection/db_connection/oracle/types.rst
+++ b/docs/connection/db_connection/oracle/types.rst
@@ -65,7 +65,7 @@ So instead of relying on Spark to create tables:
 
         writer = DBWriter(
             connection=oracle,
-            table="public.table",
+            target="public.table",
             options=Oracle.WriteOptions(if_exists="append"),
         )
         writer.run(df)
@@ -88,7 +88,7 @@ Always prefer creating table with desired DDL **BEFORE WRITING DATA**:
 
         writer = DBWriter(
             connection=oracle,
-            table="public.table",
+            target="public.table",
             options=Oracle.WriteOptions(if_exists="append"),
         )
         writer.run(df)

--- a/docs/connection/db_connection/postgres/types.rst
+++ b/docs/connection/db_connection/postgres/types.rst
@@ -68,7 +68,7 @@ So instead of relying on Spark to create tables:
 
         writer = DBWriter(
             connection=postgres,
-            table="public.table",
+            target="public.table",
             options=Postgres.WriteOptions(
                 if_exists="append",
                 createTableOptions="PARTITION BY RANGE (id)",
@@ -95,7 +95,7 @@ Always prefer creating table with desired DDL **BEFORE WRITING DATA**:
 
         writer = DBWriter(
             connection=postgres,
-            table="public.table",
+            target="public.table",
             options=Postgres.WriteOptions(if_exists="append"),
         )
         writer.run(df)

--- a/onetl/_util/alias.py
+++ b/onetl/_util/alias.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2021-2024 MTS PJSC
+# SPDX-License-Identifier: Apache-2.0
+def avoid_alias(name: str) -> str:
+    # https://github.com/pydantic/pydantic/issues/5893
+    return name

--- a/onetl/connection/db_connection/greenplum/options.py
+++ b/onetl/connection/db_connection/greenplum/options.py
@@ -11,6 +11,7 @@ try:
 except (ImportError, AttributeError):
     from pydantic import Field, root_validator  # type: ignore[no-redef, assignment]
 
+from onetl._util.alias import avoid_alias
 from onetl.connection.db_connection.jdbc_connection.options import JDBCSQLOptions
 from onetl.connection.db_connection.jdbc_mixin import JDBCOptions
 from onetl.connection.db_connection.jdbc_mixin.options import (
@@ -237,7 +238,10 @@ class GreenplumWriteOptions(JDBCOptions):
         known_options = WRITE_OPTIONS | READ_WRITE_OPTIONS
         prohibited_options = JDBCOptions.Config.prohibited_options | GENERIC_PROHIBITED_OPTIONS | READ_OPTIONS
 
-    if_exists: GreenplumTableExistBehavior = Field(default=GreenplumTableExistBehavior.APPEND, alias="mode")
+    if_exists: GreenplumTableExistBehavior = Field(  # type: ignore[literal-required]
+        default=GreenplumTableExistBehavior.APPEND,
+        alias=avoid_alias("mode"),
+    )
     """Behavior of writing data into existing table.
 
     Possible values:

--- a/onetl/connection/db_connection/hive/options.py
+++ b/onetl/connection/db_connection/hive/options.py
@@ -6,6 +6,8 @@ import warnings
 from enum import Enum
 from typing import List, Optional, Tuple, Union
 
+from onetl._util.alias import avoid_alias
+
 try:
     from pydantic.v1 import Field, root_validator, validator
 except (ImportError, AttributeError):
@@ -92,7 +94,10 @@ class HiveWriteOptions(GenericOptions):
         known_options: frozenset = frozenset()
         extra = "allow"
 
-    if_exists: HiveTableExistBehavior = Field(default=HiveTableExistBehavior.APPEND, alias="mode")
+    if_exists: HiveTableExistBehavior = Field(  # type: ignore[literal-required]
+        default=HiveTableExistBehavior.APPEND,
+        alias=avoid_alias("mode"),
+    )
     """Behavior of writing data into existing table.
 
     Possible values:

--- a/onetl/connection/db_connection/jdbc_connection/options.py
+++ b/onetl/connection/db_connection/jdbc_connection/options.py
@@ -6,6 +6,7 @@ import warnings
 from enum import Enum
 from typing import Optional
 
+from onetl._util.alias import avoid_alias
 from onetl.connection.db_connection.jdbc_mixin.options import JDBCFetchOptions
 
 try:
@@ -429,7 +430,10 @@ class JDBCWriteOptions(GenericOptions):
         prohibited_options = GENERIC_PROHIBITED_OPTIONS | READ_OPTIONS
         extra = "allow"
 
-    if_exists: JDBCTableExistBehavior = Field(default=JDBCTableExistBehavior.APPEND, alias="mode")
+    if_exists: JDBCTableExistBehavior = Field(  # type: ignore[literal-required]
+        default=JDBCTableExistBehavior.APPEND,
+        alias=avoid_alias("mode"),
+    )
     """Behavior of writing data into existing table.
 
     Possible values:

--- a/onetl/connection/db_connection/mongodb/options.py
+++ b/onetl/connection/db_connection/mongodb/options.py
@@ -10,6 +10,7 @@ try:
 except (ImportError, AttributeError):
     from pydantic import Field, root_validator  # type: ignore[no-redef, assignment]
 
+from onetl._util.alias import avoid_alias
 from onetl.impl import GenericOptions
 
 PIPELINE_PROHIBITED_OPTIONS = frozenset(
@@ -197,7 +198,10 @@ class MongoDBWriteOptions(GenericOptions):
         )
     """
 
-    if_exists: MongoDBCollectionExistBehavior = Field(default=MongoDBCollectionExistBehavior.APPEND, alias="mode")
+    if_exists: MongoDBCollectionExistBehavior = Field(  # type: ignore[literal-required]
+        default=MongoDBCollectionExistBehavior.APPEND,
+        alias=avoid_alias("mode"),
+    )
     """Behavior of writing data into existing collection.
 
     Possible values:

--- a/onetl/connection/file_connection/hdfs/connection.py
+++ b/onetl/connection/file_connection/hdfs/connection.py
@@ -23,6 +23,7 @@ try:
 except (ImportError, AttributeError):
     from pydantic import Field, FilePath, SecretStr, PrivateAttr, root_validator, validator  # type: ignore[no-redef, assignment]
 
+from onetl._util.alias import avoid_alias
 from onetl.base import PathStatProtocol
 from onetl.connection.file_connection.file_connection import FileConnection
 from onetl.connection.file_connection.hdfs.slots import HDFSSlots
@@ -195,7 +196,7 @@ class HDFS(FileConnection, RenameDirMixin):
 
     cluster: Optional[Cluster] = None
     host: Optional[Host] = None
-    webhdfs_port: int = Field(alias="port", default=50070)
+    webhdfs_port: int = Field(alias=avoid_alias("port"), default=50070)  # type: ignore[literal-required]
     user: Optional[str] = None
     password: Optional[SecretStr] = None
     keytab: Optional[FilePath] = None

--- a/onetl/connection/file_df_connection/spark_hdfs/connection.py
+++ b/onetl/connection/file_df_connection/spark_hdfs/connection.py
@@ -16,6 +16,7 @@ try:
 except (ImportError, AttributeError):
     from pydantic import Field, PrivateAttr, validator  # type: ignore[no-redef, assignment]
 
+from onetl._util.alias import avoid_alias
 from onetl.base import PurePathProtocol
 from onetl.connection.file_df_connection.spark_file_df_connection import (
     SparkFileDFConnection,
@@ -155,7 +156,7 @@ class SparkHDFS(SparkFileDFConnection):
 
     cluster: Cluster
     host: Optional[Host] = None
-    ipc_port: int = Field(default=8020, alias="port")
+    ipc_port: int = Field(default=8020, alias=avoid_alias("port"))  # type: ignore[literal-required]
 
     _active_host: Optional[Host] = PrivateAttr(default=None)
 

--- a/onetl/db/db_reader/db_reader.py
+++ b/onetl/db/db_reader/db_reader.py
@@ -17,6 +17,7 @@ try:
 except (ImportError, AttributeError):
     from pydantic import Field, PrivateAttr, root_validator, validator  # type: ignore[no-redef, assignment]
 
+from onetl._util.alias import avoid_alias
 from onetl._util.spark import override_job_description, try_import_pyspark
 from onetl.base import (
     BaseDBConnection,
@@ -308,7 +309,7 @@ class DBReader(FrozenModel):
     """
 
     connection: BaseDBConnection
-    source: str = Field(alias="table")
+    source: str = Field(alias=avoid_alias("table"))  # type: ignore[literal-required]
     columns: Optional[List[str]] = Field(default=None, min_items=1)
     where: Optional[Any] = None
     hint: Optional[Any] = None

--- a/onetl/db/db_writer/db_writer.py
+++ b/onetl/db/db_writer/db_writer.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Optional
 
+from onetl._util.alias import avoid_alias
+
 try:
     from pydantic.v1 import Field, PrivateAttr, validator
 except (ImportError, AttributeError):
@@ -100,7 +102,7 @@ class DBWriter(FrozenModel):
     """
 
     connection: BaseDBConnection
-    target: str = Field(alias="table")
+    target: str = Field(alias=avoid_alias("table"))  # type: ignore[literal-required]
     options: Optional[GenericOptions] = None
 
     _connection_checked: bool = PrivateAttr(default=False)

--- a/onetl/file/file_downloader/options.py
+++ b/onetl/file/file_downloader/options.py
@@ -9,6 +9,7 @@ try:
 except (ImportError, AttributeError):
     from pydantic import Field, root_validator  # type: ignore[no-redef, assignment]
 
+from onetl._util.alias import avoid_alias
 from onetl.impl import FileExistBehavior, GenericOptions
 
 
@@ -18,7 +19,10 @@ class FileDownloaderOptions(GenericOptions):
     .. versionadded:: 0.3.0
     """
 
-    if_exists: FileExistBehavior = Field(default=FileExistBehavior.ERROR, alias="mode")
+    if_exists: FileExistBehavior = Field(  # type: ignore[literal-required]
+        default=FileExistBehavior.ERROR,
+        alias=avoid_alias("mode"),
+    )
     """
     How to handle existing files in the local directory.
 

--- a/onetl/file/file_mover/options.py
+++ b/onetl/file/file_mover/options.py
@@ -9,6 +9,7 @@ try:
 except (ImportError, AttributeError):
     from pydantic import Field, root_validator  # type: ignore[no-redef, assignment]
 
+from onetl._util.alias import avoid_alias
 from onetl.impl import FileExistBehavior, GenericOptions
 
 
@@ -18,7 +19,10 @@ class FileMoverOptions(GenericOptions):
     .. versionadded:: 0.8.0
     """
 
-    if_exists: FileExistBehavior = Field(default=FileExistBehavior.ERROR, alias="mode")
+    if_exists: FileExistBehavior = Field(  # type: ignore[literal-required]
+        default=FileExistBehavior.ERROR,
+        alias=avoid_alias("mode"),
+    )
     """
     How to handle existing files in the local directory.
 

--- a/onetl/file/file_uploader/options.py
+++ b/onetl/file/file_uploader/options.py
@@ -9,6 +9,7 @@ try:
 except (ImportError, AttributeError):
     from pydantic import Field, root_validator  # type: ignore[no-redef, assignment]
 
+from onetl._util.alias import avoid_alias
 from onetl.impl import FileExistBehavior, GenericOptions
 
 
@@ -18,7 +19,10 @@ class FileUploaderOptions(GenericOptions):
     .. versionadded:: 0.3.0
     """
 
-    if_exists: FileExistBehavior = Field(default=FileExistBehavior.ERROR, alias="mode")
+    if_exists: FileExistBehavior = Field(  # type: ignore[literal-required]
+        default=FileExistBehavior.ERROR,
+        alias=avoid_alias("mode"),
+    )
     """
     How to handle existing files in the target directory.
 

--- a/onetl/file/format/csv.py
+++ b/onetl/file/format/csv.py
@@ -10,6 +10,7 @@ try:
 except (ImportError, AttributeError):
     from pydantic import Field  # type: ignore[no-redef, assignment]
 
+from onetl._util.alias import avoid_alias
 from onetl._util.spark import get_spark_version, stringify
 from onetl.file.format.file_format import ReadWriteFileFormat
 from onetl.hooks import slot, support_hooks
@@ -98,7 +99,7 @@ class CSV(ReadWriteFileFormat):
     """
 
     name: ClassVar[str] = "csv"
-    delimiter: str = Field(default=",", alias="sep")
+    delimiter: str = Field(default=",", alias=avoid_alias("sep"))  # type: ignore[literal-required]
     encoding: str = "utf-8"
     quote: str = '"'
     escape: str = "\\"

--- a/tests/tests_integration/test_file_df_connection_integration/test_spark_hdfs_integration.py
+++ b/tests/tests_integration/test_file_df_connection_integration/test_spark_hdfs_integration.py
@@ -29,7 +29,7 @@ def test_spark_hdfs_file_connection_check_failed(spark):
     wrong_hdfs = SparkHDFS(
         cluster="rnd-dwh",
         host="hive1",
-        port=1234,
+        ipc_port=1234,
         spark=spark,
     )
 
@@ -52,7 +52,7 @@ def test_spark_hdfs_file_connection_check_with_hooks(spark, request, hdfs_server
     SparkHDFS(
         cluster="rnd-dwh",
         host=hdfs_server.host,
-        port=hdfs_server.ipc_port,
+        ipc_port=hdfs_server.ipc_port,
         spark=spark,
     ).check()
 

--- a/tests/tests_integration/tests_file_connection_integration/test_hdfs_file_connection_integration.py
+++ b/tests/tests_integration/tests_file_connection_integration/test_hdfs_file_connection_integration.py
@@ -45,7 +45,7 @@ def test_hdfs_file_connection_check_with_keytab(mocker, hdfs_server, caplog, req
 
     request.addfinalizer(finalizer)
 
-    hdfs = HDFS(host=hdfs_server.host, port=hdfs_server.webhdfs_port, user=getuser(), keytab=keytab)
+    hdfs = HDFS(host=hdfs_server.host, webhdfs_port=hdfs_server.webhdfs_port, user=getuser(), keytab=keytab)
 
     with caplog.at_level(logging.INFO):
         assert hdfs.check()
@@ -67,7 +67,7 @@ def test_hdfs_file_connection_check_with_password(mocker, hdfs_server, caplog):
 
     mocker.patch.object(connection, "kinit")
 
-    hdfs = HDFS(host=hdfs_server.host, port=hdfs_server.webhdfs_port, user=getuser(), password="somepass")
+    hdfs = HDFS(host=hdfs_server.host, webhdfs_port=hdfs_server.webhdfs_port, user=getuser(), password="somepass")
 
     with caplog.at_level(logging.INFO):
         assert hdfs.check()
@@ -88,7 +88,7 @@ def test_hdfs_file_connection_check_failed():
     from onetl.connection import HDFS
 
     with pytest.raises(RuntimeError, match="Connection is unavailable"):
-        HDFS(host="hive1", port=1234).check()
+        HDFS(host="hive1", webhdfs_port=1234).check()
 
 
 def test_hdfs_file_connection_check_with_hooks(request, hdfs_server):
@@ -101,7 +101,7 @@ def test_hdfs_file_connection_check_with_hooks(request, hdfs_server):
 
     request.addfinalizer(is_namenode_active.disable)
 
-    HDFS(host=hdfs_server.host, port=hdfs_server.webhdfs_port).check()  # no exception
+    HDFS(host=hdfs_server.host, webhdfs_port=hdfs_server.webhdfs_port).check()  # no exception
 
     with pytest.raises(RuntimeError, match="Host 'some-node2.domain.com' is not an active namenode"):
         HDFS(host="some-node2.domain.com").check()

--- a/tests/tests_unit/test_db/test_db_reader_unit/test_clickhouse_reader_unit.py
+++ b/tests/tests_unit/test_db/test_db_reader_unit/test_clickhouse_reader_unit.py
@@ -30,7 +30,7 @@ def test_clickhouse_reader_snapshot_error_pass_df_schema(spark_mock):
     with pytest.raises(ValueError, match="'df_schema' parameter is not supported by Clickhouse"):
         DBReader(
             connection=clickhouse,
-            table="schema.table",
+            source="schema.table",
             df_schema=df_schema,
         )
 
@@ -41,7 +41,7 @@ def test_clickhouse_reader_wrong_table_name(spark_mock):
     with pytest.raises(ValueError, match="Name should be passed in `schema.name` format"):
         DBReader(
             connection=clickhouse,
-            table="table",  # Required format: table="schema.table"
+            source="table",  # Required format: source="schema.table"
         )
 
 
@@ -55,7 +55,7 @@ def test_clickhouse_reader_wrong_hint_type(spark_mock):
         DBReader(
             connection=clickhouse,
             hint={"col1": 1},
-            table="schema.table",
+            source="schema.table",
         )
 
 
@@ -69,5 +69,5 @@ def test_clickhouse_reader_wrong_where_type(spark_mock):
         DBReader(
             connection=clickhouse,
             where={"col1": 1},
-            table="schema.table",
+            source="schema.table",
         )

--- a/tests/tests_unit/test_db/test_db_reader_unit/test_common_reader_unit.py
+++ b/tests/tests_unit/test_db/test_db_reader_unit/test_common_reader_unit.py
@@ -46,7 +46,7 @@ def test_reader_hive_with_read_options(spark_mock):
     with pytest.raises(ValueError, match=r"Hive does not implement ReadOptions, but \{'some': 'option'\} is passed"):
         DBReader(
             connection=Hive(cluster="rnd-dwh", spark=spark_mock),
-            table="schema.table",
+            source="schema.table",
             options={"some": "option"},
         )
 
@@ -64,7 +64,7 @@ def test_reader_invalid_columns(spark_mock, columns):
     with pytest.raises(ValueError):
         DBReader(
             connection=Hive(cluster="rnd-dwh", spark=spark_mock),
-            table="schema.table",
+            source="schema.table",
             columns=columns,
         )
 
@@ -81,7 +81,7 @@ def test_reader_invalid_columns(spark_mock, columns):
 def test_reader_valid_columns(spark_mock, columns, real_columns):
     reader = DBReader(
         connection=Hive(cluster="rnd-dwh", spark=spark_mock),
-        table="schema.table",
+        source="schema.table",
         columns=columns,
     )
 
@@ -110,7 +110,7 @@ def test_reader_legacy_columns(spark_mock, column, real_columns, msg):
     with pytest.warns(UserWarning, match=re.escape(msg)):
         reader = DBReader(
             connection=Hive(cluster="rnd-dwh", spark=spark_mock),
-            table="schema.table",
+            source="schema.table",
             columns=column,
         )
 
@@ -130,7 +130,7 @@ def test_reader_deprecated_hwm_column(spark_mock, hwm_column, real_hwm_expressio
     with pytest.warns(UserWarning, match=error_msg):
         reader = DBReader(
             connection=Hive(cluster="rnd-dwh", spark=spark_mock),
-            table="schema.table",
+            source="schema.table",
             hwm_column=hwm_column,
         )
 
@@ -142,7 +142,7 @@ def test_reader_deprecated_hwm_column(spark_mock, hwm_column, real_hwm_expressio
 def test_reader_autofill_hwm_source(spark_mock):
     reader = DBReader(
         connection=Hive(cluster="rnd-dwh", spark=spark_mock),
-        table="schema.table",
+        source="schema.table",
         hwm=DBReader.AutoDetectHWM(
             name="some_name",
             expression="some_expression",
@@ -173,7 +173,7 @@ def test_reader_hwm_has_different_source(spark_mock):
     with pytest.raises(ValueError, match=error_msg):
         DBReader(
             connection=Hive(cluster="rnd-dwh", spark=spark_mock),
-            table="schema.table",
+            source="schema.table",
             hwm=DBReader.AutoDetectHWM(
                 name="some_name",
                 source="another.table",
@@ -186,7 +186,7 @@ def test_reader_no_hwm_expression(spark_mock):
     with pytest.raises(ValueError, match="`hwm.expression` cannot be None"):
         DBReader(
             connection=Hive(cluster="rnd-dwh", spark=spark_mock),
-            table="schema.table",
+            source="schema.table",
             hwm=DBReader.AutoDetectHWM(name="some_name"),
         )
 

--- a/tests/tests_unit/test_db/test_db_reader_unit/test_greenplum_reader_unit.py
+++ b/tests/tests_unit/test_db/test_db_reader_unit/test_greenplum_reader_unit.py
@@ -38,7 +38,7 @@ def test_greenplum_reader_snapshot_error_pass_df_schema(spark_mock):
     with pytest.raises(ValueError, match="'df_schema' parameter is not supported by Greenplum"):
         DBReader(
             connection=greenplum,
-            table="schema.table",
+            source="schema.table",
             df_schema=df_schema,
         )
 
@@ -49,7 +49,7 @@ def test_greenplum_reader_wrong_table_name(spark_mock):
     with pytest.raises(ValueError, match="Name should be passed in `schema.name` format"):
         DBReader(
             connection=greenplum,
-            table="table",  # Required format: table="schema.table"
+            source="table",  # Required format: source="schema.table"
         )
 
 
@@ -63,7 +63,7 @@ def test_greenplum_reader_hint_unsupported(spark_mock):
         DBReader(
             connection=greenplum,
             hint="col1",
-            table="schema.table",
+            source="schema.table",
         )
 
 
@@ -77,7 +77,7 @@ def test_greenplum_reader_wrong_where_type(spark_mock):
         DBReader(
             connection=greenplum,
             where={"col1": 1},
-            table="schema.table",
+            source="schema.table",
         )
 
 
@@ -164,7 +164,7 @@ def test_greenplum_reader_number_of_connections_less_than_warning_threshold(
 
     reader = DBReader(
         connection=greenplum,
-        table="schema.table",
+        source="schema.table",
     )
 
     conf = spark_mock.sparkContext.getConf()
@@ -300,7 +300,7 @@ def test_greenplum_reader_number_of_connections_higher_than_warning_threshold(
 
     reader = DBReader(
         connection=greenplum,
-        table="schema.table",
+        source="schema.table",
     )
 
     conf = spark_mock.sparkContext.getConf()
@@ -430,7 +430,7 @@ def test_greenplum_reader_number_of_connections_higher_than_exception_threshold(
 
     reader = DBReader(
         connection=greenplum,
-        table="schema.table",
+        source="schema.table",
     )
 
     conf = spark_mock.sparkContext.getConf()

--- a/tests/tests_unit/test_db/test_db_reader_unit/test_hive_reader_unit.py
+++ b/tests/tests_unit/test_db/test_db_reader_unit/test_hive_reader_unit.py
@@ -31,7 +31,7 @@ def test_hive_reader_snapshot_error_pass_df_schema(spark_mock):
     with pytest.raises(ValueError, match="'df_schema' parameter is not supported by Hive"):
         DBReader(
             connection=hive,
-            table="schema.table",
+            source="schema.table",
             df_schema=df_schema,
         )
 
@@ -42,7 +42,7 @@ def test_hive_reader_wrong_table_name(spark_mock):
     with pytest.raises(ValueError):
         DBReader(
             connection=hive,
-            table="table",  # Required format: table="schema.table"
+            source="table",  # Required format: source="schema.table"
         )
 
 
@@ -56,7 +56,7 @@ def test_hive_reader_wrong_hint_type(spark_mock):
         DBReader(
             connection=hive,
             hint={"col1": 1},
-            table="schema.table",
+            source="schema.table",
         )
 
 
@@ -70,5 +70,5 @@ def test_hive_reader_wrong_where_type(spark_mock):
         DBReader(
             connection=hive,
             where={"col1": 1},
-            table="schema.table",
+            source="schema.table",
         )

--- a/tests/tests_unit/test_db/test_db_reader_unit/test_kafka_reader_unit.py
+++ b/tests/tests_unit/test_db/test_db_reader_unit/test_kafka_reader_unit.py
@@ -44,7 +44,7 @@ def test_kafka_reader_unsupported_parameters(spark_mock, df_schema):
         DBReader(
             connection=kafka,
             where={"col1": 1},
-            table="table",
+            source="table",
         )
 
     with pytest.raises(
@@ -54,7 +54,7 @@ def test_kafka_reader_unsupported_parameters(spark_mock, df_schema):
         DBReader(
             connection=kafka,
             hint={"col1": 1},
-            table="table",
+            source="table",
         )
 
     with pytest.raises(
@@ -63,7 +63,7 @@ def test_kafka_reader_unsupported_parameters(spark_mock, df_schema):
     ):
         DBReader(
             connection=kafka,
-            table="table",
+            source="table",
             df_schema=df_schema,
         )
 
@@ -77,7 +77,7 @@ def test_kafka_reader_hwm_offset_is_valid(spark_mock):
 
     DBReader(
         connection=kafka,
-        table="table",
+        source="table",
         hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), expression="offset"),
     )
 
@@ -99,7 +99,7 @@ def test_kafka_reader_invalid_hwm_column(spark_mock, hwm_expression):
     ):
         DBReader(
             connection=kafka,
-            table="table",
+            source="table",
             hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), expression=hwm_expression),
         )
 
@@ -124,6 +124,6 @@ def test_kafka_reader_invalid_source(spark_mock, topic, error_message):
     ):
         DBReader(
             connection=kafka,
-            table=topic,
+            source=topic,
             hwm=DBReader.AutoDetectHWM(name=secrets.token_hex(5), expression="offset"),
         )

--- a/tests/tests_unit/test_db/test_db_reader_unit/test_mongodb_reader_unit.py
+++ b/tests/tests_unit/test_db/test_db_reader_unit/test_mongodb_reader_unit.py
@@ -45,7 +45,7 @@ def test_mongodb_reader_wrong_hint_type(spark_mock, df_schema):
             connection=mongo,
             where={"col_2": {"$eq": 2}, "col_1": {"$gt": 1, "$lt": 100}},
             hint="{'col1': 1}",
-            table="table",
+            source="table",
             df_schema=df_schema,
         )
 
@@ -67,7 +67,7 @@ def test_mongodb_reader_wrong_where_type(spark_mock, df_schema):
             connection=mongo,
             where="{'col_2': {'$eq': 2}, 'col_1': {'$gt': 1, '$lt': 100}, }",
             hint={"col1": 1},
-            table="table",
+            source="table",
             df_schema=df_schema,
         )
 
@@ -90,7 +90,7 @@ def test_mongodb_reader_where_wrong_value_match(spark_mock, df_schema):
         DBReader(
             connection=mongo,
             where=where,
-            table="table",
+            source="table",
             df_schema=df_schema,
         )
 
@@ -113,7 +113,7 @@ def test_mongodb_reader_where_wrong_value(spark_mock, df_schema):
         DBReader(
             connection=mongo,
             where=where,
-            table="table",
+            source="table",
             df_schema=df_schema,
         )
 
@@ -130,7 +130,7 @@ def test_mongodb_reader_without_df_schema(spark_mock):
     with pytest.raises(ValueError, match="'df_schema' parameter is mandatory for MongoDB"):
         DBReader(
             connection=mongo,
-            table="table",
+            source="table",
         )
 
 
@@ -147,4 +147,4 @@ def test_mongodb_reader_error_pass_columns(spark_mock, df_schema):
         ValueError,
         match="'columns' parameter is not supported by MongoDB",
     ):
-        DBReader(connection=mongo, table="table", columns=["_id", "test"], df_schema=df_schema)
+        DBReader(connection=mongo, source="table", columns=["_id", "test"], df_schema=df_schema)

--- a/tests/tests_unit/test_db/test_db_reader_unit/test_mssql_reader_unit.py
+++ b/tests/tests_unit/test_db/test_db_reader_unit/test_mssql_reader_unit.py
@@ -31,7 +31,7 @@ def test_mssql_reader_snapshot_error_pass_df_schema(spark_mock):
     with pytest.raises(ValueError, match="'df_schema' parameter is not supported by MSSQL"):
         DBReader(
             connection=conn,
-            table="schema.table",
+            source="schema.table",
             df_schema=df_schema,
         )
 
@@ -42,7 +42,7 @@ def test_mssql_reader_wrong_table_name(spark_mock):
     with pytest.raises(ValueError, match="Name should be passed in `schema.name` format"):
         DBReader(
             connection=mssql,
-            table="table",  # Required format: table="schema.table"
+            source="table",  # Required format: source="schema.table"
         )
 
 
@@ -56,7 +56,7 @@ def test_mssql_reader_wrong_hint_type(spark_mock):
         DBReader(
             connection=mssql,
             hint={"col1": 1},
-            table="schema.table",
+            source="schema.table",
         )
 
 
@@ -70,5 +70,5 @@ def test_mssql_reader_wrong_where_type(spark_mock):
         DBReader(
             connection=mssql,
             where={"col1": 1},
-            table="schema.table",
+            source="schema.table",
         )

--- a/tests/tests_unit/test_db/test_db_reader_unit/test_mysql_reader_unit.py
+++ b/tests/tests_unit/test_db/test_db_reader_unit/test_mysql_reader_unit.py
@@ -31,7 +31,7 @@ def test_mysql_reader_snapshot_error_pass_df_schema(spark_mock):
     with pytest.raises(ValueError, match="'df_schema' parameter is not supported by MySQL"):
         DBReader(
             connection=mysql,
-            table="schema.table",
+            source="schema.table",
             df_schema=df_schema,
         )
 
@@ -42,7 +42,7 @@ def test_mysql_reader_wrong_table_name(spark_mock):
     with pytest.raises(ValueError, match="Name should be passed in `schema.name` format"):
         DBReader(
             connection=mysql,
-            table="table",  # Required format: table="schema.table"
+            source="table",  # Required format: source="schema.table"
         )
 
 
@@ -56,7 +56,7 @@ def test_mysql_reader_wrong_hint_type(spark_mock):
         DBReader(
             connection=mysql,
             hint={"col1": 1},
-            table="schema.table",
+            source="schema.table",
         )
 
 
@@ -70,5 +70,5 @@ def test_mysql_reader_wrong_where_type(spark_mock):
         DBReader(
             connection=mysql,
             where={"col1": 1},
-            table="schema.table",
+            source="schema.table",
         )

--- a/tests/tests_unit/test_db/test_db_reader_unit/test_oracle_reader_unit.py
+++ b/tests/tests_unit/test_db/test_db_reader_unit/test_oracle_reader_unit.py
@@ -31,7 +31,7 @@ def test_oracle_reader_error_df_schema(spark_mock):
     with pytest.raises(ValueError, match="'df_schema' parameter is not supported by Oracle"):
         DBReader(
             connection=oracle,
-            table="schema.table",
+            source="schema.table",
             df_schema=df_schema,
         )
 
@@ -41,7 +41,7 @@ def test_oracle_reader_wrong_table_name(spark_mock):
     with pytest.raises(ValueError, match="Name should be passed in `schema.name` format"):
         DBReader(
             connection=oracle,
-            table="table",  # Required format: table="schema.table"
+            source="table",  # Required format: source="schema.table"
         )
 
 
@@ -55,7 +55,7 @@ def test_oracle_reader_wrong_hint_type(spark_mock):
         DBReader(
             connection=oracle,
             hint={"col1": 1},
-            table="schema.table",
+            source="schema.table",
         )
 
 
@@ -69,5 +69,5 @@ def test_oracle_reader_wrong_where_type(spark_mock):
         DBReader(
             connection=oracle,
             where={"col1": 1},
-            table="schema.table",
+            source="schema.table",
         )

--- a/tests/tests_unit/test_db/test_db_reader_unit/test_postgres_reader_unit.py
+++ b/tests/tests_unit/test_db/test_db_reader_unit/test_postgres_reader_unit.py
@@ -31,7 +31,7 @@ def test_postgres_reader_snapshot_error_pass_df_schema(spark_mock):
     with pytest.raises(ValueError, match="'df_schema' parameter is not supported by Postgres"):
         DBReader(
             connection=postgres,
-            table="schema.table",
+            source="schema.table",
             df_schema=df_schema,
         )
 
@@ -42,7 +42,7 @@ def test_postgres_reader_wrong_table_name(spark_mock):
     with pytest.raises(ValueError, match="Name should be passed in `schema.name` format"):
         DBReader(
             connection=postgres,
-            table="table",  # Required format: table="schema.table"
+            source="table",  # Required format: source="schema.table"
         )
 
 
@@ -56,7 +56,7 @@ def test_postgres_reader_hint_unsupported(spark_mock):
         DBReader(
             connection=postgres,
             hint="col1",
-            table="schema.table",
+            source="schema.table",
         )
 
 
@@ -70,5 +70,5 @@ def test_postgres_reader_wrong_where_type(spark_mock):
         DBReader(
             connection=postgres,
             where={"col1": 1},
-            table="schema.table",
+            source="schema.table",
         )

--- a/tests/tests_unit/test_db/test_db_reader_unit/test_teradata_reader_unit.py
+++ b/tests/tests_unit/test_db/test_db_reader_unit/test_teradata_reader_unit.py
@@ -31,7 +31,7 @@ def test_teradata_reader_snapshot_error_pass_df_schema(spark_mock):
     with pytest.raises(ValueError, match="'df_schema' parameter is not supported by Teradata"):
         DBReader(
             connection=teradata,
-            table="schema.table",
+            source="schema.table",
             df_schema=df_schema,
         )
 
@@ -42,7 +42,7 @@ def test_teradata_reader_wrong_table_name(spark_mock):
     with pytest.raises(ValueError, match="Name should be passed in `schema.name` format"):
         DBReader(
             connection=teradata,
-            table="table",  # Required format: table="schema.table"
+            source="table",  # Required format: source="schema.table"
         )
 
 
@@ -56,7 +56,7 @@ def test_teradata_reader_wrong_hint_type(spark_mock):
         DBReader(
             connection=teradata,
             hint={"col1": 1},
-            table="schema.table",
+            source="schema.table",
         )
 
 
@@ -70,5 +70,5 @@ def test_teradata_reader_wrong_where_type(spark_mock):
         DBReader(
             connection=teradata,
             where={"col1": 1},
-            table="schema.table",
+            source="schema.table",
         )

--- a/tests/tests_unit/test_db/test_db_writer_unit/test_clickhouse_writer_unit.py
+++ b/tests/tests_unit/test_db/test_db_writer_unit/test_clickhouse_writer_unit.py
@@ -12,5 +12,5 @@ def test_clickhouse_writer_wrong_table_name(spark_mock):
     with pytest.raises(ValueError, match="Name should be passed in `schema.name` format"):
         DBWriter(
             connection=clickhouse,
-            table="table",  # Required format: table="schema.table"
+            target="table",  # Required format: target="schema.table"
         )

--- a/tests/tests_unit/test_db/test_db_writer_unit/test_greenplum_writer_unit.py
+++ b/tests/tests_unit/test_db/test_db_writer_unit/test_greenplum_writer_unit.py
@@ -19,7 +19,7 @@ def test_greenplum_writer_wrong_table_name(spark_mock):
     with pytest.raises(ValueError, match="Name should be passed in `schema.name` format"):
         DBWriter(
             connection=greenplum,
-            table="table",  # Required format: table="schema.table"
+            target="table",  # Required format: target="schema.table"
         )
 
 
@@ -108,7 +108,7 @@ def test_greenplum_writer_number_of_connections_less_than_warning_threshold(
 
     writer = DBWriter(
         connection=greenplum,
-        table="schema.table",
+        target="schema.table",
     )
 
     conf = spark_mock.sparkContext.getConf()
@@ -247,7 +247,7 @@ def test_greenplum_writer_number_of_connections_higher_than_warning_threshold(
 
     writer = DBWriter(
         connection=greenplum,
-        table="schema.table",
+        target="schema.table",
     )
 
     conf = spark_mock.sparkContext.getConf()
@@ -381,7 +381,7 @@ def test_greenplum_writer_number_of_connections_higher_than_exception_threshold(
 
     writer = DBWriter(
         connection=greenplum,
-        table="schema.table",
+        target="schema.table",
     )
 
     conf = spark_mock.sparkContext.getConf()

--- a/tests/tests_unit/test_db/test_db_writer_unit/test_hive_writer_unit.py
+++ b/tests/tests_unit/test_db/test_db_writer_unit/test_hive_writer_unit.py
@@ -12,5 +12,5 @@ def test_hive_writer_wrong_table_name(spark_mock):
     with pytest.raises(ValueError, match="Name should be passed in `schema.name` format"):
         DBWriter(
             connection=hive,
-            table="table",  # Required format: table="schema.table"
+            target="table",  # Required format: target="schema.table"
         )

--- a/tests/tests_unit/test_db/test_db_writer_unit/test_mssql_writer_unit.py
+++ b/tests/tests_unit/test_db/test_db_writer_unit/test_mssql_writer_unit.py
@@ -12,5 +12,5 @@ def test_mssql_writer_wrong_table_name(spark_mock):
     with pytest.raises(ValueError, match="Name should be passed in `schema.name` format"):
         DBWriter(
             connection=mssql,
-            table="table",  # Required format: table="schema.table"
+            target="table",  # Required format: target="schema.table"
         )

--- a/tests/tests_unit/test_db/test_db_writer_unit/test_mysql_writer_unit.py
+++ b/tests/tests_unit/test_db/test_db_writer_unit/test_mysql_writer_unit.py
@@ -12,5 +12,5 @@ def test_mysql_writer_wrong_table_name(spark_mock):
     with pytest.raises(ValueError, match="Name should be passed in `schema.name` format"):
         DBWriter(
             connection=mysql,
-            table="table",  # Required format: table="schema.table"
+            target="table",  # Required format: target="schema.table"
         )

--- a/tests/tests_unit/test_db/test_db_writer_unit/test_oracle_writer_unit.py
+++ b/tests/tests_unit/test_db/test_db_writer_unit/test_oracle_writer_unit.py
@@ -12,5 +12,5 @@ def test_oracle_writer_wrong_table_name(spark_mock):
     with pytest.raises(ValueError, match="Name should be passed in `schema.name` format"):
         DBWriter(
             connection=oracle,
-            table="table",  # Required format: table="schema.table"
+            target="table",  # Required format: target="schema.table"
         )

--- a/tests/tests_unit/test_db/test_db_writer_unit/test_postgres_writer_unit.py
+++ b/tests/tests_unit/test_db/test_db_writer_unit/test_postgres_writer_unit.py
@@ -12,5 +12,5 @@ def test_postgres_writer_wrong_table_name(spark_mock):
     with pytest.raises(ValueError, match="Name should be passed in `schema.name` format"):
         DBWriter(
             connection=postgres,
-            table="table",  # Required format: table="schema.table"
+            target="table",  # Required format: target="schema.table"
         )

--- a/tests/tests_unit/test_db/test_db_writer_unit/test_teradata_writer_unit.py
+++ b/tests/tests_unit/test_db/test_db_writer_unit/test_teradata_writer_unit.py
@@ -12,5 +12,5 @@ def test_teradata_writer_wrong_table_name(spark_mock):
     with pytest.raises(ValueError, match="Name should be passed in `schema.name` format"):
         DBWriter(
             connection=teradata,
-            table="table",  # Required format: table="schema.table"
+            target="table",  # Required format: target="schema.table"
         )

--- a/tests/tests_unit/test_file/test_file_downloader_unit.py
+++ b/tests/tests_unit/test_file/test_file_downloader_unit.py
@@ -285,6 +285,6 @@ def test_file_downloader_options_mode_deprecated(options, value, message):
         assert options.if_exists == value
 
 
-def test_file_downloader_options_modes_wrong():
+def test_file_downloader_options_if_exists_wrong_value():
     with pytest.raises(ValueError, match="value is not a valid enumeration member"):
-        FileDownloader.Options(mode="wrong_mode")
+        FileDownloader.Options(if_exists="wrong_mode")

--- a/tests/tests_unit/test_file/test_file_mover_unit.py
+++ b/tests/tests_unit/test_file/test_file_mover_unit.py
@@ -54,6 +54,6 @@ def test_file_mover_options_mode_deprecated(options, value, message):
         assert options.if_exists == value
 
 
-def test_file_mover_options_modes_wrong():
+def test_file_mover_options_if_exists_wrong_value():
     with pytest.raises(ValueError, match="value is not a valid enumeration member"):
-        FileMover.Options(mode="wrong_mode")
+        FileMover.Options(if_exists="wrong_mode")

--- a/tests/tests_unit/test_file/test_file_uploader_unit.py
+++ b/tests/tests_unit/test_file/test_file_uploader_unit.py
@@ -73,6 +73,6 @@ def test_file_uploader_options_mode_deprecated(options, value, message):
         assert options.if_exists == value
 
 
-def test_file_uploader_options_modes_wrong():
+def test_file_uploader_options_if_exists_wrong_value():
     with pytest.raises(ValueError, match="value is not a valid enumeration member"):
-        FileUploader.Options(mode="wrong_mode")
+        FileUploader.Options(if_exists="wrong_mode")

--- a/tests/tests_unit/tests_db_connection_unit/test_greenplum_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_greenplum_unit.py
@@ -390,12 +390,6 @@ def test_greenplum_write_options_mode_deprecated(options, value, message):
         assert options.if_exists == value
 
 
-@pytest.mark.parametrize(
-    "options",
-    [
-        {"mode": "wrong_mode"},
-    ],
-)
-def test_greenplum_write_options_mode_wrong(options):
+def test_greenplum_write_options_mode_wrong():
     with pytest.raises(ValueError, match="value is not a valid enumeration member"):
-        Greenplum.WriteOptions(**options)
+        Greenplum.WriteOptions(if_exists="wrong_mode")

--- a/tests/tests_unit/tests_db_connection_unit/test_hive_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_hive_unit.py
@@ -224,12 +224,6 @@ def test_hive_write_options_mode_deprecated(options, value, message):
         assert options.if_exists == value
 
 
-@pytest.mark.parametrize(
-    "options",
-    [
-        {"mode": "wrong_mode"},
-    ],
-)
-def test_hive_write_options_mode_unsupported(options):
+def test_hive_write_options_if_exists_wrong_value():
     with pytest.raises(ValueError, match="value is not a valid enumeration member"):
-        Hive.WriteOptions(**options)
+        Hive.WriteOptions(if_exists="wrong_mode")

--- a/tests/tests_unit/tests_db_connection_unit/test_jdbc_options_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_jdbc_options_unit.py
@@ -314,12 +314,12 @@ def test_jdbc_write_options_mode_deprecated(options, value, message):
 @pytest.mark.parametrize(
     "options_class, options",
     [
-        (Postgres.WriteOptions, {"mode": "wrong_mode"}),
-        (Clickhouse.WriteOptions, {"mode": "wrong_mode"}),
-        (MSSQL.WriteOptions, {"mode": "wrong_mode"}),
-        (MySQL.WriteOptions, {"mode": "wrong_mode"}),
-        (Teradata.WriteOptions, {"mode": "wrong_mode"}),
-        (Oracle.WriteOptions, {"mode": "wrong_mode"}),
+        (Postgres.WriteOptions, {"if_exists": "wrong_mode"}),
+        (Clickhouse.WriteOptions, {"if_exists": "wrong_mode"}),
+        (MSSQL.WriteOptions, {"if_exists": "wrong_mode"}),
+        (MySQL.WriteOptions, {"if_exists": "wrong_mode"}),
+        (Teradata.WriteOptions, {"if_exists": "wrong_mode"}),
+        (Oracle.WriteOptions, {"if_exists": "wrong_mode"}),
     ],
 )
 def test_jdbc_write_options_mode_wrong(options_class, options):

--- a/tests/tests_unit/tests_db_connection_unit/test_mongodb_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_mongodb_unit.py
@@ -343,12 +343,6 @@ def test_mongodb_write_options_mode_deprecated(options, value, message):
         assert options.if_exists == value
 
 
-@pytest.mark.parametrize(
-    "options",
-    [
-        {"mode": "wrong_mode"},
-    ],
-)
-def test_mongodb_write_options_mode_wrong(options):
+def test_mongodb_write_options_if_exists_wrong_value():
     with pytest.raises(ValueError, match="value is not a valid enumeration member"):
-        MongoDB.WriteOptions(**options)
+        MongoDB.WriteOptions(if_exists="wrong_mode")

--- a/tests/tests_unit/tests_file_connection_unit/test_hdfs_unit.py
+++ b/tests/tests_unit/tests_file_connection_unit/test_hdfs_unit.py
@@ -52,11 +52,15 @@ def test_hdfs_connection_with_cluster_and_host():
 def test_hdfs_connection_with_host_and_port():
     from onetl.connection import HDFS
 
-    conn = HDFS(host="some-host.domain.com", port=9080)
-    assert conn.host == "some-host.domain.com"
-    assert conn.webhdfs_port == 9080
-    assert conn.instance_url == "hdfs://some-host.domain.com:9080"
-    assert str(conn) == "HDFS[some-host.domain.com:9080]"
+    conn1 = HDFS(host="some-host.domain.com", webhdfs_port=9080)
+    assert conn1.host == "some-host.domain.com"
+    assert conn1.webhdfs_port == 9080
+    assert conn1.instance_url == "hdfs://some-host.domain.com:9080"
+    assert str(conn1) == "HDFS[some-host.domain.com:9080]"
+
+    conn2 = HDFS(host="some-host.domain.com", port=9080)
+    assert conn1.webhdfs_port == conn2.webhdfs_port
+    assert conn1 == conn2
 
 
 def test_hdfs_connection_with_user():
@@ -147,7 +151,7 @@ def test_hdfs_connection_with_password_and_keytab(request, tmp_path_factory):
     request.addfinalizer(finalizer)
 
     with pytest.raises(ValueError, match="Please provide either `keytab` or `password` for kinit, not both"):
-        HDFS(host="hdfs2", port=50070, user="usr", password="pwd", keytab=keytab)  # noqa: F841
+        HDFS(host="hdfs2", webhdfs_port=50070, user="usr", password="pwd", keytab=keytab)  # noqa: F841
 
 
 def test_hdfs_get_known_clusters_hook(request):

--- a/tests/tests_unit/tests_file_df_connection_unit/test_spark_hdfs_unit.py
+++ b/tests/tests_unit/tests_file_df_connection_unit/test_spark_hdfs_unit.py
@@ -31,12 +31,16 @@ def test_spark_hdfs_with_cluster_and_host(spark_mock):
 
 
 def test_spark_hdfs_with_port(spark_mock):
-    conn = SparkHDFS(cluster="rnd-dwh", port=9020, spark=spark_mock)
-    assert isinstance(conn, BaseFileDFConnection)
-    assert conn.cluster == "rnd-dwh"
-    assert conn.ipc_port == 9020
-    assert conn.instance_url == "rnd-dwh"
-    assert str(conn) == "HDFS[rnd-dwh]"
+    conn1 = SparkHDFS(cluster="rnd-dwh", ipc_port=9020, spark=spark_mock)
+    assert isinstance(conn1, BaseFileDFConnection)
+    assert conn1.cluster == "rnd-dwh"
+    assert conn1.ipc_port == 9020
+    assert conn1.instance_url == "rnd-dwh"
+    assert str(conn1) == "HDFS[rnd-dwh]"
+
+    conn2 = SparkHDFS(cluster="rnd-dwh", port=9020, spark=spark_mock)
+    assert conn1.ipc_port == conn2.ipc_port
+    assert conn1 == conn2
 
 
 def test_spark_hdfs_without_cluster(spark_mock):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Due to https://github.com/pydantic/pydantic/issues/5893, VSCode prefers alias over original field name:
![Снимок экрана_20250313_173231](https://github.com/user-attachments/assets/a67f291a-1581-4dcf-9e79-c27beddf8335)
![Снимок экрана_20250313_174013](https://github.com/user-attachments/assets/69536610-aa7f-4232-8590-3fd8ad44723b)

But in some places we use `alias=...` for legacy field name, and original field name should be preferred:
![Снимок экрана_20250313_172725](https://github.com/user-attachments/assets/ce287a31-117a-42ea-84cd-1d1a7fd90a8d)
![Снимок экрана_20250313_174041](https://github.com/user-attachments/assets/0de77513-3bf6-4494-8635-2e9de248981d)

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [X] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
