### PR TITLE
[DOP-28371] Add OAuth2 authentication support to Iceberg REST Catalog

### DIFF
--- a/docs/changelog/next_release/393.feature.rst
+++ b/docs/changelog/next_release/393.feature.rst
@@ -1,0 +1,1 @@
+Introduced OAuth2 authentication in Iceberg REST Catalog

--- a/onetl/connection/db_connection/iceberg/catalog/auth/__init__.py
+++ b/onetl/connection/db_connection/iceberg/catalog/auth/__init__.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2021-2024 MTS PJSC
+# SPDX-License-Identifier: Apache-2.0
+from onetl.connection.db_connection.iceberg.catalog.auth.base import (
+    IcebergRESTCatalogAuth,
+)
+from onetl.connection.db_connection.iceberg.catalog.auth.bearer import (
+    IcebergRESTCatalogBearerAuth,
+)
+from onetl.connection.db_connection.iceberg.catalog.auth.oauth2 import (
+    IcebergRESTCatalogOAuth2,
+)

--- a/onetl/connection/db_connection/iceberg/catalog/auth/base.py
+++ b/onetl/connection/db_connection/iceberg/catalog/auth/base.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2021-2024 MTS PJSC
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Dict
+
+
+class IcebergRESTCatalogAuth(ABC):
+    """
+    Base Iceberg catalog auth interface.
+
+    .. versionadded:: 0.14.1
+    """
+
+    @abstractmethod
+    def get_config(self) -> Dict[str, str]:
+        """Return REST catalog auth configuration."""

--- a/onetl/connection/db_connection/iceberg/catalog/auth/bearer.py
+++ b/onetl/connection/db_connection/iceberg/catalog/auth/bearer.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2021-2024 MTS PJSC
+# SPDX-License-Identifier: Apache-2.0
+from typing import Dict
+
+try:
+    from pydantic.v1 import SecretStr
+except (ImportError, AttributeError):
+    from pydantic import SecretStr  # type: ignore[no-redef, assignment]
+
+from onetl.connection.db_connection.iceberg.catalog.auth import IcebergRESTCatalogAuth
+from onetl.impl.frozen_model import FrozenModel
+
+
+class IcebergRESTCatalogBearerAuth(IcebergRESTCatalogAuth, FrozenModel):
+    """Bearer Authentication for Iceberg REST Catalog.
+
+    .. versionadded:: 0.14.1
+    """
+
+    # https://github.com/apache/iceberg/blob/28555ad8fbad77a4067b6ee2afbdea15428dea26/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Manager.java#L40
+    # https://github.com/apache/iceberg/blob/720ef99720a1c59e4670db983c951243dffc4f3e/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Properties.java#L21
+    access_token: SecretStr
+
+    @property
+    def type(self) -> str:
+        return "oauth2"
+
+    def get_config(self) -> Dict[str, str]:
+        return {
+            "rest.auth.type": self.type,
+            "token": self.access_token.get_secret_value(),
+        }

--- a/onetl/connection/db_connection/iceberg/catalog/auth/oauth2.py
+++ b/onetl/connection/db_connection/iceberg/catalog/auth/oauth2.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2021-2024 MTS PJSC
+# SPDX-License-Identifier: Apache-2.0
+from datetime import timedelta
+from typing import Dict, List, Optional
+
+try:
+    from pydantic.v1 import Field, SecretStr
+except (ImportError, AttributeError):
+    from pydantic import Field, SecretStr  # type: ignore[no-redef, assignment]
+
+from onetl.connection.db_connection.iceberg.catalog.auth import IcebergRESTCatalogAuth
+from onetl.impl.frozen_model import FrozenModel
+
+
+class IcebergRESTCatalogOAuth2(IcebergRESTCatalogAuth, FrozenModel):
+    """OAuth2 Authentication for Iceberg REST Catalog.
+
+    .. versionadded:: 0.14.1
+    """
+
+    # https://github.com/apache/iceberg/blob/720ef99720a1c59e4670db983c951243dffc4f3e/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Properties.java#L49-L56
+    # https://github.com/apache/iceberg/blob/28555ad8fbad77a4067b6ee2afbdea15428dea26/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java#L366
+    client_secret: SecretStr
+    client_id: Optional[str] = None
+
+    # https://github.com/apache/iceberg/blob/720ef99720a1c59e4670db983c951243dffc4f3e/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Properties.java#L33-L39C58
+    token_refresh_interval: Optional[timedelta] = timedelta(hours=1)
+
+    token_exchange_enabled: bool = True
+
+    # by default uses v1/oauth/tokens endpoint of RESTCatalog server
+    # https://github.com/apache/iceberg/blob/28555ad8fbad77a4067b6ee2afbdea15428dea26/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Properties.java#L30-L31C30
+    # https://github.com/apache/iceberg/blob/28555ad8fbad77a4067b6ee2afbdea15428dea26/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Manager.java#L275-L293
+    # https://github.com/apache/iceberg/blob/28555ad8fbad77a4067b6ee2afbdea15428dea26/core/src/main/java/org/apache/iceberg/rest/ResourcePaths.java#L57-L59
+    oauth2_server_uri: Optional[str] = None
+
+    scopes: List[str] = Field(default_factory=list)
+    audience: Optional[str] = None
+    resource: Optional[str] = None
+
+    @property
+    def type(self) -> str:
+        return "oauth2"
+
+    def get_config(self) -> Dict[str, str]:
+        config = {
+            "rest.auth.type": self.type,
+            "credential": (
+                f"{self.client_id}:{self.client_secret.get_secret_value()}"
+                if self.client_id
+                else self.client_secret.get_secret_value()
+            ),
+            "token-expires-in-ms": (
+                int(self.token_refresh_interval.total_seconds() * 1000) if self.token_refresh_interval else None
+            ),
+            "token-refresh-enabled": "true" if self.token_refresh_interval is not None else "false",
+            "token-exchange-enabled": "true" if self.token_exchange_enabled else "false",
+            "oauth2-server-uri": self.oauth2_server_uri,
+            "scope": " ".join(self.scopes) if self.scopes else None,
+            "audience": self.audience,
+            "resource": self.resource,
+        }
+        return {k: v for k, v in config.items() if v is not None}

--- a/onetl/connection/db_connection/iceberg/catalog/rest.py
+++ b/onetl/connection/db_connection/iceberg/catalog/rest.py
@@ -2,7 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from typing import Dict
+from typing import Dict, Optional
+
+from onetl.connection.db_connection.iceberg.catalog.auth.base import (
+    IcebergRESTCatalogAuth,
+)
 
 try:
     from pydantic.v1 import Field
@@ -22,6 +26,8 @@ class IcebergRESTCatalog(IcebergCatalog, FrozenModel):
     uri: str
     headers: Dict[str, str] = Field(default_factory=dict)
     extra: Dict[str, str] = Field(default_factory=dict)
+
+    auth: Optional[IcebergRESTCatalogAuth] = None
 
     @property
     def type(self) -> str:

--- a/onetl/connection/db_connection/iceberg/connection.py
+++ b/onetl/connection/db_connection/iceberg/connection.py
@@ -167,6 +167,9 @@ class Iceberg(DBConnection):
             "org.apache.iceberg.spark.SparkCatalog",
         )
         catalog_config = self.catalog.get_config() if self.catalog else {}
+        catalog_auth_config = self.catalog.auth.get_config() if self.catalog and self.catalog.auth else {}
+
+        catalog_config.update(catalog_auth_config)
         catalog_config.update(self.extra.dict())
         for k, v in catalog_config.items():
             self.spark.conf.set(f"spark.sql.catalog.{self.catalog_name}.{k}", v)


### PR DESCRIPTION
## Change Summary

- Added `IcebergRESTCatalogAuth` base class with `get_config()` method
- Implemented `IcebergRESTCatalogOAuth2`, `IcebergRESTCatalogBearerAuth` classes
- Updated `IcebergRESTCatalog` class to accept `auth: IcebergRESTCatalogAuth`

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
