### PR TITLE
[DOP-28365] Add support for IcebergRESTCatalog

### DIFF
--- a/docs/changelog/next_release/391.feature.rst
+++ b/docs/changelog/next_release/391.feature.rst
@@ -1,0 +1,1 @@
+Add support for IcebergRESTCatalog

--- a/onetl/connection/db_connection/iceberg/catalog/__init__.py
+++ b/onetl/connection/db_connection/iceberg/catalog/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2021-2024 MTS PJSC
+# SPDX-License-Identifier: Apache-2.0
+from onetl.connection.db_connection.iceberg.catalog.base import IcebergCatalog
+from onetl.connection.db_connection.iceberg.catalog.rest import IcebergRESTCatalog

--- a/onetl/connection/db_connection/iceberg/catalog/base.py
+++ b/onetl/connection/db_connection/iceberg/catalog/base.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2021-2024 MTS PJSC
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Dict
+
+
+class IcebergCatalog(ABC):
+    """
+    Base Iceberg catalog interface.
+
+    .. versionadded:: 0.15.0
+    """
+
+    @abstractmethod
+    def get_config(self) -> Dict[str, str]:
+        """Return flat dict with catalog configuration."""

--- a/onetl/connection/db_connection/iceberg/catalog/rest.py
+++ b/onetl/connection/db_connection/iceberg/catalog/rest.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2021-2024 MTS PJSC
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from typing import Dict
+
+try:
+    from pydantic.v1 import Field
+except (ImportError, AttributeError):
+    from pydantic import Field  # type: ignore[no-redef, assignment]
+
+from onetl.connection.db_connection.iceberg.catalog import IcebergCatalog
+from onetl.impl.frozen_model import FrozenModel
+
+
+class IcebergRESTCatalog(IcebergCatalog, FrozenModel):
+    """Iceberg REST Catalog.
+
+    .. versionadded:: 0.15.0
+    """
+
+    uri: str
+    headers: Dict[str, str] = Field(default_factory=dict)
+    extra: Dict[str, str] = Field(default_factory=dict)
+
+    @property
+    def type(self) -> str:
+        return "rest"
+
+    def get_config(self) -> Dict[str, str]:
+        config = {
+            "type": self.type,
+            "uri": self.uri,
+            **self.extra,
+        }
+        for key, value in self.headers.items():
+            config[f"header.{key}"] = value
+        return config


### PR DESCRIPTION
## Change Summary

- Added `IcebergCatalog` base class with `get_config()` method
- Implemented `IcebergRESTCatalog(IcebergCatalog)`
- Updated `Iceberg` class to accept `catalog: IcebergCatalog` (optional for now)
- Merged generated catalog config into Spark session config under:  
```
spark.catalog.{catalog_name}.type: rest
spark.catalog.{catalog_name}.uri: ...
spark.catalog.{catalog_name}.header.{header.key}: {header.value}
spark.catalog.{catalog_name}.{extra.key}: {extra.value}
```

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
