### PR TITLE
Replace `Literal[None]` with `None` in type annotations

### DIFF
--- a/onetl/hwm/auto_hwm.py
+++ b/onetl/hwm/auto_hwm.py
@@ -11,11 +11,9 @@ try:
 except (ImportError, AttributeError):
     from pydantic import root_validator  # type: ignore[no-redef, assignment]
 
-from typing_extensions import Literal
-
 
 class AutoDetectHWM(HWM):
-    value: Literal[None] = None
+    value: None = None
 
     @root_validator(pre=True)
     def handle_aliases(cls, values):


### PR DESCRIPTION

types `None` and `Literal[None]` are exactly equivalent