### PR TITLE
[DOP-22432] Improve CSV documentation

### DIFF
--- a/docs/file_df/file_formats/csv.rst
+++ b/docs/file_df/file_formats/csv.rst
@@ -6,4 +6,5 @@ CSV
 .. currentmodule:: onetl.file.format.csv
 
 .. autoclass:: CSV
-    :members: __init__, parse_column, serialize_column
+    :members: __init__, parse_column, serialize_column, charToEscapeQuoteEscaping,columnNameOfCorruptRecord,comment,compression,dateFormat,delimiter,emptyValue,enforceSchema,escapeQuotes,header,ignoreLeadingWhiteSpace,ignoreTrailingWhiteSpace,inferSchema,locale,maxCharsPerColumn,mode,multiLine,nanValue,negativeInf,nullValue,positiveInf,preferDate,quote,quoteAll,samplingRatio,timestampFormat,timestampNTZFormat,unescapedQuoteHandling
+    :member-order: bysource

--- a/onetl/file/format/csv.py
+++ b/onetl/file/format/csv.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, Optional, Union
+
+from typing_extensions import Literal
 
 try:
     from pydantic.v1 import Field
@@ -19,48 +21,16 @@ if TYPE_CHECKING:
     from pyspark.sql import Column, SparkSession
     from pyspark.sql.types import StructType
 
-
-READ_WRITE_OPTIONS = frozenset(
-    (
-        "charToEscapeQuoteEscaping",
-        "dateFormat",
-        "emptyValue",
-        "ignoreLeadingWhiteSpace",
-        "ignoreTrailingWhiteSpace",
-        "nullValue",
-        "timestampFormat",
-        "timestampNTZFormat",
-    ),
-)
-
-READ_OPTIONS = frozenset(
-    (
-        "columnNameOfCorruptRecord",
-        "comment",
-        "enableDateTimeParsingFallback",
-        "enforceSchema",
-        "inferSchema",
-        "locale",
-        "maxCharsPerColumn",
-        "maxColumns",
-        "mode",
-        "multiLine",
-        "nanValue",
-        "negativeInf",
-        "positiveInf",
-        "preferDate",
-        "samplingRatio",
-        "unescapedQuoteHandling",
-    ),
-)
-
-WRITE_OPTIONS = frozenset(
-    (
-        "compression",
-        "escapeQuotes",
-        "quoteAll",
-    ),
-)
+PARSE_COLUMN_UNSUPPORTED_OPTIONS = {
+    "header",
+    "compression",
+    "encoding",
+    "inferSchema",
+    "samplingRatio",
+    "enforceSchema",
+    "preferDate",
+    "multiLine",
+}
 
 
 @support_hooks
@@ -78,36 +48,447 @@ class CSV(ReadWriteFileFormat):
         "some","value"
         "another","value"
 
-    .. note ::
-
-        You can pass any option to the constructor, even if it is not mentioned in this documentation.
-        **Option names should be in** ``camelCase``!
-
-        The set of supported options depends on Spark version. See link above.
-
     .. versionadded:: 0.9.0
 
     Examples
     --------
 
-    Describe options how to read from/write to CSV file with specific options:
+    .. note ::
 
-    .. code:: python
+        You can pass any option mentioned in `official documentation <https://spark.apache.org/docs/latest/sql-data-sources-csv.html>`_.
 
-        csv = CSV(sep=",", encoding="utf-8", inferSchema=True, compression="gzip")
+        The set of supported options depends on Spark version.
+
+    .. tabs::
+
+        .. code-tab:: py Read files
+
+            # Create Spark session
+            spark = ...
+
+            # Read file /some/file.CSV from local file system
+            from onetl.connection import SparkLocalFS
+            from onetl.file import FileDFReader
+            from onetl.file.format import CSV
+
+            csv = CSV(header=True, inferSchema=True, mode="PERMISSIVE")
+
+            reader = FileDFReader(
+                connection=SparkLocalFS(spark=spark),
+                format=csv,
+            )
+            df = reader.run(["/some/file.csv"])
+
+        .. code-tab:: py Write files
+
+            # Create Spark session
+            spark = ...
+            # Defined DataFrame
+            df = ...
+
+            # Write DataFrame as CSV files at /some/folder on local file system
+            from onetl.connection import SparkLocalFS
+            from onetl.file import FileDFWriter
+            from onetl.file.format import CSV
+
+            csv = CSV(header=True, compression="gzip")
+
+            writer = FileDFWriter(
+                connection=SparkLocalFS(spark=spark),
+                format=csv,
+                target_path="/some/folder",
+            )
+            writer.run(df)
 
     """
 
     name: ClassVar[str] = "csv"
+
     delimiter: str = Field(default=",", alias=avoid_alias("sep"))  # type: ignore[literal-required]
-    encoding: str = "utf-8"
-    quote: str = '"'
-    escape: str = "\\"
-    header: bool = False
-    lineSep: str = "\n"  # noqa: N815
+    """
+    Character used to separate fields in CSV row.
+    """
+
+    header: Optional[bool] = None
+    """
+    If ``True``, the first row of the file is considered a header.
+    Default ``False``.
+    """
+
+    quote: str = Field(default='"', max_length=1)
+    """
+    Character used to quote field values within CSV field.
+
+    Empty string is considered as ``\\u0000`` (``NUL``) character.
+    """
+
+    quoteAll: Optional[bool] = None
+    """
+    If ``True``, all fields are quoted:
+
+    .. code:: csv
+
+        "some","field with \\"quote","123",""
+
+    If ``False``, only quote fields containing :obj:`~quote` symbols.
+
+    .. code:: csv
+
+        any,"field with \\"quote",123,
+
+    Default ``False``.
+
+    .. note::
+
+        Used only for writing files.
+    """
+
+    escape: str = Field(default="\\", max_length=1)
+    """
+    Character used to escape quotes within CSV field.
+
+    Empty string is considered as ``\\u0000`` (``NUL``) character.
+    """
+
+    lineSep: Optional[str] = Field(default=None, min_length=1, max_length=2)
+    """
+    Character used to separate lines in the CSV file.
+
+    Defaults:
+      * Try to detect for reading (``\\r\\n``, ``\\r``, ``\\n``)
+      * ``\\n`` for writing
+
+    .. note::
+
+        Used only for reading and writing files.
+        Ignored by :obj:`~parse_column` method, as it expects that each DataFrame row will contain exactly one CSV line.
+    """
+
+    encoding: Optional[str] = Field(default=None, min_length=1)
+    """
+    Encoding of the CSV file.
+    Default ``UTF-8``.
+
+    .. note::
+
+        Used only for reading and writing files. Ignored by :obj:`~parse_column` method.
+    """
+
+    compression: Union[str, Literal["none", "bzip2", "gzip", "lz4", "snappy", "deflate"], None] = None
+    """
+    Compression codec of the CSV file.
+    Default ``none``.
+
+    .. note::
+
+        Used only for writing files. Ignored by :obj:`~parse_column` method.
+    """
+
+    inferSchema: Optional[bool] = None
+    """
+    If ``True``, try to infer the input schema by reading a sample of the file (see :obj:`~samplingRatio`).
+    Default ``False`` which means that all parsed columns will be ``StringType()``.
+
+    .. note::
+
+        Used only for reading files, and only if user haven't provider explicit DataFrame schema.
+        Ignored by :obj:`~parse_column` function.
+    """
+
+    samplingRatio: Optional[float] = Field(default=None, ge=0, le=1)
+    """
+    For ``inferSchema=True``, read the specified fraction of rows to infer the schema.
+    Default ``1``.
+
+    .. note::
+
+        Used only for reading files. Ignored by :obj:`~parse_column` function.
+    """
+
+    comment: Optional[str] = Field(default=None, max_length=1)
+    """
+    If set, all lines starting with specified character (e.g. ``#``) are considered a comment, and skipped.
+    Default is not set, meaning that CSV lines should not contain comments.
+
+    .. note::
+
+        Used only for reading files and :obj:`~parse_column` method.
+    """
+
+    enforceSchema: Optional[bool] = None
+    """
+    If ``True``, inferred or user-provided schema has higher priority than CSV file headers.
+    This means that all input files should have the same structure.
+
+    If ``False``, CSV headers are used as a primary source of information about column names and their position.
+
+    Default ``True``.
+
+    .. note::
+
+        Used only for reading files. Ignored by :obj:`~parse_column` function.
+    """
+
+    escapeQuotes: Optional[bool] = None
+    """
+    If ``True``, escape quotes within CSV field.
+
+    .. code:: csv
+
+        any,field with \\"quote,123,
+
+    If ``False``, wrap fields containing :obj:`~quote` symbols with quotes.
+
+    .. code:: csv
+
+        any,"field with ""quote ",123,
+
+    Default ``True``.
+
+    .. note::
+
+        Used only for writing files.
+    """
+
+    unescapedQuoteHandling: Union[
+        None,
+        Literal[
+            "STOP_AT_CLOSING_QUOTE",
+            "BACK_TO_DELIMITER",
+            "STOP_AT_DELIMITER",
+            "SKIP_VALUE",
+            "RAISE_ERROR",
+        ],
+    ] = None
+    """
+    Define how to handle unescaped quotes within CSV field.
+
+    * ``STOP_AT_CLOSING_QUOTE`` - collect all characters until closing quote.
+    * ``BACK_TO_DELIMITER`` - collect all characters until delimiter or line end.
+    * ``STOP_AT_DELIMITER`` - collect all characters until delimiter or line end.
+       If quotes are not closed, this may produce incorrect results (e.g. including delimiter inside field value).
+    * ``SKIP_VALUE`` - skip field and consider it as :obj:`~nullValue`.
+    * ``RAISE_ERROR`` - raise error immediately.
+
+    Default ``STOP_AT_DELIMITER``.
+
+    .. note::
+
+        Used only for reading files and :obj:`~parse_column` method.
+    """
+
+    ignoreLeadingWhiteSpace: Optional[bool] = None
+    """
+    If ``True``, trim leading whitespaces in field value.
+
+    Defaults:
+      * ``True`` for reading.
+      * ``False`` for writing.
+    """
+
+    ignoreTrailingWhiteSpace: Optional[bool] = None
+    """
+    If ``True``, trim trailing whitespaces in field value.
+
+    Defaults:
+      * ``True`` for reading.
+      * ``False`` for writing.
+    """
+
+    emptyValue: Optional[str] = None
+    """
+    Value used for empty string fields.
+
+    Defaults:
+      * empty string for reading.
+      * ``""`` for writing.
+    """
+
+    nullValue: Optional[str] = None
+    """
+    If set, this value will be converted to ``null``.
+    Default is empty string.
+    """
+
+    nanValue: Optional[str] = Field(default=None)
+    """
+    If set, this string will be considered as Not-A-Number (NaN) value for ``FloatType()`` and ``DoubleType()``.
+    Default is ``NaN``.
+
+    .. note::
+
+        Used only for reading files and :obj:`~parse_column` method.
+    """
+
+    positiveInf: Optional[str] = Field(default=None, min_length=1)
+    """
+    If set, this string will be considered as positive infinity value for ``FloatType()`` and ``DoubleType()``.
+    Default is ``Inf``.
+
+    .. note::
+
+        Used only for reading files and :obj:`~parse_column` method.
+    """
+
+    negativeInf: Optional[str] = Field(default=None, min_length=1)
+    """
+    If set, this string will be considered as negative infinity value for ``FloatType()`` and ``DoubleType()``.
+    Default is ``-Inf``.
+
+    .. note::
+
+        Used only for reading files and :obj:`~parse_column` method.
+    """
+
+    preferDate: Optional[bool] = None
+    """
+    If ``True`` and ``inferSchema=True`` and column does match :obj:`~dateFormat`, consider it as ``DateType()``.
+    For columns matching both :obj:`~timestampFormat` and :obj:`~dateFormat`, consider it as ``TimestampType()``.
+
+    If ``False``, date and timestamp columns will be considered as ``StringType()``.
+
+    Default ``True``.
+
+    .. note::
+
+        Used only for reading files. Ignored by :obj:`~parse_column` function.
+    """
+
+    dateFormat: Optional[str] = Field(default=None, min_length=1)
+    """
+    String format for ``DateType()`` representation.
+    Default is ``yyyy-MM-dd``.
+    """
+
+    timestampFormat: Optional[str] = Field(default=None, min_length=1)
+    """
+    String format for `TimestampType()`` representation.
+    Default is ``yyyy-MM-dd'T'HH:mm:ss[.SSS][XXX]``.
+    """
+
+    timestampNTZFormat: Optional[str] = Field(default=None, min_length=1)
+    """
+    String format for `TimestampNTZType()`` representation.
+    Default is ``yyyy-MM-dd'T'HH:mm:ss[.SSS]``.
+
+    .. note::
+
+        Added in Spark 3.2.0
+    """
+
+    locale: Optional[str] = Field(default=None, min_length=1)
+    """
+    Locale name used to parse dates and timestamps.
+    Default is ``en-US``
+
+    ..  note::
+
+        Used only for reading files and :obj:`~parse_column` method.
+    """
+
+    maxCharsPerColumn: Optional[int] = None
+    """
+    Maximum number of characters to read per column.
+    Default is ``-1``, which means no limit.
+
+    .. note::
+
+        Used only for reading files and :obj:`~parse_column` method.
+    """
+
+    mode: Optional[Literal["PERMISSIVE", "DROPMALFORMED", "FAILFAST"]] = None
+    """
+    How to handle parsing errors:
+      * ``PERMISSIVE`` - set field value as ``null``, move raw data to :obj:`~columnNameOfCorruptRecord` column.
+      * ``DROPMALFORMED`` - skip the malformed row.
+      * ``FAILFAST`` - throw an error immediately.
+
+    Default is ``PERMISSIVE``.
+
+    .. note::
+
+        Used only for reading files and :obj:`~parse_column` method.
+    """
+
+    columnNameOfCorruptRecord: Optional[str] = Field(default=None, min_length=1)
+    """
+    Name of column to put corrupt records in.
+    Default is ``_corrupt_record``.
+
+    .. warning::
+
+        If DataFrame schema is provided, this column should be added to schema explicitly:
+
+        .. code:: python
+
+            from onetl.connection import SparkLocalFS
+            from onetl.file import FileDFReader
+            from onetl.file.format import CSV
+
+            from pyspark.sql.types import StructType, StructField, TimestampType, StringType
+
+            spark = ...
+
+            schema = StructType(
+                [
+                    StructField("my_field", TimestampType()),
+                    StructField("_corrupt_record", StringType()),  # <-- important
+                ]
+            )
+
+            csv = CSV(mode="PERMISSIVE", columnNameOfCorruptRecord="_corrupt_record")
+
+            reader = FileDFReader(
+                connection=connection,
+                format=csv,
+                schema=schema,  # < ---
+            )
+            df = reader.run(["/some/file.csv"])
+
+    .. note::
+
+        Used only for reading files and :obj:`~parse_column` method.
+    """
+
+    multiLine: Optional[bool] = None
+    """
+    If ``True``, fields may contain line separators.
+    If ``False``, the input is expected to have one record per file.
+
+    Default is ``True``.
+
+    .. note::
+
+        Used only for reading files.
+        Ignored by :obj:`~parse_column` method, as it expects that each DataFrame row will contain exactly one CSV line.
+    """
+
+    charToEscapeQuoteEscaping: Optional[str] = Field(default=None, max_length=1)
+    """
+    If CSV field value contains :obj:`~escape` character, it should be escaped as well.
+    For example, if ``escape="\\"``, when line:
+
+    .. code:: csv
+
+        "some \\" quoted value",other
+        "some \\\\ backslashed value",another
+
+    will be parsed as:
+
+    .. code:: python
+
+        [
+            ('some " quoted value', "other"),
+            ("some \\ backslashed value", "another"),
+        ]
+
+    And vice-versa, for writing CSV rows to file.
+
+    Default is same as :obj:`~escape`.
+    """
 
     class Config:
-        known_options = READ_WRITE_OPTIONS | READ_OPTIONS | WRITE_OPTIONS
+        known_options = frozenset()
         extra = "allow"
 
     @slot
@@ -193,7 +574,7 @@ class CSV(ReadWriteFileFormat):
             column_name, column = column, col(column).cast("string")
 
         schema_string = schema.simpleString()
-        options = stringify(self.dict(by_alias=True))
+        options = stringify(self.dict(by_alias=True, exclude_none=True))
         return from_csv(column, schema_string, options).alias(column_name)
 
     def serialize_column(self, column: str | Column) -> Column:
@@ -264,7 +645,7 @@ class CSV(ReadWriteFileFormat):
         else:
             column_name, column = column, col(column)
 
-        options = stringify(self.dict(by_alias=True))
+        options = stringify(self.dict(by_alias=True, exclude_none=True))
         return to_csv(column, options).alias(column_name)
 
     def _check_spark_version_for_serialization(self, spark: SparkSession):
@@ -278,13 +659,16 @@ class CSV(ReadWriteFileFormat):
             raise ValueError(error_msg)
 
     def _check_unsupported_serialization_options(self):
-        unsupported_options = ["header", "compression", "inferSchema"]
-        current_options = self.dict()
-        for option in unsupported_options:
-            if current_options.get(option):
-                warnings.warn(
-                    f"Option `{option}` is set but not supported in `CSV.parse_column` or `CSV.serialize_column`. "
-                    "This may lead to unexpected behavior.",
-                    UserWarning,
-                    stacklevel=2,
-                )
+        current_options = self.dict(by_alias=True, exclude_none=True)
+        unsupported_options = current_options.keys() & PARSE_COLUMN_UNSUPPORTED_OPTIONS
+        if unsupported_options:
+            warnings.warn(
+                f"Options `{sorted(unsupported_options)}` are set but not supported in `CSV.parse_column` or `CSV.serialize_column`.",
+                UserWarning,
+                stacklevel=2,
+            )
+
+    def __repr__(self):
+        options_dict = self.dict(by_alias=True, exclude_none=True)
+        options_kwargs = ", ".join(f"{k}={v!r}" for k, v in options_dict.items())
+        return f"{self.__class__.__name__}({options_kwargs})"

--- a/onetl/file/format/file_format.py
+++ b/onetl/file/format/file_format.py
@@ -34,7 +34,7 @@ class ReadOnlyFileFormat(BaseReadableFileFormat, GenericOptions):
 
     @slot
     def apply_to_reader(self, reader: DataFrameReader) -> DataFrameReader:
-        options = self.dict(by_alias=True)
+        options = self.dict(by_alias=True, exclude_none=True)
         return reader.format(self.name).options(**options)
 
 
@@ -47,7 +47,7 @@ class WriteOnlyFileFormat(BaseWritableFileFormat, GenericOptions):
 
     @slot
     def apply_to_writer(self, writer: DataFrameWriter) -> DataFrameWriter:
-        options = self.dict(by_alias=True)
+        options = self.dict(by_alias=True, exclude_none=True)
         return writer.format(self.name).options(**options)
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -358,6 +358,8 @@ per-file-ignores =
     onetl/file/format/*.py:
 # N815  variable 'rootTag' in class scope should not be mixedCase
         N815,
+# WPS342 Found implicit raw string
+        WPS342,
     onetl/hooks/slot.py:
 # WPS210 Found too many local variables
         WPS210,

--- a/tests/tests_unit/test_file/test_format_unit/test_csv_unit.py
+++ b/tests/tests_unit/test_file/test_format_unit/test_csv_unit.py
@@ -10,70 +10,54 @@ pytestmark = [pytest.mark.csv]
 def test_csv_options_default():
     csv = CSV()
     assert csv.delimiter == ","
-    assert csv.encoding == "utf-8"
     assert csv.quote == '"'
     assert csv.escape == "\\"
-    assert csv.header is False
-    assert csv.lineSep == "\n"
-
-
-def test_csv_options_default_override():
-    csv = CSV(
-        delimiter="value",
-        encoding="value",
-        quote="value",
-        escape="value",
-        header=True,
-        lineSep="value",
-    )
-    assert csv.delimiter == "value"
-    assert csv.encoding == "value"
-    assert csv.quote == "value"
-    assert csv.escape == "value"
-    assert csv.header is True
-    assert csv.lineSep == "value"
 
 
 def test_csv_options_delimiter_alias():
-    csv = CSV(sep="value")
-    assert csv.delimiter == "value"
+    csv = CSV(sep=";")
+    assert csv.delimiter == ";"
 
 
 @pytest.mark.parametrize(
-    "known_option",
+    "known_option, value, expected_value",
     [
-        "charToEscapeQuoteEscaping",
-        "dateFormat",
-        "emptyValue",
-        "ignoreLeadingWhiteSpace",
-        "ignoreTrailingWhiteSpace",
-        "nullValue",
-        "timestampFormat",
-        "timestampNTZFormat",
-        "columnNameOfCorruptRecord",
-        "comment",
-        "enableDateTimeParsingFallback",
-        "enforceSchema",
-        "inferSchema",
-        "locale",
-        "maxCharsPerColumn",
-        "maxColumns",
-        "mode",
-        "multiLine",
-        "nanValue",
-        "negativeInf",
-        "positiveInf",
-        "preferDate",
-        "samplingRatio",
-        "unescapedQuoteHandling",
-        "compression",
-        "escapeQuotes",
-        "quoteAll",
+        ("delimiter", ";", ";"),
+        ("quote", "'", "'"),
+        ("escape", "#", "#"),
+        ("encoding", "value", "value"),
+        ("header", True, True),
+        ("lineSep", "\r\n", "\r\n"),
+        ("charToEscapeQuoteEscaping", "\\", "\\"),
+        ("dateFormat", "value", "value"),
+        ("emptyValue", "value", "value"),
+        ("ignoreLeadingWhiteSpace", True, True),
+        ("ignoreTrailingWhiteSpace", True, True),
+        ("nullValue", "value", "value"),
+        ("timestampFormat", "value", "value"),
+        ("timestampNTZFormat", "value", "value"),
+        ("columnNameOfCorruptRecord", "value", "value"),
+        ("comment", "#", "#"),
+        ("enforceSchema", True, True),
+        ("inferSchema", True, True),
+        ("locale", "value", "value"),
+        ("maxCharsPerColumn", 120, 120),
+        ("mode", "PERMISSIVE", "PERMISSIVE"),
+        ("multiLine", True, True),
+        ("nanValue", "value", "value"),
+        ("negativeInf", "value", "value"),
+        ("positiveInf", "value", "value"),
+        ("preferDate", True, True),
+        ("samplingRatio", 0.1, 0.1),
+        ("unescapedQuoteHandling", "STOP_AT_DELIMITER", "STOP_AT_DELIMITER"),
+        ("compression", "gzip", "gzip"),
+        ("escapeQuotes", True, True),
+        ("quoteAll", True, True),
     ],
 )
-def test_csv_options_known(known_option):
-    csv = CSV.parse({known_option: "value"})
-    assert getattr(csv, known_option) == "value"
+def test_csv_options_known(known_option, value, expected_value):
+    csv = CSV.parse({known_option: value})
+    assert getattr(csv, known_option) == expected_value
 
 
 def test_csv_options_unknown(caplog):
@@ -82,3 +66,9 @@ def test_csv_options_unknown(caplog):
         assert csv.unknown == "abc"
 
     assert ("Options ['unknown'] are not known by CSV, are you sure they are valid?") in caplog.text
+
+
+def test_csv_options_repr():
+    # There are too many options with default value None, hide them from repr
+    csv = CSV(header=True, mode="PERMISSIVE", unknownOption="abc")
+    assert repr(csv) == "CSV(sep=',', header=True, quote='\"', escape='\\\\', mode='PERMISSIVE', unknownOption='abc')"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Previously CSV class documentation only noted that options are documented elsewhere. Now all of them are documented, included to constructor signature and can be recommended by IDE.
Almost all option values are None, and excluded from class repr.

Before:
https://onetl.readthedocs.io/en/0.13.3/file_df/file_formats/csv.html

After:
https://onetl--358.org.readthedocs.build/en/358/file_df/file_formats/csv.html

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [X] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
