### PR TITLE
[DOP-22434] Improve ORC documentation

### DIFF
--- a/docs/file_df/file_formats/orc.rst
+++ b/docs/file_df/file_formats/orc.rst
@@ -6,4 +6,5 @@ ORC
 .. currentmodule:: onetl.file.format.orc
 
 .. autoclass:: ORC
-    :members: __init__
+    :members: __init__, mergeSchema,compression
+    :member-order: bysource

--- a/onetl/connection/db_connection/hive/connection.py
+++ b/onetl/connection/db_connection/hive/connection.py
@@ -523,7 +523,7 @@ class Hive(DBConnection):
 
         if isinstance(write_options.format, (WriteOnlyFileFormat, ReadWriteFileFormat)):
             options_dict["format"] = write_options.format.name
-            options_dict.update(write_options.format.dict(exclude={"name"}))
+            options_dict.update(write_options.format.dict(exclude={"name"}, exclude_none=True))
 
         return options_dict
 

--- a/onetl/file/format/orc.py
+++ b/onetl/file/format/orc.py
@@ -2,7 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, Optional, Union
+
+from typing_extensions import Literal
 
 from onetl.file.format.file_format import ReadWriteFileFormat
 from onetl.hooks import slot, support_hooks
@@ -17,51 +19,119 @@ PROHIBITED_OPTIONS = frozenset(
     ),
 )
 
-READ_OPTIONS = frozenset(
-    ("mergeSchema",),
-)
-
-WRITE_OPTIONS = frozenset(
-    (
-        "compression",
-        "orc.*",
-    ),
+ORC_JAVA_OPTIONS = frozenset(
+    ("orc.*",),
 )
 
 
 @support_hooks
 class ORC(ReadWriteFileFormat):
     """
-    ORC file format. |support_hooks|
+    ORC file format (columnar). |support_hooks|
 
     Based on `Spark ORC Files <https://spark.apache.org/docs/latest/sql-data-sources-orc.html>`_ file format.
 
     Supports reading/writing files with ``.orc`` extension.
-
-    .. note ::
-
-        You can pass any option to the constructor, even if it is not mentioned in this documentation.
-        **Option names should be in** ``camelCase``!
-
-        The set of supported options depends on Spark version. See link above.
 
     .. versionadded:: 0.9.0
 
     Examples
     --------
 
-    Describe options how to read from/write to ORC file with specific options:
+    .. note ::
 
-    .. code:: python
+        You can pass any option mentioned in `official documentation <https://spark.apache.org/docs/latest/sql-data-sources-orc.html>`_.
+        The set of supported options depends on Spark version.
 
-        orc = ORC(compression="snappy")
+        You may also set options mentioned `orc-java documentation <https://orc.apache.org/docs/core-java-config.html>`_.
+        They are prefixed with ``orc.`` with dots in names, so instead of calling constructor ``ORC(orc.option=True)`` (invalid in Python)
+        you should call method ``ORC.parse({"orc.option": True})``.
+
+    .. tabs::
+
+        .. code-tab:: py Read files
+
+            # Create Spark session
+            spark = ...
+
+            # Read ORC files at /some/folder from local file system
+            from onetl.connection import SparkLocalFS
+            from onetl.file import FileDFReader
+            from onetl.file.format import ORC
+
+            orc = ORC(mergeSchema=True)
+
+            reader = FileDFReader(
+                connection=SparkLocalFS(spark=spark),
+                format=orc,
+                source_path="/some/folder",
+            )
+            df = reader.run()
+
+        .. tab:: Write files
+
+            .. code:: python
+
+                # Create Spark session
+                spark = ...
+                # Defined DataFrame
+                df = ...
+
+                # Write DataFrame as ORC files at /some/folder on local file system
+                from onetl.connection import SparkLocalFS
+                from onetl.file import FileDFWriter
+                from onetl.file.format import ORC
+
+                orc = ORC.parse(
+                    {
+                        "compression": "snappy",
+                        # Enable Bloom filter for columns 'id' and 'name'
+                        "orc.bloom.filter.columns": "id,name",
+                        # Set Bloom filter false positive probability
+                        "orc.bloom.filter.fpp": 0.01,
+                        # Do not use dictionary for 'highly_selective_column'
+                        "orc.column.encoding.direct": "highly_selective_column",
+                        # other options
+                    }
+                )
+
+                writer = FileDFWriter(
+                    connection=SparkLocalFS(spark=spark),
+                    format=orc,
+                    target_path="/some/folder",
+                )
+                writer.run(df)
 
     """
 
     name: ClassVar[str] = "orc"
 
+    mergeSchema: Optional[bool] = None
+    """
+    Merge schemas of all ORC files being read into a single schema.
+    By default, Spark config option ``spark.sql.orc.mergeSchema`` value is used (``False``).
+
+    .. note::
+
+        Used only for reading files.
+    """
+
+    compression: Union[
+        str,
+        Literal["uncompressed", "snappy", "zlib", "lzo", "zstd", "lz4"],
+        None,
+    ] = None
+    """
+    Compression codec of the ORC files.
+    By default, Spark config option ``spark.sql.orc.compression.codec`` value is used (``snappy``).
+
+    .. note::
+
+        Used only for writing files.
+    """
+
     class Config:
-        known_options = READ_OPTIONS | WRITE_OPTIONS
+        known_options = ORC_JAVA_OPTIONS
         prohibited_options = PROHIBITED_OPTIONS
         extra = "allow"
 
@@ -69,3 +139,11 @@ class ORC(ReadWriteFileFormat):
     def check_if_supported(self, spark: SparkSession) -> None:
         # always available
         pass
+
+    def __repr__(self):
+        options_dict = self.dict(by_alias=True, exclude_none=True)
+        if any("." in field for field in options_dict.keys()):
+            return f"{self.__class__.__name__}.parse({options_dict})"
+
+        options_kwargs = ", ".join(f"{k}={v!r}" for k, v in options_dict.items())
+        return f"{self.__class__.__name__}({options_kwargs})"

--- a/tests/tests_unit/test_file/test_format_unit/test_orc_unit.py
+++ b/tests/tests_unit/test_file/test_format_unit/test_orc_unit.py
@@ -8,16 +8,18 @@ pytestmark = [pytest.mark.orc]
 
 
 @pytest.mark.parametrize(
-    "known_option",
+    "known_option, value, expected_value",
     [
-        "mergeSchema",
-        "compression",
-        "orc.bloom.filter.columns",
+        ("mergeSchema", True, True),
+        ("compression", "snappy", "snappy"),
+        ("orc.bloom.filter.columns", "id,name", "id,name"),
+        ("orc.bloom.filter.fpp", 0.01, 0.01),
+        ("orc.column.encoding.direct", "highly_selective_column", "highly_selective_column"),
     ],
 )
-def test_orc_options_known(known_option):
-    orc = ORC.parse({known_option: "value"})
-    assert getattr(orc, known_option) == "value"
+def test_orc_options_known(known_option, value, expected_value):
+    orc = ORC.parse({known_option: value})
+    assert getattr(orc, known_option) == expected_value
 
 
 def test_orc_options_unknown(caplog):
@@ -26,6 +28,14 @@ def test_orc_options_unknown(caplog):
         assert orc.unknown == "abc"
 
     assert ("Options ['unknown'] are not known by ORC, are you sure they are valid?") in caplog.text
+
+
+def test_orc_options_repr():  # There are too many options with default value None, hide them from repr
+    orc = ORC(compression="snappy", unknownOption="abc")
+    assert repr(orc) == "ORC(compression='snappy', unknownOption='abc')"
+
+    orc_with_dots = ORC.parse({"orc.bloom.filter.columns": "id,name", "unknownOption": "abc"})
+    assert repr(orc_with_dots) == "ORC.parse({'orc.bloom.filter.columns': 'id,name', 'unknownOption': 'abc'})"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Previously ORC class documentation only noted that options are documented elsewhere. Now all of them are documented, included to constructor signature and can be recommended by IDE.
Almost all option values are None, and excluded from class repr.

Before:
https://onetl.readthedocs.io/en/0.13.3/file_df/file_formats/orc.html

After:
https://onetl--362.org.readthedocs.build/en/362/file_df/file_formats/orc.html

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [X] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
