### PR TITLE
[DOP-22430] Improve XML documentation

### DIFF
--- a/docs/file_df/file_formats/xml.rst
+++ b/docs/file_df/file_formats/xml.rst
@@ -6,4 +6,5 @@ XML
 .. currentmodule:: onetl.file.format.xml
 
 .. autoclass:: XML
-    :members: get_packages, parse_column
+    :members: get_packages, parse_column,arrayElementName,attributePrefix,charset,columnNameOfCorruptRecord,compression,dateFormat,declaration,excludeAttribute,ignoreNamespace,ignoreSurroundingSpaces,inferSchema,mode,nullValue,rootTag,rowTag,row_tag,rowValidationXSDPath,samplingRatio,timestampFormat,treatEmptyValuesAsNulls,valueTag,wildcardColName
+    :member-order: bysource

--- a/onetl/file/format/__init__.py
+++ b/onetl/file/format/__init__.py
@@ -8,3 +8,14 @@ from onetl.file.format.jsonline import JSONLine
 from onetl.file.format.orc import ORC
 from onetl.file.format.parquet import Parquet
 from onetl.file.format.xml import XML
+
+__all__ = [
+    "Avro",
+    "CSV",
+    "Excel",
+    "JSON",
+    "JSONLine",
+    "ORC",
+    "Parquet",
+    "XML",
+]

--- a/onetl/file/format/file_format.py
+++ b/onetl/file/format/file_format.py
@@ -60,10 +60,10 @@ class ReadWriteFileFormat(BaseReadableFileFormat, BaseWritableFileFormat, Generi
 
     @slot
     def apply_to_reader(self, reader: DataFrameReader) -> DataFrameReader:
-        options = self.dict(by_alias=True)
+        options = self.dict(by_alias=True, exclude_none=True)
         return reader.format(self.name).options(**options)
 
     @slot
     def apply_to_writer(self, writer: DataFrameWriter) -> DataFrameWriter:
-        options = self.dict(by_alias=True)
+        options = self.dict(by_alias=True, exclude_none=True)
         return writer.format(self.name).options(**options)

--- a/setup.cfg
+++ b/setup.cfg
@@ -355,6 +355,9 @@ per-file-ignores =
         F401,
 # WPS442 Found outer scope names shadowing: KerberosClient
         WPS442,
+    onetl/file/format/*.py:
+# N815  variable 'rootTag' in class scope should not be mixedCase
+        N815,
     onetl/hooks/slot.py:
 # WPS210 Found too many local variables
         WPS210,

--- a/tests/tests_unit/test_file/test_format_unit/test_xml_unit.py
+++ b/tests/tests_unit/test_file/test_format_unit/test_xml_unit.py
@@ -83,44 +83,58 @@ def test_xml_get_packages_package_version_error(spark_version, scala_version, pa
         )
 
 
+def test_xml_options_row_tag_case():
+    xml1 = XML(row_tag="item")
+    xml2 = XML(rowTag="item")
+    assert xml1 == xml2
+    assert xml1.row_tag == "item"
+    assert xml2.row_tag == "item"
+
+
 @pytest.mark.parametrize(
-    "known_option",
+    "known_option, raw_value, expected_value",
     [
-        "samplingRatio",
-        "excludeAttribute",
-        "treatEmptyValuesAsNulls",
-        "mode",
-        "inferSchema",
-        "columnNameOfCorruptRecord",
-        "attributePrefix",
-        "valueTag",
-        "charset",
-        "ignoreSurroundingSpaces",
-        "wildcardColName",
-        "rowValidationXSDPath",
-        "ignoreNamespace",
-        "timestampFormat",
-        "dateFormat",
-        "rootTag",
-        "declaration",
-        "arrayElementName",
-        "nullValue",
-        "compression",
+        ("samplingRatio", 0.1, 0.1),
+        ("excludeAttribute", True, True),
+        ("treatEmptyValuesAsNulls", "true", "true"),
+        ("mode", "PERMISSIVE", "PERMISSIVE"),
+        ("inferSchema", True, True),
+        ("columnNameOfCorruptRecord", "value", "value"),
+        ("attributePrefix", "value", "value"),
+        ("valueTag", "value", "value"),
+        ("charset", "value", "value"),
+        ("ignoreSurroundingSpaces", True, True),
+        ("wildcardColName", "value", "value"),
+        ("rowValidationXSDPath", "value", "value"),
+        ("ignoreNamespace", True, True),
+        ("timestampFormat", "value", "value"),
+        ("dateFormat", "value", "value"),
+        ("rootTag", "value", "value"),
+        ("declaration", "value", "value"),
+        ("arrayElementName", "value", "value"),
+        ("nullValue", "value", "value"),
+        ("compression", "gzip", "gzip"),
     ],
 )
-def test_xml_options_known(known_option):
-    xml = XML.parse({known_option: "value", "row_tag": "item"})
-    assert getattr(xml, known_option) == "value"
+def test_xml_options_known(known_option, raw_value, expected_value):
+    xml = XML.parse({known_option: raw_value, "rowTag": "item"})
+    assert getattr(xml, known_option) == expected_value
 
 
-def test_xml_option_path_error(caplog):
+def test_xml_option_path_error():
     msg = r"Options \['path'\] are not allowed to use in a XML"
     with pytest.raises(ValueError, match=msg):
-        XML(row_tag="item", path="/path")
+        XML(rowTag="item", path="/path")
 
 
 def test_xml_options_unknown(caplog):
     with caplog.at_level(logging.WARNING):
-        xml = XML(row_tag="item", unknownOption="abc")
+        xml = XML(rowTag="item", unknownOption="abc")
         assert xml.unknownOption == "abc"
     assert "Options ['unknownOption'] are not known by XML, are you sure they are valid?" in caplog.text
+
+
+def test_xml_options_repr():
+    # There are too many options with default value None, hide them from repr
+    xml = XML(rowTag="item", mode="PERMISSIVE", unknownOption="abc")
+    assert repr(xml) == "XML(rowTag='item', mode='PERMISSIVE', unknownOption='abc')"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Previously XML class documentation only noted that options are documented elsewhere. Now all of them are documented, included to constructor signature and can be recommended by IDE.
Almost all option values are None, and excluded from class repr.

Before:
https://onetl.readthedocs.io/en/0.13.3/file_df/file_formats/xml.html

After:
https://onetl--355.org.readthedocs.build/en/355/file_df/file_formats/xml.html

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [X] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
