### PR TITLE
[DOP-28400] Move path_style_access from SparkS3.extra

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -565,7 +565,7 @@ Read files directly from S3 path, convert them to dataframe, transform it and th
         access_key="somekey",
         secret_key="somesecret",
         # Access bucket as s3.test.com/my-bucket
-        extra={"path.style.access": True},
+        path_style_access=True,
         spark=spark,
     ).check()
 

--- a/docs/changelog/next_release/392.feature.rst
+++ b/docs/changelog/next_release/392.feature.rst
@@ -1,0 +1,2 @@
+Allowed to set ``path_style_access`` as a parameter in ``SparkS3`` connection instead of ``extra`` field.
+This change improved IDE autocompletion and made it more explicit that the parameter is important for the connector's functionality.

--- a/docs/connection/file_df_connection/spark_s3/prerequisites.rst
+++ b/docs/connection/file_df_connection/spark_s3/prerequisites.rst
@@ -28,7 +28,7 @@ AWS and some other S3 cloud providers allows bucket access using domain style on
 Other implementations, like Minio, by default allows path style access only, e.g. ``https://s3provider.com/mybucket``
 (see `MINIO_DOMAIN <https://min.io/docs/minio/linux/reference/minio-server/minio-server.html#envvar.MINIO_DOMAIN>`_).
 
-You should set ``path.style.access`` to ``True`` or ``False``, to choose the preferred style.
+You should set ``path_style_access`` to ``True`` or ``False``, to choose the preferred style.
 
 Authentication
 ~~~~~~~~~~~~~~

--- a/docs/connection/file_df_connection/spark_s3/troubleshooting.rst
+++ b/docs/connection/file_df_connection/spark_s3/troubleshooting.rst
@@ -246,7 +246,7 @@ Another option is to disable SSL check:
 
 But is is **NOT** recommended.
 
-Accessing S3 without domain-style access style support
+Accessing S3 without path-style access style support
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code:: text
@@ -260,10 +260,8 @@ To use path-style access, use option below:
     spark_s3 = SparkS3(
         host="s3provider.com",
         bucket="my-bucket",
+        path_style_access=True,
         ...,
-        extra={
-            "path.style.access": True,
-        },
     )
 
 Slow or unstable writing to S3

--- a/tests/fixtures/connections/s3.py
+++ b/tests/fixtures/connections/s3.py
@@ -90,9 +90,7 @@ def s3_file_df_connection(s3_file_connection, spark, s3_server):
         access_key=s3_server.access_key,
         secret_key=s3_server.secret_key,
         protocol=s3_server.protocol,
-        extra={
-            "path.style.access": True,
-        },
+        path_style_access=True,
         spark=spark,
     )
 

--- a/tests/tests_integration/test_file_df_connection_integration/test_spark_s3_integration.py
+++ b/tests/tests_integration/test_file_df_connection_integration/test_spark_s3_integration.py
@@ -25,8 +25,8 @@ def test_spark_s3_check(s3_file_df_connection, caplog):
     assert "secret_key = SecretStr('**********')" in caplog.text
     assert s3.secret_key.get_secret_value() not in caplog.text
     assert "session_token =" not in caplog.text
+    assert "path_style_access" in caplog.text
     assert "extra = {" in caplog.text
-    assert "'path.style.access': True" in caplog.text
 
     assert "Connection is available." in caplog.text
 

--- a/tests/tests_unit/tests_file_df_connection_unit/test_spark_s3_unit.py
+++ b/tests/tests_unit/tests_file_df_connection_unit/test_spark_s3_unit.py
@@ -126,6 +126,40 @@ def test_spark_s3_with_port(spark_mock_hadoop_3, protocol):
     assert str(conn) == "S3[some_host:9000/bucket]"
 
 
+def test_spark_s3_with_path_style_access(spark_mock_hadoop_3):
+    conn = SparkS3(
+        host="some_host",
+        bucket="bucket",
+        path_style_access=True,
+        spark=spark_mock_hadoop_3,
+    )
+
+    assert conn.path_style_access is True
+
+
+def test_spark_s3_with_path_style_access_from_extra(spark_mock_hadoop_3):
+    conn = SparkS3(
+        host="some_host",
+        bucket="bucket",
+        spark=spark_mock_hadoop_3,
+        extra={
+            "path.style.access": True,
+        },
+    )
+
+    assert conn.path_style_access is True
+
+
+def test_spark_s3_without_path_style_access(spark_mock_hadoop_3):
+    conn = SparkS3(
+        host="some_host",
+        bucket="bucket",
+        spark=spark_mock_hadoop_3,
+    )
+
+    assert conn.path_style_access is False
+
+
 @pytest.mark.parametrize(
     "name, value",
     [


### PR DESCRIPTION
## Change Summary

Allowed to set ``path_style_access`` as a parameter in ``SparkS3`` connection instead of using ``extra`` field:
```python
SparkS3(
    ...,
    path_style_access=True,
)
```
This change improved IDE autocompletion and made it more explicit that the parameter is important for the connector's functionality.


## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [x] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
