### PR TITLE
Speed up HDFS, S3 and WebDAV tests using pytest-xdist

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync --extra files --extra spark --group dev
+          uv sync --extra files --group test-spark-3.5 --group dev
           uv pip install -U flake8-commas
 
           # Set the `CODEQL-PYTHON` environment variable to the Python executable

--- a/.github/workflows/test-hdfs.yml
+++ b/.github/workflows/test-hdfs.yml
@@ -80,7 +80,7 @@ jobs:
           mkdir reports/ || echo "Directory exists"
           source .env.local
           echo "127.0.0.1 hdfs" | sudo tee -a /etc/hosts
-          ./pytest_runner.sh -m hdfs
+          ./pytest_runner.sh -n logical -m hdfs
 
       - name: Dump HDFS logs on failure
         if: failure()

--- a/.github/workflows/test-hive-and-iceberg.yml
+++ b/.github/workflows/test-hive-and-iceberg.yml
@@ -71,8 +71,7 @@ jobs:
         run: |
           mkdir reports/ || echo "Directory exists"
           source .env.local
-          ./pytest_runner.sh -m hive
-          ./pytest_runner.sh -m "iceberg and not s3 and not hdfs"
+          ./pytest_runner.sh -m "hive or (iceberg and local_fs)"
 
       - name: Upload coverage results
         uses: actions/upload-artifact@v6

--- a/.github/workflows/test-local-fs.yml
+++ b/.github/workflows/test-local-fs.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           mkdir reports/ || echo "Directory exists"
           source .env.local
-          ./pytest_runner.sh -m local_fs
+          ./pytest_runner.sh -m "local_fs and not iceberg"
 
       - name: Upload coverage results
         uses: actions/upload-artifact@v6

--- a/.github/workflows/test-postgres.yml
+++ b/.github/workflows/test-postgres.yml
@@ -92,7 +92,7 @@ jobs:
           source .env.local
           export ONETL_PG_PORT=6432
           # Run only some basic tests
-          ./pytest_runner.sh -m postgres  -k "tests_core_integration or tests_db_connection_integration"
+          ./pytest_runner.sh -m postgres -k "tests_core_integration or tests_db_connection_integration"
 
       - name: Dump Postgres logs on failure
         if: failure()

--- a/.github/workflows/test-s3.yml
+++ b/.github/workflows/test-s3.yml
@@ -83,7 +83,7 @@ jobs:
         run: |
           mkdir reports/ || echo "Directory exists"
           source .env.local
-          ./pytest_runner.sh -m s3
+          ./pytest_runner.sh -n logical -m s3
 
       - name: Dump S3 logs on failure
         if: failure()

--- a/.github/workflows/test-webdav.yml
+++ b/.github/workflows/test-webdav.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           mkdir reports/ || echo "Directory exists"
           source .env.local
-          ./pytest_runner.sh -m webdav
+          ./pytest_runner.sh -n 2 -m webdav
 
       - name: Dump WebDAV logs on failure
         if: failure()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ concurrency:
 
 env:
   DEFAULT_PYTHON: '3.13'
-  MIN_COVERAGE: 96
+  MIN_COVERAGE: 95
 
 permissions:
   contents: write

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,8 +175,10 @@ test = [
     "pytest-lazy-fixture",
     "pytest-mock",
     "pytest-rerunfailures",
+    "pytest-xdist[psutil]",
     "requests",
     "responses",
+    "filelock",
 ]
 dev = [
     "black",

--- a/tests/fixtures/connections/file_connections.py
+++ b/tests/fixtures/connections/file_connections.py
@@ -1,4 +1,3 @@
-import secrets
 import shutil
 
 import pytest
@@ -51,10 +50,11 @@ def file_connection_with_path_and_files(request):
 
 
 @pytest.fixture()
-def file_connection_resource_path(resource_path, tmp_path_factory):
-    temp_dir = tmp_path_factory.mktemp("test_files") / secrets.token_hex(5)
+def file_connection_resource_path(resource_path, tmp_path_factory, worker_id):
+    temp_dir = tmp_path_factory.mktemp("test_files") / worker_id
     shutil.copytree(resource_path / "file_connection", temp_dir)
-    return temp_dir
+    yield temp_dir
+    shutil.rmtree(temp_dir, ignore_errors=True)
 
 
 @pytest.fixture()

--- a/tests/fixtures/connections/ftp.py
+++ b/tests/fixtures/connections/ftp.py
@@ -37,19 +37,16 @@ def ftp_file_connection(ftp_server):
 
 
 @pytest.fixture()
-def ftp_file_connection_with_path(request, ftp_file_connection):
+def ftp_file_connection_with_path(ftp_file_connection, worker_id):
     connection = ftp_file_connection
-    root = PurePosixPath("/data")
-
-    def finalizer():
-        connection.remove_dir(root, recursive=True)
-
-    request.addfinalizer(finalizer)
+    root = PurePosixPath("/data", worker_id)
 
     connection.remove_dir(root, recursive=True)
     connection.create_dir(root)
 
-    return connection, root
+    yield connection, root
+
+    connection.remove_dir(root, recursive=True)
 
 
 @pytest.fixture()

--- a/tests/fixtures/connections/ftps.py
+++ b/tests/fixtures/connections/ftps.py
@@ -37,19 +37,16 @@ def ftps_file_connection(ftps_server):
 
 
 @pytest.fixture()
-def ftps_file_connection_with_path(request, ftps_file_connection):
+def ftps_file_connection_with_path(ftps_file_connection, worker_id):
     connection = ftps_file_connection
-    root = PurePosixPath("/data")
-
-    def finalizer():
-        connection.remove_dir(root, recursive=True)
-
-    request.addfinalizer(finalizer)
+    root = PurePosixPath("/data", worker_id)
 
     connection.remove_dir(root, recursive=True)
     connection.create_dir(root)
 
-    return connection, root
+    yield connection, root
+
+    connection.remove_dir(root, recursive=True)
 
 
 @pytest.fixture()

--- a/tests/fixtures/connections/hdfs.py
+++ b/tests/fixtures/connections/hdfs.py
@@ -35,19 +35,16 @@ def hdfs_file_connection(hdfs_server):
 
 
 @pytest.fixture()
-def hdfs_file_connection_with_path(request, hdfs_file_connection):
+def hdfs_file_connection_with_path(hdfs_file_connection, worker_id):
     connection = hdfs_file_connection
-    root = PurePosixPath("/data")
-
-    def finalizer():
-        connection.remove_dir(root, recursive=True)
-
-    request.addfinalizer(finalizer)
+    root = PurePosixPath("/data", worker_id)
 
     connection.remove_dir(root, recursive=True)
     connection.create_dir(root)
 
-    return connection, root
+    yield connection, root
+
+    connection.remove_dir(root, recursive=True)
 
 
 @pytest.fixture()

--- a/tests/fixtures/connections/local_fs.py
+++ b/tests/fixtures/connections/local_fs.py
@@ -1,5 +1,4 @@
 import os
-import secrets
 import shutil
 from pathlib import Path
 
@@ -21,26 +20,33 @@ def local_fs_file_df_connection(spark):
 
 
 @pytest.fixture()
-def local_fs_file_df_connection_with_path(local_fs_file_df_connection, tmp_path_factory):
+def local_fs_file_df_connection_with_path(local_fs_file_df_connection, tmp_path_factory, worker_id):
     connection = local_fs_file_df_connection
-    root = tmp_path_factory.mktemp("local_fs")
-    return connection, root
+    root = tmp_path_factory.mktemp("local-fs") / worker_id
+    # Iceberg warehouse dir should be created beforehand
+    root.mkdir(exist_ok=True)
+    yield connection, root
+    shutil.rmtree(root, ignore_errors=True)
 
 
 @pytest.fixture()
 def local_fs_file_df_connection_with_path_and_files(
     local_fs_file_df_connection,
     tmp_path_factory,
+    worker_id,
     resource_path,
 ):
     connection = local_fs_file_df_connection
-    root = tmp_path_factory.mktemp("local_fs") / secrets.token_hex(5)
+    root = tmp_path_factory.mktemp("local-fs") / worker_id
     copy_from = resource_path / "file_df_connection"
 
+    # there is no dirs_exist_ok in python 3.7, so we don't create root dir before copy
     shutil.copytree(copy_from, root)
 
     files = []
     for directory, _, content in os.walk(root):
         for file in content:
             files.append(Path(directory) / file)
-    return connection, root, files
+
+    yield connection, root, files
+    shutil.rmtree(root, ignore_errors=True)

--- a/tests/fixtures/connections/s3.py
+++ b/tests/fixtures/connections/s3.py
@@ -1,5 +1,6 @@
 import os
 from collections import namedtuple
+from contextlib import suppress
 from pathlib import PurePosixPath
 
 import pytest
@@ -34,6 +35,8 @@ def s3_server():
     ],
 )
 def s3_file_connection(s3_server):
+    from minio.error import S3Error
+
     from onetl.connection import S3
 
     s3 = S3(
@@ -45,25 +48,22 @@ def s3_file_connection(s3_server):
         protocol=s3_server.protocol,
     )
 
-    if not s3.client.bucket_exists(bucket_name=s3_server.bucket):
+    with suppress(S3Error):
         s3.client.make_bucket(bucket_name=s3_server.bucket)
 
     return s3
 
 
 @pytest.fixture()
-def s3_file_connection_with_path(request, s3_file_connection):
+def s3_file_connection_with_path(s3_file_connection, worker_id):
     connection = s3_file_connection
-    root = PurePosixPath("/data")
-
-    def finalizer():
-        connection.remove_dir(root, recursive=True)
-
-    request.addfinalizer(finalizer)
+    root = PurePosixPath("/data", worker_id)
 
     connection.remove_dir(root, recursive=True)
 
-    return connection, root
+    yield connection, root
+
+    connection.remove_dir(root, recursive=True)
 
 
 @pytest.fixture()

--- a/tests/fixtures/connections/samba.py
+++ b/tests/fixtures/connections/samba.py
@@ -41,18 +41,15 @@ def samba_file_connection(samba_server):
 
 
 @pytest.fixture()
-def samba_file_connection_with_path(request, samba_file_connection):
+def samba_file_connection_with_path(samba_file_connection, worker_id):
     connection = samba_file_connection
-    root = PurePosixPath("/data")
-
-    def finalizer():
-        connection.remove_dir(root, recursive=True)
-
-    request.addfinalizer(finalizer)
+    root = PurePosixPath("/data", worker_id)
 
     connection.remove_dir(root, recursive=True)
 
-    return connection, root
+    yield connection, root
+
+    connection.remove_dir(root, recursive=True)
 
 
 @pytest.fixture()

--- a/tests/fixtures/connections/sftp.py
+++ b/tests/fixtures/connections/sftp.py
@@ -37,19 +37,16 @@ def sftp_file_connection(sftp_server):
 
 
 @pytest.fixture()
-def sftp_file_connection_with_path(request, sftp_file_connection):
+def sftp_file_connection_with_path(sftp_file_connection, worker_id):
     connection = sftp_file_connection
-    root = PurePosixPath("/app/data")
-
-    def finalizer():
-        connection.remove_dir(root, recursive=True)
-
-    request.addfinalizer(finalizer)
+    root = PurePosixPath("/app/data", worker_id)
 
     connection.remove_dir(root, recursive=True)
     connection.create_dir(root)
 
-    return connection, root
+    yield connection, root
+
+    connection.remove_dir(root, recursive=True)
 
 
 @pytest.fixture()

--- a/tests/fixtures/connections/webdav.py
+++ b/tests/fixtures/connections/webdav.py
@@ -44,19 +44,16 @@ def webdav_file_connection(webdav_server):
 
 
 @pytest.fixture()
-def webdav_file_connection_with_path(request, webdav_file_connection):
+def webdav_file_connection_with_path(webdav_file_connection, worker_id):
     connection = webdav_file_connection
-    root = PurePosixPath("/data")
-
-    def finalizer():
-        connection.remove_dir(root, recursive=True)
-
-    request.addfinalizer(finalizer)
+    root = PurePosixPath("/data", worker_id)
 
     connection.remove_dir(root, recursive=True)
     connection.create_dir(root)
 
-    return connection, root
+    yield connection, root
+
+    connection.remove_dir(root, recursive=True)
 
 
 @pytest.fixture()

--- a/tests/fixtures/processing/fixtures/kafka.py
+++ b/tests/fixtures/processing/fixtures/kafka.py
@@ -4,15 +4,13 @@ import pytest
 
 
 @pytest.fixture
-def kafka_topic(processing, request):
-    topic = secrets.token_hex(6)
+def kafka_topic(processing, worker_id):
+    topic = f"{worker_id}_topic_{secrets.token_hex(5)}"
     processing.create_topic(topic, num_partitions=1)
 
-    def delete_topic():
-        processing.delete_topic([topic])
+    yield topic
 
-    request.addfinalizer(delete_topic)
-    return topic
+    processing.delete_topic([topic])
 
 
 @pytest.fixture

--- a/tests/fixtures/processing/fixtures/processing.py
+++ b/tests/fixtures/processing/fixtures/processing.py
@@ -42,11 +42,11 @@ def processing(request, spark):
 
 
 @pytest.fixture
-def get_schema_table(processing):
+def get_schema_table(processing, worker_id):
     schema = processing.schema
     processing.create_schema(schema=schema)
 
-    table = f"test_{secrets.token_hex(5)}"
+    table = f"test_{worker_id}_{secrets.token_hex(3)}"
     full_name = f"{schema}.{table}"
 
     yield PreparedDbInfo(full_name=full_name, schema=schema, table=table)

--- a/tests/fixtures/spark.py
+++ b/tests/fixtures/spark.py
@@ -3,22 +3,23 @@ import shutil
 from pathlib import Path
 
 import pytest
+from filelock import FileLock
 
 from onetl._util.version import Version
 
 
 @pytest.fixture(scope="session")
-def warehouse_dir(tmp_path_factory):
+def warehouse_dir(tmp_path_factory, worker_id):
     # https://spark.apache.org/docs/latest/sql-data-sources-hive-tables.html
-    path = tmp_path_factory.mktemp("spark-warehouse")
+    path = tmp_path_factory.mktemp("spark-warehouse") / worker_id
     yield path
     shutil.rmtree(path, ignore_errors=True)
 
 
 @pytest.fixture(scope="session")
-def spark_metastore_dir(tmp_path_factory):
+def spark_metastore_dir(tmp_path_factory, worker_id):
     # https://stackoverflow.com/a/44048667
-    path = tmp_path_factory.mktemp("metastore_db")
+    path = tmp_path_factory.mktemp("metastore-db") / worker_id
     yield path
     shutil.rmtree(path, ignore_errors=True)
 
@@ -83,6 +84,7 @@ def maven_packages(request):
     if "avro" in markers:
         # There is no Avro package for Spark 2.3
         packages.extend(Avro.get_packages(spark_version=str(pyspark_version)))
+
     if "kafka" in markers:
         # Kafka connector for Spark 2.3 is too old and not supported
         packages.extend(Kafka.get_packages(spark_version=str(pyspark_version)))
@@ -149,10 +151,18 @@ def excluded_packages():
         pytest.param("real-spark", marks=[pytest.mark.db_connection, pytest.mark.connection]),
     ],
 )
-def spark(warehouse_dir, spark_metastore_dir, ivysettings_path, maven_packages, excluded_packages):
+def spark(
+    warehouse_dir,
+    spark_metastore_dir,
+    ivysettings_path,
+    maven_packages,
+    excluded_packages,
+    worker_id,
+    tmp_path_factory,
+):
     from pyspark.sql import SparkSession
 
-    spark = (
+    spark_builder = (
         SparkSession.builder.config("spark.app.name", "onetl")  # noqa: WPS221
         .config("spark.master", "local[*]")
         .config("spark.jars.packages", ",".join(maven_packages))
@@ -172,8 +182,17 @@ def spark(warehouse_dir, spark_metastore_dir, ivysettings_path, maven_packages, 
         )
         .config("spark.sql.warehouse.dir", warehouse_dir)
         .enableHiveSupport()
-        .getOrCreate()
     )
+
+    if worker_id == "master":
+        spark = spark_builder.getOrCreate()
+    else:
+        # https://pytest-xdist.readthedocs.io/en/stable/how-to.html#making-session-scoped-fixtures-execute-only-once
+        # Parallel start of Spark sessions can fail to write same files into ~/.ivy2 cache
+        # So we starting sessions one by one
+        root_tmp_dir = tmp_path_factory.getbasetemp().parent
+        with FileLock(root_tmp_dir / "spark_session.lock"):
+            spark = spark_builder.getOrCreate()
 
     yield spark
     spark.sparkContext.stop()
@@ -181,7 +200,9 @@ def spark(warehouse_dir, spark_metastore_dir, ivysettings_path, maven_packages, 
 
 
 @pytest.fixture(scope="session")
-def iceberg_warehouse_dir(tmp_path_factory):
-    path = tmp_path_factory.mktemp("iceberg-warehouse")
+def iceberg_warehouse_dir(tmp_path_factory, worker_id):
+    path = tmp_path_factory.mktemp("iceberg-warehouse") / worker_id
+    # Iceberg warehouse dir should be created beforehand
+    path.mkdir(exist_ok=True)
     yield path
     shutil.rmtree(path, ignore_errors=True)

--- a/tests/tests_integration/test_file_format_integration/test_avro_integration.py
+++ b/tests/tests_integration/test_file_format_integration/test_avro_integration.py
@@ -48,7 +48,6 @@ def avro_schema():
     ids=["without_compression", "with_compression"],
 )
 def test_avro_reader(
-    spark,
     local_fs_file_df_connection_with_path_and_files,
     file_df_dataframe,
     avro_schema,
@@ -82,7 +81,6 @@ def test_avro_reader(
     ids=["without_compression", "with_compression"],
 )
 def test_avro_writer(
-    spark,
     local_fs_file_df_connection_with_path,
     file_df_dataframe,
     avro_schema,
@@ -115,7 +113,6 @@ def test_avro_writer(
 
 @pytest.mark.parametrize("column_type", [str, col])
 def test_avro_serialize_and_parse_column(
-    spark,
     file_df_dataframe,
     avro_schema,
     column_type,
@@ -136,7 +133,6 @@ def test_avro_serialize_and_parse_column(
 
 @pytest.mark.parametrize("column_type", [str, col])
 def test_avro_serialize_and_parse_no_schema(
-    spark,
     file_df_dataframe,
     column_type,
 ):
@@ -160,7 +156,6 @@ def test_avro_serialize_and_parse_no_schema(
 @pytest.mark.parametrize("column_type", [str, col])
 @responses.activate
 def test_avro_serialize_and_parse_with_schema_url(
-    spark,
     file_df_dataframe,
     column_type,
     avro_schema,
@@ -183,7 +178,6 @@ def test_avro_serialize_and_parse_with_schema_url(
 
 
 def test_avro_serialize_and_parse_column_unsupported_options_warning(
-    spark,
     file_df_dataframe,
     avro_schema,
 ):

--- a/tests/tests_integration/tests_db_connection_integration/test_clickhouse_integration.py
+++ b/tests/tests_integration/tests_db_connection_integration/test_clickhouse_integration.py
@@ -116,10 +116,11 @@ def test_clickhouse_connection_fetch(spark, processing, load_table_data, suffix,
     )
 
     schema = load_table_data.schema
-    table = load_table_data.full_name
+    table = load_table_data.table
+    full_table = load_table_data.full_name
 
     with caplog.at_level(logging.INFO):
-        df = clickhouse.fetch(f"SELECT * FROM {table}{suffix}")
+        df = clickhouse.fetch(f"SELECT * FROM {full_table}{suffix}")
         assert "Detected dialect: 'org.apache.spark.sql.jdbc.NoopDialect'" in caplog.text
 
     table_df = processing.get_expected_dataframe(
@@ -131,11 +132,11 @@ def test_clickhouse_connection_fetch(spark, processing, load_table_data, suffix,
     clickhouse.close()
 
     # dataframe content is expected
-    df = clickhouse.fetch(f"SELECT * FROM {table} WHERE id_int < 50{suffix}")
+    df = clickhouse.fetch(f"SELECT * FROM {full_table} WHERE id_int < 50{suffix}")
     filtered_df = table_df[table_df.id_int < 50]
     processing.assert_equal_df(df=df, other_frame=filtered_df, order_by="id_int")
 
-    df = clickhouse.fetch(f"SHOW TABLES IN {schema}{suffix}")
+    df = clickhouse.fetch(f"SHOW TABLES FROM {schema} ILIKE '{table}'{suffix}")
     result_df = pandas.DataFrame([[load_table_data.table]], columns=["name"])
     processing.assert_equal_df(df=df, other_frame=result_df)
 
@@ -154,7 +155,7 @@ def test_clickhouse_connection_fetch(spark, processing, load_table_data, suffix,
 
     # fetch is always read-only
     with pytest.raises(Exception):
-        clickhouse.fetch(f"DROP TABLE {table}{suffix}")
+        clickhouse.fetch(f"DROP TABLE {full_table}{suffix}")
 
 
 @pytest.mark.parametrize("suffix", ["", ";"])

--- a/tests/tests_integration/tests_db_connection_integration/test_hive_integration.py
+++ b/tests/tests_integration/tests_db_connection_integration/test_hive_integration.py
@@ -28,10 +28,12 @@ def test_hive_connection_sql(spark, processing, load_table_data, suffix):
     database_table_column = database_name_column = "namespace"
 
     hive = Hive(cluster="rnd-dwh", spark=spark)
-    schema = load_table_data.schema
-    table = load_table_data.full_name
 
-    df = hive.sql(f"SELECT * FROM {table}{suffix}")
+    schema = load_table_data.schema
+    table = load_table_data.table
+    full_table = load_table_data.full_name
+
+    df = hive.sql(f"SELECT * FROM {full_table}{suffix}")
     table_df = processing.get_expected_dataframe(
         schema=load_table_data.schema,
         table=load_table_data.table,
@@ -39,7 +41,7 @@ def test_hive_connection_sql(spark, processing, load_table_data, suffix):
     )
     processing.assert_equal_df(df=df, other_frame=table_df, order_by="id_int")
 
-    df = hive.sql(f"SELECT * FROM {table} WHERE id_int < 50{suffix}")
+    df = hive.sql(f"SELECT * FROM {full_table} WHERE id_int < 50{suffix}")
     filtered_df = table_df[table_df.id_int < 50]
     processing.assert_equal_df(df=df, other_frame=filtered_df, order_by="id_int")
 
@@ -47,7 +49,7 @@ def test_hive_connection_sql(spark, processing, load_table_data, suffix):
     result_df = pandas.DataFrame([["default"], [schema]], columns=[database_table_column])
     processing.assert_equal_df(df=df, other_frame=result_df)
 
-    df = hive.sql(f"SHOW TABLES IN {schema}")
+    df = hive.sql(f"SHOW TABLES IN {schema} LIKE '{table}'")
     result_df = pandas.DataFrame(
         [[schema, load_table_data.table, False]],
         columns=[database_name_column, "tableName", "isTemporary"],

--- a/tests/tests_integration/tests_db_connection_integration/test_iceberg_integration.py
+++ b/tests/tests_integration/tests_db_connection_integration/test_iceberg_integration.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 import pytest
 
@@ -26,10 +27,12 @@ def test_iceberg_connection_sql(iceberg_connection_fs_catalog_local_fs_warehouse
     database_table_column = database_name_column = "namespace"
     connection = iceberg_connection_fs_catalog_local_fs_warehouse
 
-    schema = f"{connection.catalog_name}.{load_table_data.schema}"
-    table = f"{connection.catalog_name}.{load_table_data.full_name}"
+    catalog = connection.catalog_name
+    schema = load_table_data.schema
+    table = load_table_data.table
+    full_table = f"{catalog}.{load_table_data.full_name}"
 
-    df = connection.sql(f"SELECT * FROM {table}{suffix}")
+    df = connection.sql(f"SELECT * FROM {full_table}{suffix}")
     table_df = processing.get_expected_dataframe(
         schema=load_table_data.schema,
         table=load_table_data.table,
@@ -37,17 +40,17 @@ def test_iceberg_connection_sql(iceberg_connection_fs_catalog_local_fs_warehouse
     )
     processing.assert_equal_df(df=df, other_frame=table_df, order_by="id_int")
 
-    df = connection.sql(f"SELECT * FROM {table} WHERE id_int < 50{suffix}")
+    df = connection.sql(f"SELECT * FROM {full_table} WHERE id_int < 50{suffix}")
     filtered_df = table_df[table_df.id_int < 50]
     processing.assert_equal_df(df=df, other_frame=filtered_df, order_by="id_int")
 
-    df = connection.sql("SHOW NAMESPACES")
-    result_df = pandas.DataFrame([["default"]], columns=[database_table_column])
+    df = connection.sql(f"SHOW NAMESPACES IN {catalog}{suffix}")
+    result_df = pandas.DataFrame([[schema]], columns=[database_table_column])
     processing.assert_equal_df(df=df, other_frame=result_df)
 
-    df = connection.sql(f"SHOW TABLES IN {schema}")
+    df = connection.sql(f"SHOW TABLES IN {catalog}.{schema} LIKE '{re.escape(table)}'{suffix}")
     result_df = pandas.DataFrame(
-        [[schema.split(".")[-1], load_table_data.table, False]],
+        [[schema, table, False]],
         columns=[database_name_column, "tableName", "isTemporary"],
     )
     processing.assert_equal_df(df=df, other_frame=result_df)

--- a/tests/tests_integration/tests_db_connection_integration/test_mysql_integration.py
+++ b/tests/tests_integration/tests_db_connection_integration/test_mysql_integration.py
@@ -122,10 +122,11 @@ def test_mysql_connection_fetch(spark, processing, load_table_data, suffix):
     )
 
     schema = load_table_data.schema
-    table = load_table_data.full_name
+    table = load_table_data.table
+    full_table = load_table_data.full_name
 
     # dataframe content is expected
-    df = mysql.fetch(f"SELECT * FROM {table}{suffix}")
+    df = mysql.fetch(f"SELECT * FROM {full_table}{suffix}")
     table_df = processing.get_expected_dataframe(
         schema=load_table_data.schema,
         table=load_table_data.table,
@@ -133,12 +134,12 @@ def test_mysql_connection_fetch(spark, processing, load_table_data, suffix):
     )
     processing.assert_equal_df(df=df, other_frame=table_df, order_by="id_int")
 
-    df = mysql.fetch(f"SELECT * FROM {table} WHERE id_int < 50{suffix}")
+    df = mysql.fetch(f"SELECT * FROM {full_table} WHERE id_int < 50{suffix}")
     filtered_df = table_df[table_df.id_int < 50]
     processing.assert_equal_df(df=df, other_frame=filtered_df, order_by="id_int")
 
-    df = mysql.fetch(f"SHOW TABLES{suffix}")
-    result_df = pandas.DataFrame([[load_table_data.table]], columns=[f"Tables_in_{schema}"])
+    df = mysql.fetch(f"SHOW TABLES IN {schema} LIKE '{table}'{suffix}")
+    result_df = pandas.DataFrame([[load_table_data.table]], columns=[f"Tables_in_{schema} ({table})"])
     processing.assert_equal_df(df=df, other_frame=result_df)
 
     # client info is expected
@@ -159,7 +160,7 @@ def test_mysql_connection_fetch(spark, processing, load_table_data, suffix):
 
     # fetch is always read-only
     with pytest.raises(Exception):
-        mysql.fetch(f"DROP TABLE {table}{suffix}")
+        mysql.fetch(f"DROP TABLE {full_table}{suffix}")
 
 
 @pytest.mark.parametrize("suffix", ["", ";"])

--- a/tests/tests_integration/tests_file_connection_integration/test_hdfs_file_connection_integration.py
+++ b/tests/tests_integration/tests_file_connection_integration/test_hdfs_file_connection_integration.py
@@ -35,7 +35,6 @@ def test_hdfs_file_connection_check_with_keytab(mocker, hdfs_server, caplog, req
     mocker.patch.object(connection, "kinit")
 
     folder: Path = tmp_path_factory.mktemp("keytab")
-    folder.mkdir(exist_ok=True, parents=True)
     keytab = folder / "user.keytab"
     keytab.touch()
     hdfs = HDFS(host="some_host", user="some_user", keytab=keytab)

--- a/tests/tests_integration/tests_file_connection_integration/test_s3_file_connection_integration.py
+++ b/tests/tests_integration/tests_file_connection_integration/test_s3_file_connection_integration.py
@@ -43,23 +43,24 @@ def test_s3_file_connection_check_failed(s3_server):
 
 @pytest.mark.parametrize("path_prefix", ["/", ""])
 def test_s3_file_connection_list_dir(path_prefix, s3_file_connection_with_path_and_files):
-    s3, _, _ = s3_file_connection_with_path_and_files
+    s3, upload_to, _ = s3_file_connection_with_path_and_files
+
+    root = path_prefix + os.fspath(upload_to).lstrip("/")
 
     def dir_content(path):
         return sorted(os.fspath(file) for file in s3.list_dir(path))
 
-    assert dir_content(f"{path_prefix}data/exclude_dir") == [
-        "/data/exclude_dir/excluded1.txt",
-        "/data/exclude_dir/nested",
+    assert dir_content(f"{root}/exclude_dir") == [
+        f"{upload_to}/exclude_dir/excluded1.txt",
+        f"{upload_to}/exclude_dir/nested",
     ]
-    assert dir_content(f"{path_prefix}data") == [
-        "/data/ascii.txt",
-        "/data/exclude_dir",
-        "/data/nested",
-        "/data/some.csv",
-        "/data/utf-8.txt",
+    assert dir_content(root) == [
+        f"{upload_to}/ascii.txt",
+        f"{upload_to}/exclude_dir",
+        f"{upload_to}/nested",
+        f"{upload_to}/some.csv",
+        f"{upload_to}/utf-8.txt",
     ]
-    assert "/data" in dir_content(path_prefix)  # "tmp" could present
 
 
 def test_s3_file_connection_directory_marker(s3_file_connection_with_path):

--- a/tests/tests_unit/tests_file_connection_unit/test_hdfs_unit.py
+++ b/tests/tests_unit/tests_file_connection_unit/test_hdfs_unit.py
@@ -92,8 +92,7 @@ def test_hdfs_connection_with_password():
 def test_hdfs_connection_with_keytab(request, tmp_path_factory):
     from onetl.connection import HDFS
 
-    folder: Path = tmp_path_factory.mktemp("keytab")
-    folder.mkdir(exist_ok=True, parents=True)
+    folder: Path = tmp_path_factory.mktemp("keytabs")
     keytab = folder / "user.keytab"
     keytab.touch()
     conn = HDFS(host="some-host.domain.com", user="some_user", keytab=keytab)
@@ -117,7 +116,7 @@ def test_hdfs_connection_keytab_does_not_exist():
 def test_hdfs_connection_keytab_is_directory(request, tmp_path_factory):
     from onetl.connection import HDFS
 
-    folder: Path = tmp_path_factory.mktemp("keytab")
+    folder: Path = tmp_path_factory.mktemp("keytabs")
     keytab = folder / "user.keytab"
     keytab.mkdir(exist_ok=True, parents=True)
 
@@ -141,7 +140,6 @@ def test_hdfs_connection_with_password_and_keytab(request, tmp_path_factory):
     from onetl.connection import HDFS
 
     folder: Path = tmp_path_factory.mktemp("keytab")
-    folder.mkdir(exist_ok=True, parents=True)
     keytab = folder / "user.keytab"
     keytab.touch()
 

--- a/tests/tests_unit/tests_file_connection_unit/test_sftp_unit.py
+++ b/tests/tests_unit/tests_file_connection_unit/test_sftp_unit.py
@@ -48,7 +48,6 @@ def test_sftp_connection_with_key_file(request, tmp_path_factory):
     from onetl.connection import SFTP
 
     folder: Path = tmp_path_factory.mktemp("key_file")
-    folder.mkdir(exist_ok=True, parents=True)
     key_file = folder / "id_rsa"
     key_file.touch()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Make following tests faster by running them in parallel:
* HDFS: 6min -> 2.5min
* S3: 3min -> 2min
* WebDAV: 2.5min -> 1.5min

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
