### PR TITLE
[DOP-22433] Improve JSON/JSONLine documentation

### DIFF
--- a/docs/file_df/file_formats/json.rst
+++ b/docs/file_df/file_formats/json.rst
@@ -6,4 +6,5 @@ JSON
 .. currentmodule:: onetl.file.format.json
 
 .. autoclass:: JSON
-    :members: __init__, parse_column, serialize_column
+    :members: __init__, parse_column, serialize_column, allowBackslashEscapingAnyCharacter,allowComments,allowNonNumericNumbers,allowNumericLeadingZeros,allowSingleQuotes,allowUnquotedControlChars,allowUnquotedFieldNames,columnNameOfCorruptRecord,dateFormat,dropFieldIfAllNull,encoding,lineSep,locale,mode,prefersDecimal,primitivesAsString,samplingRatio,timestampFormat,timestampNTZFormat,timezone
+    :member-order: bysource

--- a/docs/file_df/file_formats/jsonline.rst
+++ b/docs/file_df/file_formats/jsonline.rst
@@ -6,4 +6,5 @@ JSONLine
 .. currentmodule:: onetl.file.format.jsonline
 
 .. autoclass:: JSONLine
-    :members: __init__
+    :members: __init__, allowBackslashEscapingAnyCharacter,allowComments,allowNonNumericNumbers,allowNumericLeadingZeros,allowSingleQuotes,allowUnquotedControlChars,allowUnquotedFieldNames,columnNameOfCorruptRecord,compression,dateFormat,dropFieldIfAllNull,encoding,ignoreNullFields,lineSep,locale,mode,prefersDecimal,primitivesAsString,samplingRatio,timestampFormat,timestampNTZFormat,timezone
+    :member-order: bysource

--- a/onetl/file/format/file_format.py
+++ b/onetl/file/format/file_format.py
@@ -34,7 +34,7 @@ class ReadOnlyFileFormat(BaseReadableFileFormat, GenericOptions):
 
     @slot
     def apply_to_reader(self, reader: DataFrameReader) -> DataFrameReader:
-        options = self.dict(by_alias=True)
+        options = self.dict(by_alias=True, exclude_none=True)
         return reader.format(self.name).options(**options)
 
 
@@ -47,7 +47,7 @@ class WriteOnlyFileFormat(BaseWritableFileFormat, GenericOptions):
 
     @slot
     def apply_to_writer(self, writer: DataFrameWriter) -> DataFrameWriter:
-        options = self.dict(by_alias=True)
+        options = self.dict(by_alias=True, exclude_none=True)
         return writer.format(self.name).options(**options)
 
 

--- a/onetl/file/format/json.py
+++ b/onetl/file/format/json.py
@@ -2,9 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar
+import warnings
+from typing import TYPE_CHECKING, ClassVar, Optional
 
 from typing_extensions import Literal
+
+try:
+    from pydantic.v1 import Field
+except (ImportError, AttributeError):
+    from pydantic import Field  # type: ignore[no-redef, assignment]
 
 from onetl._util.spark import stringify
 from onetl.file.format.file_format import ReadOnlyFileFormat
@@ -15,41 +21,14 @@ if TYPE_CHECKING:
     from pyspark.sql.types import ArrayType, MapType, StructType
 
 
-READ_WRITE_OPTIONS = frozenset(
-    (
-        "dateFormat",
-        "enableDateTimeParsingFallback",
-        "timestampFormat",
-        "timestampNTZFormat",
-        "timeZone",
-    ),
-)
-
-READ_OPTIONS = frozenset(
-    (
-        "allowBackslashEscapingAnyCharacter",
-        "allowComments",
-        "allowNonNumericNumbers",
-        "allowNumericLeadingZeros",
-        "allowSingleQuotes",
-        "allowUnquotedControlChars",
-        "allowUnquotedFieldNames",
-        "columnNameOfCorruptRecord",
-        "dropFieldIfAllNull",
-        "locale",
-        "mode",
-        "prefersDecimal",
-        "primitivesAsString",
-        "samplingRatio",
-    ),
-)
-
-WRITE_OPTIONS = frozenset(
-    (
-        "compression",
-        "ignoreNullFields",
-    ),
-)
+PARSE_COLUMN_UNSUPPORTED_OPTIONS = {
+    "encoding",
+    "lineSep",
+    "samplingRatio",
+    "primitivesAsString",
+    "prefersDecimal",
+    "dropFieldIfAllNull",
+}
 
 
 @support_hooks
@@ -71,36 +50,282 @@ class JSON(ReadOnlyFileFormat):
 
     .. warning::
 
-        For writing prefer using :obj:`JSONLine <onetl.file.format.jsonline.JSONLine>`.
-
-    .. note ::
-
-        You can pass any option to the constructor, even if it is not mentioned in this documentation.
-        **Option names should be in** ``camelCase``!
-
-        The set of supported options depends on Spark version. See link above.
+        For writing files use :obj:`JSONLine <onetl.file.format.jsonline.JSONLine>`.
 
     .. versionadded:: 0.9.0
 
     Examples
     --------
 
-    Describe options how to read from/write to JSON file with specific options:
+    .. note ::
+
+        You can pass any option mentioned in `official documentation <https://spark.apache.org/docs/latest/sql-data-sources-json.html>`_.
+
+        The set of supported options depends on Spark version.
+
+    Read files:
 
     .. code:: python
 
-        json = JSON(encoding="utf-8", compression="gzip")
+        # Create Spark session
+        spark = ...
+
+        # Read file /some/file.JSON from local file system
+        from onetl.connection import SparkLocalFS
+        from onetl.file import FileDFReader
+        from onetl.file.format import JSON
+
+        json = JSON(encoding="utf-8")
+
+        reader = FileDFReader(
+            connection=SparkLocalFS(spark=spark),
+            format=json,
+        )
+        df = reader.run(["/some/file.json"])
 
     """
 
     name: ClassVar[str] = "json"
 
-    multiLine: Literal[True] = True  # noqa: N815
-    encoding: str = "utf-8"
-    lineSep: str = "\n"  # noqa: N815
+    multiLine: Literal[True] = True
+
+    encoding: Optional[str] = None
+    """
+    Encoding of the JSON file.
+    Default ``UTF-8``.
+
+    .. note::
+
+        Used only for reading and writing files.
+
+        Ignored by :obj:`~parse_column` and :obj:`~serialize_column` methods.
+    """
+
+    lineSep: Optional[str] = None
+    """
+    Character used to separate lines in the JSON file.
+
+    Defaults:
+      * Try to detect for reading (``\\r\\n``, ``\\r``, ``\\n``)
+      * ``\\n`` for writing
+
+    .. note::
+
+        Used only for reading and writing files.
+
+        Ignored by :obj:`~parse_column` and :obj:`~serialize_column` methods,
+        as they handle each DataFrame row separately.
+    """
+
+    allowComments: Optional[bool] = None
+    """
+    If ``True``, add support for C/C++/Java style comments (``//``, ``/* */``).
+    Default ``False``, meaning that JSON files should not contain comments.
+
+    .. note::
+
+        Used only for reading files and :obj:`~parse_column` method.
+    """
+
+    allowUnquotedFieldNames: Optional[bool] = None
+    """
+    If ``True``, allow JSON object field names without quotes (JavaScript-style).
+    Default ``False``.
+
+    .. note::
+
+        Used only for reading files and :obj:`~parse_column` method.
+    """
+
+    allowSingleQuotes: Optional[bool] = None
+    """
+    If ``True``, allow JSON object field names to be wrapped with single quotes (``'``).
+    Default ``True``.
+
+    .. note::
+
+        Used only for reading files and :obj:`~parse_column` method.
+    """
+
+    allowNumericLeadingZeros: Optional[bool] = None
+    """
+    If ``True``, allow leading zeros in numbers (e.g. ``00012``).
+    Default ``False``.
+
+    .. note::
+
+        Used only for reading files and :obj:`~parse_column` method.
+    """
+
+    allowNonNumericNumbers: Optional[bool] = None
+    """
+    If ``True``, allow numbers to contain non-numeric characters, like:
+      * scientific notation (e.g. ``12e10``).
+      * positive infinity floating point value (``Infinity``, ``+Infinity``, ``+INF``).
+      * negative infinity floating point value (``-Infinity``, ``-INF``).
+      * Not-a-Number floating point value (``NaN``).
+
+    Default ``True``.
+
+    .. note::
+
+        Used only for reading files and :obj:`~parse_column` method.
+    """
+
+    allowBackslashEscapingAnyCharacter: Optional[bool] = None
+    """
+    If ``True``, prefix ``\\`` can escape any character.
+    Default ``False``.
+
+    .. note::
+
+        Used only for reading files and :obj:`~parse_column` method.
+    """
+
+    allowUnquotedControlChars: Optional[bool] = None
+    """
+    If ``True``, allow unquoted control characters (ASCII values 0-31) in strings without escaping them with ``\\``.
+    Default ``False``.
+
+    .. note::
+
+        Used only for reading files and :obj:`~parse_column` method.
+    """
+
+    mode: Optional[Literal["PERMISSIVE", "DROPMALFORMED", "FAILFAST"]] = None
+    """
+    How to handle parsing errors:
+      * ``PERMISSIVE`` - set field value as ``null``, move raw data to :obj:`~columnNameOfCorruptRecord` column.
+      * ``DROPMALFORMED`` - skip the malformed row.
+      * ``FAILFAST`` - throw an error immediately.
+
+    Default is ``PERMISSIVE``.
+
+    .. note::
+
+        Used only for reading files and :obj:`~parse_column` method.
+    """
+
+    columnNameOfCorruptRecord: Optional[str] = Field(default=None, min_length=1)
+    """
+    Name of column to put corrupt records in.
+    Default is ``_corrupt_record``.
+
+    .. warning::
+
+        If DataFrame schema is provided, this column should be added to schema explicitly:
+
+        .. code:: python
+
+            from onetl.connection import SparkLocalFS
+            from onetl.file import FileDFReader
+            from onetl.file.format import JSON
+
+            from pyspark.sql.types import StructType, StructField, TimestampType, StringType
+
+            spark = ...
+
+            schema = StructType(
+                [
+                    StructField("my_field", TimestampType()),
+                    StructField("_corrupt_record", StringType()),  # <-- important
+                ]
+            )
+
+            json = JSON(mode="PERMISSIVE", columnNameOfCorruptRecord="_corrupt_record")
+
+            reader = FileDFReader(
+                connection=connection,
+                format=json,
+                schema=schema,  # < ---
+            )
+            df = reader.run(["/some/file.json"])
+
+    .. note::
+
+        Used only for reading files and :obj:`~parse_column` method.
+    """
+
+    samplingRatio: Optional[float] = Field(default=None, ge=0, le=1)
+    """
+    While inferring schema, read the specified fraction of file rows.
+    Default ``1``.
+
+    .. note::
+
+        Used only for reading files. Ignored by :obj:`~parse_column` function.
+    """
+
+    primitivesAsString: Optional[bool] = None
+    """
+    If ``True``, infer all primitive types (string, integer, float, boolean) as strings.
+    Default ``False``.
+
+    .. note::
+
+        Used only for reading files. Ignored by :obj:`~parse_column` method.
+    """
+
+    prefersDecimal: Optional[bool] = None
+    """
+    If ``True``, infer all floating-point values as ``Decimal``.
+    Default ``False``.
+
+    .. note::
+
+        Used only for reading files. Ignored by :obj:`~parse_column` method.
+    """
+
+    dropFieldIfAllNull: Optional[bool] = None
+    """
+    If ``True`` and inferred column is always null or empty array, exclude if from DataFrame schema.
+    Default ``False``.
+
+    .. note::
+
+        Used only for reading files. Ignored by :obj:`~parse_column` method.
+    """
+
+    dateFormat: Optional[str] = Field(default=None, min_length=1)
+    """
+    String format for ``DateType()`` representation.
+    Default is ``yyyy-MM-dd``.
+    """
+
+    timestampFormat: Optional[str] = Field(default=None, min_length=1)
+    """
+    String format for `TimestampType()`` representation.
+    Default is ``yyyy-MM-dd'T'HH:mm:ss[.SSS][XXX]``.
+    """
+
+    timestampNTZFormat: Optional[str] = Field(default=None, min_length=1)
+    """
+    String format for `TimestampNTZType()`` representation.
+    Default is ``yyyy-MM-dd'T'HH:mm:ss[.SSS]``.
+
+    .. note::
+
+        Added in Spark 3.2.0
+    """
+
+    timezone: Optional[str] = Field(default=None, min_length=1, alias="timeZone")
+    """
+    Allows to override timezone used for parsing or serializing date and timestamp values.
+    By default, ``spark.sql.session.timeZone`` is used.
+    """
+
+    locale: Optional[str] = Field(default=None, min_length=1)
+    """
+    Locale name used to parse dates and timestamps.
+    Default is ``en-US``.
+
+    ..  note::
+
+        Used only for reading files and :obj:`~parse_column` method.
+    """
 
     class Config:
-        known_options = READ_WRITE_OPTIONS | READ_OPTIONS | WRITE_OPTIONS
+        known_options = frozenset()
         extra = "allow"
 
     @slot
@@ -174,13 +399,14 @@ class JSON(ReadOnlyFileFormat):
         from pyspark.sql.functions import col, from_json
 
         self.check_if_supported(SparkSession._instantiatedSession)  # noqa:  WPS437
+        self._check_unsupported_serialization_options()
 
         if isinstance(column, Column):
             column_name, column = column._jc.toString(), column.cast("string")  # noqa:  WPS437
         else:
             column_name, column = column, col(column).cast("string")
 
-        options = stringify(self.dict(by_alias=True))
+        options = stringify(self.dict(by_alias=True, exclude_none=True))
         return from_json(column, schema, options).alias(column_name)
 
     def serialize_column(self, column: str | Column) -> Column:
@@ -236,11 +462,28 @@ class JSON(ReadOnlyFileFormat):
         from pyspark.sql.functions import col, to_json
 
         self.check_if_supported(SparkSession._instantiatedSession)  # noqa:  WPS437
+        self._check_unsupported_serialization_options()
 
         if isinstance(column, Column):
             column_name = column._jc.toString()  # noqa:  WPS437
         else:
             column_name, column = column, col(column)
 
-        options = stringify(self.dict(by_alias=True))
+        options = stringify(self.dict(by_alias=True, exclude_none=True))
         return to_json(column, options).alias(column_name)
+
+    def _check_unsupported_serialization_options(self):
+        current_options = self.dict(by_alias=True, exclude_none=True)
+        unsupported_options = current_options.keys() & PARSE_COLUMN_UNSUPPORTED_OPTIONS
+        if unsupported_options:
+            warnings.warn(
+                f"Options `{sorted(unsupported_options)}` are set but not supported "
+                f"in `JSON.parse_column` or `JSON.serialize_column`.",
+                UserWarning,
+                stacklevel=2,
+            )
+
+    def __repr__(self):
+        options_dict = self.dict(by_alias=True, exclude_none=True, exclude={"multiLine"})
+        options_kwargs = ", ".join(f"{k}={v!r}" for k, v in options_dict.items())
+        return f"{self.__class__.__name__}({options_kwargs})"

--- a/onetl/file/format/jsonline.py
+++ b/onetl/file/format/jsonline.py
@@ -2,52 +2,20 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, Optional, Union
 
 from typing_extensions import Literal
+
+try:
+    from pydantic.v1 import Field
+except (ImportError, AttributeError):
+    from pydantic import Field  # type: ignore[no-redef, assignment]
 
 from onetl.file.format.file_format import ReadWriteFileFormat
 from onetl.hooks import slot, support_hooks
 
 if TYPE_CHECKING:
     from pyspark.sql import SparkSession
-
-
-READ_WRITE_OPTIONS = frozenset(
-    (
-        "dateFormat",
-        "enableDateTimeParsingFallback",
-        "timestampFormat",
-        "timestampNTZFormat",
-        "timeZone",
-    ),
-)
-
-READ_OPTIONS = frozenset(
-    (
-        "allowBackslashEscapingAnyCharacter",
-        "allowComments",
-        "allowNonNumericNumbers",
-        "allowNumericLeadingZeros",
-        "allowSingleQuotes",
-        "allowUnquotedControlChars",
-        "allowUnquotedFieldNames",
-        "columnNameOfCorruptRecord",
-        "dropFieldIfAllNull",
-        "locale",
-        "mode",
-        "prefersDecimal",
-        "primitivesAsString",
-        "samplingRatio",
-    ),
-)
-
-WRITE_OPTIONS = frozenset(
-    (
-        "compression",
-        "ignoreNullFields",
-    ),
-)
 
 
 @support_hooks
@@ -57,7 +25,7 @@ class JSONLine(ReadWriteFileFormat):
 
     Based on `Spark JSON <https://spark.apache.org/docs/latest/sql-data-sources-json.html>`_ file format.
 
-    Supports reading/writing files with ``.json`` extension (NOT ``.jsonl`` or ``.jsonline``) with content like:
+    Supports reading/writing files with ``.json`` extension with content like:
 
     .. code-block:: json
         :caption: example.json
@@ -65,37 +33,322 @@ class JSONLine(ReadWriteFileFormat):
         {"key": "value1"}
         {"key": "value2"}
 
-    .. note ::
-
-        You can pass any option to the constructor, even if it is not mentioned in this documentation.
-        **Option names should be in** ``camelCase``!
-
-        The set of supported options depends on Spark version. See link above.
-
     .. versionadded:: 0.9.0
 
     Examples
     --------
 
-    Describe options how to read from/write to JSON file with specific options:
+    .. note ::
 
-    .. code:: python
+        You can pass any option mentioned in `official documentation <https://spark.apache.org/docs/latest/sql-data-sources-json.html>`_.
 
-        jsonline = JSONLine(encoding="utf-8", compression="gzip")
+        The set of supported options depends on Spark version.
 
+    .. tabs::
+
+        .. code-tab:: py Read files
+
+            # Create Spark session
+            spark = ...
+
+            # Read file /some/file.JSONLine from local file system
+            from onetl.connection import SparkLocalFS
+            from onetl.file import FileDFReader
+            from onetl.file.format import JSONLine
+
+            jsonline = JSONLine(encoding="UTF-8", mode="PERMISSIVE")
+
+            reader = FileDFReader(
+                connection=SparkLocalFS(spark=spark),
+                format=jsonline,
+            )
+            df = reader.run(["/some/file.jsonl"])
+
+        .. tab:: Write files
+
+            .. warning::
+
+                Written files have extension ``.json``, not ``.jsonl`` or ``.jsonline``.
+
+
+            .. code:: python
+
+                # Create Spark session
+                spark = ...
+                # Defined DataFrame
+                df = ...
+
+                # Write DataFrame as JSONLine files at /some/folder on local file system
+                from onetl.connection import SparkLocalFS
+                from onetl.file import FileDFWriter
+                from onetl.file.format import JSONLine
+
+                jsonline = JSONLine(encoding="UTF-8", compression="gzip")
+
+                writer = FileDFWriter(
+                    connection=SparkLocalFS(spark=spark),
+                    format=jsonline,
+                    target_path="/some/folder",
+                )
+                writer.run(df)
     """
 
     name: ClassVar[str] = "json"
 
-    multiLine: Literal[False] = False  # noqa: N815
-    encoding: str = "utf-8"
-    lineSep: str = "\n"  # noqa: N815
+    multiLine: Literal[False] = False
+
+    encoding: Optional[str] = None
+    """
+    Encoding of the JSONLine files.
+    Default ``UTF-8``.
+    """
+
+    lineSep: Optional[str] = None
+    """
+    Character used to separate lines in the JSONLine files.
+
+    Defaults:
+      * Try to detect for reading (``\\r\\n``, ``\\r``, ``\\n``)
+      * ``\\n`` for writing.
+    """
+
+    compression: Union[str, Literal["none", "bzip2", "gzip", "lz4", "snappy", "deflate"], None] = None
+    """
+    Compression codec of the JSONLine file.
+    Default ``none``.
+
+    .. note::
+
+        Used only for writing files.
+    """
+
+    ignoreNullFields: Optional[bool] = None
+    """
+    If ``True`` and field value is ``null``, don't add field into resulting object
+    Default is value of ``spark.sql.jsonGenerator.ignoreNullFields`` (``True``).
+
+    .. note::
+
+        Used only for writing files.
+    """
+
+    allowComments: Optional[bool] = None
+    """
+    If ``True``, add support for C/C++/Java style comments (``//``, ``/* */``).
+    Default ``False``, meaning that JSONLine files should not contain comments.
+
+    .. note::
+
+        Used only for reading files.
+    """
+
+    allowUnquotedFieldNames: Optional[bool] = None
+    """
+    If ``True``, allow JSON object field names without quotes (JavaScript-style).
+    Default ``False``.
+
+    .. note::
+
+        Used only for reading files.
+    """
+
+    allowSingleQuotes: Optional[bool] = None
+    """
+    If ``True``, allow JSON object field names to be wrapped with single quotes (``'``).
+    Default ``True``.
+
+    .. note::
+
+        Used only for reading files.
+    """
+
+    allowNumericLeadingZeros: Optional[bool] = None
+    """
+    If ``True``, allow leading zeros in numbers (e.g. ``00012``).
+    Default ``False``.
+
+    .. note::
+
+        Used only for reading files.
+    """
+
+    allowNonNumericNumbers: Optional[bool] = None
+    """
+    If ``True``, allow numbers to contain non-numeric characters, like:
+      * scientific notation (e.g. ``12e10``).
+      * positive infinity floating point value (``Infinity``, ``+Infinity``, ``+INF``).
+      * negative infinity floating point value (``-Infinity``, ``-INF``).
+      * Not-a-Number floating point value (``NaN``).
+
+    Default ``True``.
+
+    .. note::
+
+        Used only for reading files.
+    """
+
+    allowBackslashEscapingAnyCharacter: Optional[bool] = None
+    """
+    If ``True``, prefix ``\\`` can escape any character.
+    Default ``False``.
+
+    .. note::
+
+        Used only for reading files.
+    """
+
+    allowUnquotedControlChars: Optional[bool] = None
+    """
+    If ``True``, allow unquoted control characters (ASCII values 0-31) in strings without escaping them with ``\\``.
+    Default ``False``.
+
+    .. note::
+
+        Used only for reading files.
+    """
+
+    mode: Optional[Literal["PERMISSIVE", "DROPMALFORMED", "FAILFAST"]] = None
+    """
+    How to handle parsing errors:
+      * ``PERMISSIVE`` - set field value as ``null``, move raw data to :obj:`~columnNameOfCorruptRecord` column.
+      * ``DROPMALFORMED`` - skip the malformed row.
+      * ``FAILFAST`` - throw an error immediately.
+
+    Default is ``PERMISSIVE``.
+
+    .. note::
+
+        Used only for reading files.
+    """
+
+    columnNameOfCorruptRecord: Optional[str] = Field(default=None, min_length=1)
+    """
+    Name of column to put corrupt records in.
+    Default is ``_corrupt_record``.
+
+    .. warning::
+
+        If DataFrame schema is provided, this column should be added to schema explicitly:
+
+        .. code:: python
+
+            from onetl.connection import SparkLocalFS
+            from onetl.file import FileDFReader
+            from onetl.file.format import JSONLine
+
+            from pyspark.sql.types import StructType, StructField, TimestampType, StringType
+
+            spark = ...
+
+            schema = StructType(
+                [
+                    StructField("my_field", TimestampType()),
+                    StructField("_corrupt_record", StringType()),  # <-- important
+                ]
+            )
+
+            jsonline = JSONLine(mode="PERMISSIVE", columnNameOfCorruptRecord="_corrupt_record")
+
+            reader = FileDFReader(
+                connection=connection,
+                format=jsonline,
+                schema=schema,  # < ---
+            )
+            df = reader.run(["/some/file.jsonl"])
+
+    .. note::
+
+        Used only for reading files.
+    """
+
+    samplingRatio: Optional[float] = Field(default=None, ge=0, le=1)
+    """
+    While inferring schema, read the specified fraction of file rows.
+    Default ``1``.
+
+    .. note::
+
+        Used only for reading files.
+    """
+
+    primitivesAsString: Optional[bool] = None
+    """
+    If ``True``, infer all primitive types (string, integer, float, boolean) as strings.
+    Default ``False``.
+
+    .. note::
+
+        Used only for reading files.
+    """
+
+    prefersDecimal: Optional[bool] = None
+    """
+    If ``True``, infer all floating-point values as ``Decimal``.
+    Default ``False``.
+
+    .. note::
+
+        Used only for reading files.
+    """
+
+    dropFieldIfAllNull: Optional[bool] = None
+    """
+    If ``True`` and inferred column is always null or empty array, exclude if from DataFrame schema.
+    Default ``False``.
+
+    .. note::
+
+        Used only for reading files.
+    """
+
+    dateFormat: Optional[str] = Field(default=None, min_length=1)
+    """
+    String format for ``DateType()`` representation.
+    Default is ``yyyy-MM-dd``.
+    """
+
+    timestampFormat: Optional[str] = Field(default=None, min_length=1)
+    """
+    String format for `TimestampType()`` representation.
+    Default is ``yyyy-MM-dd'T'HH:mm:ss[.SSS][XXX]``.
+    """
+
+    timestampNTZFormat: Optional[str] = Field(default=None, min_length=1)
+    """
+    String format for `TimestampNTZType()`` representation.
+    Default is ``yyyy-MM-dd'T'HH:mm:ss[.SSS]``.
+
+    .. note::
+
+        Added in Spark 3.2.0
+    """
+
+    timezone: Optional[str] = Field(default=None, min_length=1, alias="timeZone")
+    """
+    Allows to override timezone used for parsing or serializing date and timestamp values.
+    By default, ``spark.sql.session.timeZone`` is used.
+    """
+
+    locale: Optional[str] = Field(default=None, min_length=1)
+    """
+    Locale name used to parse dates and timestamps.
+    Default is ``en-US``.
+
+    ..  note::
+
+        Used only for reading files.
+    """
 
     class Config:
-        known_options = READ_WRITE_OPTIONS | READ_OPTIONS | WRITE_OPTIONS
+        known_options = frozenset()
         extra = "allow"
 
     @slot
     def check_if_supported(self, spark: SparkSession) -> None:
         # always available
         pass
+
+    def __repr__(self):
+        options_dict = self.dict(by_alias=True, exclude_none=True, exclude={"multiLine"})
+        options_kwargs = ", ".join(f"{k}={v!r}" for k, v in options_dict.items())
+        return f"{self.__class__.__name__}({options_kwargs})"

--- a/setup.cfg
+++ b/setup.cfg
@@ -358,6 +358,8 @@ per-file-ignores =
     onetl/file/format/*.py:
 # N815  variable 'rootTag' in class scope should not be mixedCase
         N815,
+# WPS342 Found implicit raw string
+        WPS342,
     onetl/hooks/slot.py:
 # WPS210 Found too many local variables
         WPS210,

--- a/tests/tests_unit/test_file/test_format_unit/test_json_unit.py
+++ b/tests/tests_unit/test_file/test_format_unit/test_json_unit.py
@@ -9,18 +9,7 @@ pytestmark = [pytest.mark.json]
 
 def test_json_options_default():
     json = JSON()
-    assert json.encoding == "utf-8"
-    assert json.lineSep == "\n"
     assert json.multiLine is True
-
-
-def test_json_options_default_override():
-    json = JSON(
-        encoding="value",
-        lineSep="value",
-    )
-    assert json.encoding == "value"
-    assert json.lineSep == "value"
 
 
 def test_json_options_cannot_override_multiline():
@@ -28,35 +17,38 @@ def test_json_options_cannot_override_multiline():
         JSON(multiLine=False)
 
 
+def test_json_options_timezone_alias():
+    json = JSON(timeZone="value")
+    assert json.timezone == "value"
+
+
 @pytest.mark.parametrize(
-    "known_option",
+    "known_option, value, expected",
     [
-        "dateFormat",
-        "enableDateTimeParsingFallback",
-        "timestampFormat",
-        "timestampNTZFormat",
-        "timeZone",
-        "allowBackslashEscapingAnyCharacter",
-        "allowComments",
-        "allowNonNumericNumbers",
-        "allowNumericLeadingZeros",
-        "allowSingleQuotes",
-        "allowUnquotedControlChars",
-        "allowUnquotedFieldNames",
-        "columnNameOfCorruptRecord",
-        "dropFieldIfAllNull",
-        "locale",
-        "mode",
-        "prefersDecimal",
-        "primitivesAsString",
-        "samplingRatio",
-        "compression",
-        "ignoreNullFields",
+        ("encoding", "value", "value"),
+        ("lineSep", "\r\n", "\r\n"),
+        ("dateFormat", "value", "value"),
+        ("timestampFormat", "value", "value"),
+        ("timestampNTZFormat", "value", "value"),
+        ("allowBackslashEscapingAnyCharacter", True, True),
+        ("allowComments", True, True),
+        ("allowNonNumericNumbers", True, True),
+        ("allowNumericLeadingZeros", True, True),
+        ("allowSingleQuotes", True, True),
+        ("allowUnquotedControlChars", True, True),
+        ("allowUnquotedFieldNames", True, True),
+        ("columnNameOfCorruptRecord", "value", "value"),
+        ("dropFieldIfAllNull", True, True),
+        ("locale", "value", "value"),
+        ("mode", "PERMISSIVE", "PERMISSIVE"),
+        ("prefersDecimal", True, True),
+        ("primitivesAsString", True, True),
+        ("samplingRatio", 0.1, 0.1),
     ],
 )
-def test_json_options_known(known_option):
-    json = JSON.parse({known_option: "value"})
-    assert getattr(json, known_option) == "value"
+def test_json_options_known(known_option, value, expected):
+    json = JSON.parse({known_option: value})
+    assert getattr(json, known_option) == expected
 
 
 def test_json_options_unknown(caplog):
@@ -65,3 +57,9 @@ def test_json_options_unknown(caplog):
         assert json.unknown == "abc"
 
     assert ("Options ['unknown'] are not known by JSON, are you sure they are valid?") in caplog.text
+
+
+def test_jsonline_options_repr():
+    # There are too many options with default value None, hide them from repr
+    json = JSON(encoding="UTF-8", mode="PERMISSIVE", unknownOption="abc")
+    assert repr(json) == "JSON(encoding='UTF-8', mode='PERMISSIVE', unknownOption='abc')"

--- a/tests/tests_unit/test_file/test_format_unit/test_jsonline_unit.py
+++ b/tests/tests_unit/test_file/test_format_unit/test_jsonline_unit.py
@@ -9,18 +9,7 @@ pytestmark = [pytest.mark.json]
 
 def test_jsonline_options_default():
     jsonline = JSONLine()
-    assert jsonline.encoding == "utf-8"
-    assert jsonline.lineSep == "\n"
     assert jsonline.multiLine is False
-
-
-def test_jsonline_options_default_override():
-    jsonline = JSONLine(
-        encoding="value",
-        lineSep="value",
-    )
-    assert jsonline.encoding == "value"
-    assert jsonline.lineSep == "value"
 
 
 def test_jsonline_options_cannot_override_multiline():
@@ -28,35 +17,40 @@ def test_jsonline_options_cannot_override_multiline():
         JSONLine(multiLine=True)
 
 
+def test_jsonline_options_timezone_alias():
+    json = JSONLine(timeZone="value")
+    assert json.timezone == "value"
+
+
 @pytest.mark.parametrize(
-    "known_option",
+    "known_option, value, expected",
     [
-        "dateFormat",
-        "enableDateTimeParsingFallback",
-        "timestampFormat",
-        "timestampNTZFormat",
-        "timeZone",
-        "allowBackslashEscapingAnyCharacter",
-        "allowComments",
-        "allowNonNumericNumbers",
-        "allowNumericLeadingZeros",
-        "allowSingleQuotes",
-        "allowUnquotedControlChars",
-        "allowUnquotedFieldNames",
-        "columnNameOfCorruptRecord",
-        "dropFieldIfAllNull",
-        "locale",
-        "mode",
-        "prefersDecimal",
-        "primitivesAsString",
-        "samplingRatio",
-        "compression",
-        "ignoreNullFields",
+        ("encoding", "value", "value"),
+        ("lineSep", "\r\n", "\r\n"),
+        ("dateFormat", "value", "value"),
+        ("timestampFormat", "value", "value"),
+        ("timestampNTZFormat", "value", "value"),
+        ("allowBackslashEscapingAnyCharacter", True, True),
+        ("allowComments", True, True),
+        ("allowNonNumericNumbers", True, True),
+        ("allowNumericLeadingZeros", True, True),
+        ("allowSingleQuotes", True, True),
+        ("allowUnquotedControlChars", True, True),
+        ("allowUnquotedFieldNames", True, True),
+        ("columnNameOfCorruptRecord", "value", "value"),
+        ("dropFieldIfAllNull", True, True),
+        ("locale", "value", "value"),
+        ("mode", "PERMISSIVE", "PERMISSIVE"),
+        ("prefersDecimal", True, True),
+        ("primitivesAsString", True, True),
+        ("samplingRatio", 0.1, 0.1),
+        ("compression", "gzip", "gzip"),
+        ("ignoreNullFields", True, True),
     ],
 )
-def test_jsonline_options_known(known_option):
-    jsonline = JSONLine.parse({known_option: "value"})
-    assert getattr(jsonline, known_option) == "value"
+def test_jsonline_options_known(known_option, value, expected):
+    jsonline = JSONLine.parse({known_option: value})
+    assert getattr(jsonline, known_option) == expected
 
 
 def test_jsonline_options_unknown(caplog):
@@ -65,3 +59,9 @@ def test_jsonline_options_unknown(caplog):
         assert jsonline.unknown == "abc"
 
     assert ("Options ['unknown'] are not known by JSONLine, are you sure they are valid?") in caplog.text
+
+
+def test_jsonline_options_repr():
+    # There are too many options with default value None, hide them from repr
+    json = JSONLine(encoding="UTF-8", mode="PERMISSIVE", unknownOption="abc")
+    assert repr(json) == "JSONLine(encoding='UTF-8', mode='PERMISSIVE', unknownOption='abc')"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Previously JSON and JSONLine classes documentation only noted that options are documented elsewhere. Now all of them are documented, included to constructor signature and can be recommended by IDE.
Almost all option values are None, and excluded from class repr.

Before:
https://onetl.readthedocs.io/en/0.13.3/file_df/file_formats/json.html
https://onetl.readthedocs.io/en/0.13.3/file_df/file_formats/jsonline.html

After:
https://onetl--359.org.readthedocs.build/en/359/file_df/file_formats/json.html
https://onetl--359.org.readthedocs.build/en/359/file_df/file_formats/jsonline.html

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [X] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
