### PR TITLE
Treat S3 objects with name ending with slash as directory marker

### DIFF
--- a/.github/workflows/data/s3/matrix.yml
+++ b/.github/workflows/data/s3/matrix.yml
@@ -1,6 +1,6 @@
 min: &min
-  # prior image versions returns empty content of bucket root, some kind of bug
-  minio-version: 2021.3.17
+  # prior image versions doesn't support directory markers (empty objects with path ending with /)
+  minio-version: 2021.12.9
   # Minimal Spark version with Hadoop 3.x support
   spark-version: 3.2.4
   pydantic-version: 1
@@ -9,7 +9,7 @@ min: &min
   os: ubuntu-22.04
 
 max: &max
-  minio-version: 2025.2.18
+  minio-version: 2025.7.23
   spark-version: 3.5.5
   pydantic-version: 2
   python-version: '3.13'

--- a/docs/changelog/next_release/379.feature.rst
+++ b/docs/changelog/next_release/379.feature.rst
@@ -1,0 +1,1 @@
+Treat S3 objects with names ending with a ``/`` slash as directory marker

--- a/onetl/connection/file_connection/file_connection.py
+++ b/onetl/connection/file_connection/file_connection.py
@@ -543,9 +543,9 @@ class FileConnection(BaseFileConnection, FrozenModel):
         self._remove_dir(root)
 
     @abstractmethod
-    def _scan_entries(self, path: RemotePath) -> list:
+    def _scan_entries(self, path: RemotePath) -> Iterable:
         """
-        The method returns a list that contains entries.
+        The method returns an iterator that returns entries.
 
         Entry is an object containing information about a path, like file or nested directory.
 
@@ -559,19 +559,19 @@ class FileConnection(BaseFileConnection, FrozenModel):
 
         Returns
         -------
-        list
-            List of the entries
+        Iterable
+            Iterable entries
 
         Examples
         --------
 
-        Get a list of entries:
+        Get a entries:
 
         .. code:: python
 
-            entry_list = connection._scan_entries(path="/a/path/to/the/directory")
+            entry_iterable = connection._scan_entries(path="/a/path/to/the/directory")
 
-            print(entry_list)
+            print(entry_iterable)
 
             [
                 {

--- a/onetl/connection/file_connection/webdav.py
+++ b/onetl/connection/file_connection/webdav.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import datetime
 import io
 import os
-import stat
 import textwrap
 from logging import getLogger
 from ssl import SSLContext
@@ -166,7 +165,7 @@ class WebDAV(FileConnection, RenameDirMixin):
         info = self.client.info(os.fspath(path))
 
         if self.client.is_dir(os.fspath(path)):
-            return RemotePathStat(st_mode=stat.S_IFDIR)
+            return RemotePathStat()
 
         return RemotePathStat(
             st_size=info["size"],
@@ -243,7 +242,7 @@ class WebDAV(FileConnection, RenameDirMixin):
 
     def _extract_stat_from_entry(self, top: RemotePath, entry: dict) -> RemotePathStat:
         if entry["isdir"]:
-            return RemotePathStat(st_mode=stat.S_IFDIR)
+            return RemotePathStat()
 
         return RemotePathStat(
             st_size=entry["size"],

--- a/tests/tests_integration/tests_core_integration/test_file_downloader_integration.py
+++ b/tests/tests_integration/tests_core_integration/test_file_downloader_integration.py
@@ -922,7 +922,7 @@ def test_file_downloader_run_input_is_not_file(request, file_connection, tmp_pat
         local_path=local_path,
     )
 
-    with pytest.raises(NotAFileError, match=rf"'{not_a_file}' \(kind='directory', .*\) is not a file"):
+    with pytest.raises(NotAFileError, match=rf"'{not_a_file}' \(kind='directory'.*\) is not a file"):
         downloader.run([not_a_file])
 
 

--- a/tests/tests_integration/tests_core_integration/test_file_mover_integration.py
+++ b/tests/tests_integration/tests_core_integration/test_file_mover_integration.py
@@ -941,7 +941,7 @@ def test_file_mover_run_input_is_not_file(request, file_connection):
         target_path=target_path,
     )
 
-    with pytest.raises(NotAFileError, match=rf"'{not_a_file}' \(kind='directory', .*\) is not a file"):
+    with pytest.raises(NotAFileError, match=rf"'{not_a_file}' \(kind='directory'.*\) is not a file"):
         mover.run([not_a_file])
 
 

--- a/tests/tests_integration/tests_file_connection_integration/test_s3_file_connection_integration.py
+++ b/tests/tests_integration/tests_file_connection_integration/test_s3_file_connection_integration.py
@@ -1,3 +1,4 @@
+import io
 import logging
 import os
 
@@ -50,3 +51,29 @@ def test_s3_file_connection_list_dir(path_prefix, s3_file_connection_with_path_a
     assert dir_content(f"{path_prefix}data/exclude_dir") == ["excluded1.txt", "nested"]
     assert dir_content(f"{path_prefix}data") == ["ascii.txt", "exclude_dir", "nested", "some.csv", "utf-8.txt"]
     assert "data" in dir_content(path_prefix)  # "tmp" could present
+
+
+def test_s3_file_connection_directory_marker(s3_file_connection_with_path):
+    s3, path = s3_file_connection_with_path
+
+    empty_dir = path.joinpath("empty")
+    temp_dir = path.joinpath("tmp")
+    temp_file = temp_dir.joinpath("file")
+    s3.client.put_object(s3.bucket, object_name=empty_dir.as_posix() + "/", data=io.BytesIO(), length=0)
+    s3.client.put_object(s3.bucket, object_name=temp_dir.as_posix() + "/", data=io.BytesIO(), length=0)
+    s3.client.put_object(s3.bucket, object_name=temp_file.as_posix(), data=io.BytesIO(), length=0)
+
+    def dir_content(path):
+        return sorted(os.fspath(file) for file in s3.list_dir(path))
+
+    assert dir_content(path) == ["empty", "tmp"]
+    assert dir_content(temp_dir) == ["file"]
+
+    s3.remove_dir(empty_dir, recursive=False)
+    assert not s3.path_exists(empty_dir)
+
+    s3.remove_dir(temp_dir, recursive=True)
+    assert not s3.path_exists(temp_file)
+    assert not s3.path_exists(temp_dir)
+
+    assert not s3.path_exists(path)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Spark 4.0 started to create empty objects in S3 with name ending with `/` as a directory-like marker. This implementation avoids scanning all paths by prefix, and just fetching object by key instead, which is much faster. This is also the case for Iceberg.

Adjust S3 connector `_scan_entries` and `_remove_dir` code to handle this case.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
