### PR TITLE
[DOP-22434] Improve Parquet documentation

### DIFF
--- a/docs/file_df/file_formats/parquet.rst
+++ b/docs/file_df/file_formats/parquet.rst
@@ -6,4 +6,5 @@ Parquet
 .. currentmodule:: onetl.file.format.parquet
 
 .. autoclass:: Parquet
-    :members: __init__
+    :members: __init__, mergeSchema,compression
+    :member-order: bysource

--- a/onetl/connection/db_connection/hive/connection.py
+++ b/onetl/connection/db_connection/hive/connection.py
@@ -523,7 +523,7 @@ class Hive(DBConnection):
 
         if isinstance(write_options.format, (WriteOnlyFileFormat, ReadWriteFileFormat)):
             options_dict["format"] = write_options.format.name
-            options_dict.update(write_options.format.dict(exclude={"name"}))
+            options_dict.update(write_options.format.dict(exclude={"name"}, exclude_none=True))
 
         return options_dict
 

--- a/tests/tests_unit/test_file/test_format_unit/test_parquet_unit.py
+++ b/tests/tests_unit/test_file/test_format_unit/test_parquet_unit.py
@@ -8,18 +8,17 @@ pytestmark = [pytest.mark.parquet]
 
 
 @pytest.mark.parametrize(
-    "known_option",
+    "known_option, value, expected_value",
     [
-        "datetimeRebaseMode",
-        "int96RebaseMode",
-        "mergeSchema",
-        "compression",
-        "parquet.bloom.filter.enabled#favorite_color",
+        ("mergeSchema", True, True),
+        ("compression", "snappy", "snappy"),
+        ("parquet.bloom.filter.enabled#id", True, True),
+        ("parquet.bloom.filter.expected.ndv#id", 100, 100),
     ],
 )
-def test_parquet_options_known(known_option):
-    parquet = Parquet.parse({known_option: "value"})
-    assert getattr(parquet, known_option) == "value"
+def test_parquet_options_known(known_option, value, expected_value):
+    parquet = Parquet.parse({known_option: value})
+    assert getattr(parquet, known_option) == expected_value
 
 
 def test_parquet_options_unknown(caplog):
@@ -28,6 +27,14 @@ def test_parquet_options_unknown(caplog):
         assert parquet.unknown == "abc"
 
     assert ("Options ['unknown'] are not known by Parquet, are you sure they are valid?") in caplog.text
+
+
+def test_parquet_options_repr():  # There are too many options with default value None, hide them from repr
+    parquet = Parquet(mergeSchema=True, compression="snappy", unknownOption="abc")
+    assert repr(parquet) == "Parquet(mergeSchema=True, compression='snappy', unknownOption='abc')"
+
+    parquet_with_dots = Parquet.parse({"parquet.bloom.filter.enabled#id": True, "unknownOption": "abc"})
+    assert repr(parquet_with_dots) == "Parquet.parse({'parquet.bloom.filter.enabled#id': True, 'unknownOption': 'abc'})"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Previously Parquet class documentation only noted that options are documented elsewhere. Now all of them are documented, included to constructor signature and can be recommended by IDE.
Almost all option values are None, and excluded from class repr.

Before:
https://onetl.readthedocs.io/en/0.13.3/file_df/file_formats/parquet.html

After:
https://onetl--361.org.readthedocs.build/en/361/file_df/file_formats/parquet.html

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [X] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
