### PR TITLE
[DOP-28367] Add basic authentication support to Iceberg REST Catalog

### DIFF
--- a/docs/changelog/next_release/394.feature.rst
+++ b/docs/changelog/next_release/394.feature.rst
@@ -1,0 +1,1 @@
+Introduced Basic authentication in Iceberg REST Catalog

--- a/onetl/connection/db_connection/iceberg/catalog/auth/__init__.py
+++ b/onetl/connection/db_connection/iceberg/catalog/auth/__init__.py
@@ -3,6 +3,9 @@
 from onetl.connection.db_connection.iceberg.catalog.auth.base import (
     IcebergRESTCatalogAuth,
 )
+from onetl.connection.db_connection.iceberg.catalog.auth.basic import (
+    IcebergRESTCatalogBasicAuth,
+)
 from onetl.connection.db_connection.iceberg.catalog.auth.bearer import (
     IcebergRESTCatalogBearerAuth,
 )

--- a/onetl/connection/db_connection/iceberg/catalog/auth/basic.py
+++ b/onetl/connection/db_connection/iceberg/catalog/auth/basic.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2021-2024 MTS PJSC
+# SPDX-License-Identifier: Apache-2.0
+from typing import Dict
+
+try:
+    from pydantic.v1 import SecretStr
+except (ImportError, AttributeError):
+    from pydantic import SecretStr  # type: ignore[no-redef, assignment]
+
+from onetl.connection.db_connection.iceberg.catalog.auth import IcebergRESTCatalogAuth
+from onetl.impl.frozen_model import FrozenModel
+
+
+class IcebergRESTCatalogBasicAuth(IcebergRESTCatalogAuth, FrozenModel):
+    """Basic Authentication for Iceberg REST Catalog.
+
+    .. versionadded:: 0.14.1
+    """
+
+    # https://github.com/apache/iceberg/blob/28555ad8fbad77a4067b6ee2afbdea15428dea26/core/src/main/java/org/apache/iceberg/rest/auth/BasicAuthManager.java
+    user: str
+    password: SecretStr
+
+    @property
+    def type(self) -> str:
+        return "basic"
+
+    def get_config(self) -> Dict[str, str]:
+        config = {
+            "rest.auth.type": self.type,
+            "rest.auth.basic.username": self.user,
+            "rest.auth.basic.password": self.password.get_secret_value(),
+        }
+        return config

--- a/onetl/connection/db_connection/iceberg/catalog/auth/oauth2.py
+++ b/onetl/connection/db_connection/iceberg/catalog/auth/oauth2.py
@@ -51,7 +51,7 @@ class IcebergRESTCatalogOAuth2(IcebergRESTCatalogAuth, FrozenModel):
                 else self.client_secret.get_secret_value()
             ),
             "token-expires-in-ms": (
-                int(self.token_refresh_interval.total_seconds() * 1000) if self.token_refresh_interval else None
+                str(int(self.token_refresh_interval.total_seconds() * 1000)) if self.token_refresh_interval else None
             ),
             "token-refresh-enabled": "true" if self.token_refresh_interval is not None else "false",
             "token-exchange-enabled": "true" if self.token_exchange_enabled else "false",

--- a/onetl/connection/db_connection/iceberg/catalog/rest.py
+++ b/onetl/connection/db_connection/iceberg/catalog/rest.py
@@ -41,4 +41,8 @@ class IcebergRESTCatalog(IcebergCatalog, FrozenModel):
         }
         for key, value in self.headers.items():
             config[f"header.{key}"] = value
+
+        if self.auth:
+            config.update(self.auth.get_config())
+
         return config

--- a/onetl/connection/db_connection/iceberg/connection.py
+++ b/onetl/connection/db_connection/iceberg/connection.py
@@ -167,9 +167,6 @@ class Iceberg(DBConnection):
             "org.apache.iceberg.spark.SparkCatalog",
         )
         catalog_config = self.catalog.get_config() if self.catalog else {}
-        catalog_auth_config = self.catalog.auth.get_config() if self.catalog and self.catalog.auth else {}
-
-        catalog_config.update(catalog_auth_config)
         catalog_config.update(self.extra.dict())
         for k, v in catalog_config.items():
             self.spark.conf.set(f"spark.sql.catalog.{self.catalog_name}.{k}", v)


### PR DESCRIPTION
## Change Summary

Implemented `IcebergRESTCatalogBasicAuth` class

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
