### PR TITLE
[DOP-36248] Update contributing guide for mkdocs

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -47,8 +47,8 @@ jobs:
 
       - name: Check changelog entry exists
         run: |
-          if [ ! -s docs/changelog/next_release/${{ github.event.pull_request.number }}.*.rst ]; then
-              echo "Please add corresponding file 'docs/changelog/next_release/<issue number>.<change type>.rst' with changes description"
+          if [ ! -s mddocs/docs/changelog/next_release/${{ github.event.pull_request.number }}.*.md ]; then
+              echo "Please add corresponding file 'mddocs/docs/changelog/next_release/<issue number>.<change type>.md' with changes description"
               exit 1
           fi
 

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Fix logo in Readme
         run: |
-          sed -i "s#image:: docs/#image:: https://raw.githubusercontent.com/MTSWebServices/onetl/$GITHUB_SHA/docs/#g" README.rst
+          sed -i "s#image:: mddocs/docs/#image:: https://raw.githubusercontent.com/MTSWebServices/onetl/$GITHUB_SHA/mddocs/docs/#g" README.rst
 
       - name: Set up Python ${{ env.DEFAULT_PYTHON }}
         id: python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Fix logo in Readme
         run: |
-          sed -i "s#image:: docs/#image:: https://raw.githubusercontent.com/MTSWebServices/onetl/$GITHUB_REF_NAME/docs/#g" README.rst
+          sed -i "s#image:: mddocs/docs/#image:: https://raw.githubusercontent.com/MTSWebServices/onetl/$GITHUB_SHA/mddocs/docs/#g" README.rst
 
       - name: Set up Python ${{ env.DEFAULT_PYTHON }}
         id: python
@@ -53,48 +53,15 @@ jobs:
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@release/v1
 
-      - name: Get changelog
+      - name: Prepare changelog
         run: |
-          cat docs/changelog/$GITHUB_REF_NAME.rst > changelog.rst
-
-      - name: Prepare rST syntax for conversion to Markdown
-        run: |
-          # Replace Github links from Sphinx syntax with Markdown
-          sed -i -E 's/:github:issue:`(.*)`/#\1/g' changelog.rst
-          sed -i -E 's/:github:pull:`(.*)`/#\1/g' changelog.rst
-          sed -i -E 's/:github:user:`(.*)`/@\1/g' changelog.rst
-          sed -i -E 's/:github:org:`(.*)`/@\1/g' changelog.rst
-
-      - name: Convert rST to Markdown
-        uses: docker://pandoc/core:2.9
-        with:
-          args: >-
-            --output=changelog.md
-            --from=rst
-            --to=gfm
-            --wrap=none
-            changelog.rst
-
-      - name: Fixing Markdown syntax after conversion
-        run: |
-          # Replace ``` {.python caption="abc"} with ```python caption="abc"
-          sed -i -E 's/``` \{\.(.*)\}/```\1/g' changelog.md
-
-          # Replace ``` python with ```python
-          sed -i -E 's/``` (\w+)/```\1/g' changelog.md
-
-          # Replace \# with #
-          sed -i -E 's/\\#/#/g' changelog.md
-
-      - name: Get release name
-        id: release-name
-        run: |
-          # Release name looks like: 0.7.0 (2023-05-15)
+          cat mddocs/docs/changelog/${GITHUB_REF_NAME}.md > changelog.md
+          # Remove anchors like "{ #DBR-onetl-changelog-0-7-0 }"
+          sed -i -E 's/\{.*\}//g' changelog.md
+          # Header looks like "# 0.7.0 (2023-05-15)"
+          # Release name looks like "0.7.0 (2023-05-15)"
           echo -n name= > "$GITHUB_OUTPUT"
           cat changelog.md | head -1 | sed -E "s/#+\s*//g" >> "$GITHUB_OUTPUT"
-
-      - name: Fix headers
-        run: |
           # Remove header with release name
           sed -i -e '1,2d' changelog.md
 

--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,5 @@ docker-compose*override*
 
 metastore_db/
 spark-warehouse/
+
+mddocs/generated/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -113,7 +113,7 @@ repos:
     hooks:
       - id: ruff-format
         priority: 8
-      - id: ruff
+      - id: ruff-check
         args: [--fix]
         priority: 9
 
@@ -130,7 +130,7 @@ repos:
         name: towncrier
         entry: towncrier build --draft
         language: system
-        types: [rst]
+        types: [markdown]
         pass_filenames: false
         priority: 8
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -222,10 +222,9 @@ Build documentation using Sphinx:
 
 .. code:: bash
 
-    cd docs
-    make html
+    make docs-serve
 
-Then open in browser ``docs/_build/index.html``.
+Then open in browser ``http://localhost:8000/``.
 
 
 Create pull request
@@ -261,22 +260,15 @@ combined with others, it will be a part of the "news digest"
 telling the readers **what changed** in a specific version of
 the library *since the previous version*.
 
-You should also use
-reStructuredText syntax for highlighting code (inline or block),
-linking parts of the docs or external sites.
-If you wish to sign your change, feel free to add ``-- by
-:user:`github-username``` at the end (replace ``github-username``
-with your own!).
-
 Finally, name your file following the convention that Towncrier
 understands: it should start with the number of an issue or a
 PR followed by a dot, then add a patch type, like ``feature``,
-``doc``, ``misc`` etc., and add ``.rst`` as a suffix. If you
+``doc``, ``misc`` etc., and add ``.md`` as a suffix. If you
 need to add more than one fragment, you may add an optional
 sequence number (delimited with another period) between the type
 and the suffix.
 
-In general the name will follow ``<pr_number>.<category>.rst`` pattern,
+In general the name will follow ``<pr_number>.<category>.md`` pattern,
 where the categories are:
 
 - ``feature``: Any new feature
@@ -295,21 +287,15 @@ changes accompanying the relevant code changes.
 Examples for adding changelog entries to your Pull Requests
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. code-block:: rst
-    :caption: docs/changelog/next_release/1234.doc.1.rst
+.. code-block:: markdown
+    :caption: mddocs/docs/changelog/next_release/2345.bugfix.md
 
-    Added a ``:github:user:`` role to Sphinx config -- by :github:user:`someuser`
+    Fixed behavior of `WebDAV` connector
 
-.. code-block:: rst
-    :caption: docs/changelog/next_release/2345.bugfix.rst
+.. code-block:: markdown
+    :caption: mddocs/docs/changelog/next_release/3456.feature.md
 
-    Fixed behavior of ``WebDAV`` connector -- by :github:user:`someuser`
-
-.. code-block:: rst
-    :caption: docs/changelog/next_release/3456.feature.rst
-
-    Added support of ``timeout`` in ``S3`` connector
-    -- by :github:user:`someuser`, :github:user:`anotheruser` and :github:user:`otheruser`
+    Added support of `timeout` in ``S3`` connector
 
 .. tip::
 
@@ -333,51 +319,26 @@ Release Process
 
 Before making a release from the ``develop`` branch, follow these steps:
 
-0. Checkout to ``develop`` branch and update it to the actual state
+1. Checkout to ``develop`` branch and update it to the actual state
 
 .. code:: bash
 
     git checkout develop
     git pull -p
 
-1. Backup ``NEXT_RELEASE.rst``
-
-.. code:: bash
-
-    cp "docs/changelog/NEXT_RELEASE.rst" "docs/changelog/temp_NEXT_RELEASE.rst"
-
-2. Build the Release notes with Towncrier
+2. Get current release version
 
 .. code:: bash
 
     VERSION=$(cat onetl/VERSION)
-    towncrier build "--version=${VERSION}" --yes
 
-3. Change file with changelog to release version number
-
-.. code:: bash
-
-    mv docs/changelog/NEXT_RELEASE.rst "docs/changelog/${VERSION}.rst"
-
-4. Remove content above the version number heading in the ``${VERSION}.rst`` file
+3. Build changelog for current release
 
 .. code:: bash
 
-    awk '!/^.*towncrier release notes start/' "docs/changelog/${VERSION}.rst" > temp && mv temp "docs/changelog/${VERSION}.rst"
+    make docs-generate-changelog
 
-5. Update Changelog Index
-
-.. code:: bash
-
-    awk -v version=${VERSION} '/DRAFT/{print;print "    " version;next}1' docs/changelog/index.rst > temp && mv temp docs/changelog/index.rst
-
-6. Restore ``NEXT_RELEASE.rst`` file from backup
-
-.. code:: bash
-
-    mv "docs/changelog/temp_NEXT_RELEASE.rst" "docs/changelog/NEXT_RELEASE.rst"
-
-7. Commit and push changes to ``develop`` branch
+4. Commit and push changes to ``develop`` branch
 
 .. code:: bash
 
@@ -385,7 +346,7 @@ Before making a release from the ``develop`` branch, follow these steps:
     git commit -m "Prepare for release ${VERSION}"
     git push
 
-8. Merge ``develop`` branch to ``master``, **WITHOUT** squashing
+5. Merge ``develop`` branch to ``master``, **WITHOUT** squashing
 
 .. code:: bash
 
@@ -394,14 +355,14 @@ Before making a release from the ``develop`` branch, follow these steps:
     git merge develop
     git push
 
-9. Add git tag to the latest commit in ``master`` branch
+6. Add git tag to the latest commit in ``master`` branch
 
 .. code:: bash
 
     git tag "$VERSION"
     git push origin "$VERSION"
 
-10. Update version in ``develop`` branch **after release**:
+7. Update version in ``develop`` branch **after release**:
 
 .. code:: bash
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@
 include .env.local
 
 export SPARK_EXTERNAL_IP := $(shell docker network inspect onetl_onetl --format '{{ (index .IPAM.Config 0).Gateway }}')
-VERSION = develop
 SPARK_VERSION ?= 3.5
 VIRTUAL_ENV ?= .venv
 PYTHON = ${VIRTUAL_ENV}/bin/python
@@ -101,12 +100,33 @@ test-doctest: ##@Run documentation tests
 docs: docs-build docs-open ##@Docs Generate & open docs
 
 docs-build: ##@Docs Generate docs
-	$(MAKE) -C docs html
+	DISABLE_MKDOCS_2_WARNING=true mkdocs build -f mddocs/mkdocs.yml
 
 docs-open: ##@Docs Open docs
-	xdg-open docs/_build/html/index.html
+	xdg-open mddocs/generated/index.html
 
 docs-cleanup: ##@Docs Cleanup docs
-	$(MAKE) -C docs clean
+	rm -rf mddocs/generated/
 
 docs-fresh: docs-cleanup docs-build ##@Docs Cleanup & build docs
+
+docs-serve: ##@Docs Run docs server
+	DISABLE_MKDOCS_2_WARNING=true mkdocs serve -f mddocs/mkdocs.yml
+
+docs-generate-changelog: ##@Docs Generate changelog
+	export VERSION=$(shell cat onetl/VERSION)
+	echo "Building changelog for ${VERSION}"
+	cp "mddocs/docs/changelog/RELEASE_TEMPLATE.md" "mddocs/docs/changelog/temp_RELEASE_TEMPLATE.md"
+	towncrier build "--version=${VERSION}" --yes
+	mv "mddocs/docs/changelog/RELEASE_TEMPLATE.md" "mddocs/docs/changelog/${VERSION}.md"
+	mv "mddocs/docs/changelog/temp_RELEASE_TEMPLATE.md" "mddocs/docs/changelog/RELEASE_TEMPLATE.md"
+
+	# Remove content above the version number heading in the `${VERSION}.md` file
+	awk '/##/,0' "mddocs/docs/changelog/${VERSION}.md" > temp && mv temp "mddocs/docs/changelog/${VERSION}.md"
+
+	export DATE=$(shell date --rfc-3339=date)
+	export VERSION_ANCHOR=$(shell echo ${VERSION} | tr '.' '-')
+
+	# Update Changelog Index and Navigation
+	sed "s#\(.*NEXT_RELEASE.*\)#\1\n- [${VERSION} (${DATE})][DBR-onetl-changelog-${VERSION_ANCHOR}]#" "mddocs/docs/changelog/index.md" > temp && mv temp "mddocs/docs/changelog/index.md"
+	sed "s#\(.*NEXT_RELEASE.*\)#\1\n    * [${VERSION}](changelog/${VERSION}.md)#" "mddocs/docs/nav.md" > temp && mv temp "mddocs/docs/nav.md"

--- a/mddocs/docs/changelog/DRAFT.md
+++ b/mddocs/docs/changelog/DRAFT.md
@@ -1,3 +1,0 @@
-```{eval-rst}
-.. towncrier-draft-entries:: |release| [UNRELEASED]
-```

--- a/mddocs/docs/changelog/NEXT_RELEASE.md
+++ b/mddocs/docs/changelog/NEXT_RELEASE.md
@@ -1,1 +1,1 @@
-% towncrier release notes start
+:: towncrier-draft Next release

--- a/mddocs/docs/changelog/RELEASE_TEMPLATE.md
+++ b/mddocs/docs/changelog/RELEASE_TEMPLATE.md
@@ -1,0 +1,1 @@
+<!-- towncrier release notes start -->

--- a/mddocs/docs/changelog/index.md
+++ b/mddocs/docs/changelog/index.md
@@ -1,5 +1,6 @@
 # Changelog { #DBR-onetl-changelog }
 
+- [Next release](./NEXT_RELEASE)
 - [0.15.1 (2026-04-15)][DBR-onetl-changelog-0-15-1]
 - [0.15.0 (2025-12-08)][DBR-onetl-changelog-0-15-0]
 - [0.14.1 (2025-11-25)][DBR-onetl-changelog-0-14-1]

--- a/mddocs/docs/contributing.md
+++ b/mddocs/docs/contributing.md
@@ -204,14 +204,13 @@ Create virtualenv and install dependencies:
 make venv-install
 ```
 
-Build documentation using Sphinx:
+Build documentation using mkdocs:
 
 ```bash
-cd docs
-make html
+make docs-serve
 ```
 
-Then open in browser `docs/_build/index.html`.
+Then open in browser http://localhost:8000/
 
 ### Create pull request { #DBR-onetl-contributing-create-pull-request }
 
@@ -233,7 +232,7 @@ After pull request is created, it get a corresponding number, e.g. 123 (`pr_numb
 for changelog management.
 
 To submit a change note about your PR, add a text file into the
-[docs/changelog/next_release](changelog/NEXT_RELEASE.md) folder. It should contain an
+[docs/changelog/RELEASE_TEMPLATE](changelog/RELEASE_TEMPLATE.md) folder. It should contain an
 explanation of what applying this PR will change in the way
 end-users interact with the project. One sentence is usually
 enough but feel free to add as many details as you feel necessary
@@ -244,22 +243,15 @@ combined with others, it will be a part of the "news digest"
 telling the readers **what changed** in a specific version of
 the library *since the previous version*.
 
-You should also use
-reStructuredText syntax for highlighting code (inline or block),
-linking parts of the docs or external sites.
-If you wish to sign your change, feel free to add `-- by
-:user:`github-username`` at the end (replace `github-username`
-with your own!).
-
 Finally, name your file following the convention that Towncrier
 understands: it should start with the number of an issue or a
 PR followed by a dot, then add a patch type, like `feature`,
-`doc`, `misc` etc., and add `.rst` as a suffix. If you
+`doc`, `misc` etc., and add `.md` as a suffix. If you
 need to add more than one fragment, you may add an optional
 sequence number (delimited with another period) between the type
 and the suffix.
 
-In general the name will follow `<pr_number>.<category>.rst` pattern,
+In general the name will follow `<pr_number>.<category>.md` pattern,
 where the categories are:
 
 * `feature`: Any new feature
@@ -277,17 +269,12 @@ changes accompanying the relevant code changes.
 
 #### Examples for adding changelog entries to your Pull Requests { #DBR-onetl-contributing-examples-for-adding-changelog-entries-to-your-pull-requests }
 
-```rst title="docs/changelog/next_release/1234.doc.1.rst"
-Added a `:github:user:` role to Sphinx config -- by :github:user:`someuser`
+```markdown title="mddocs/docs/changelog/RELEASE_TEMPLATE/2345.bugfix.md"
+Fixed behavior of `WebDAV` connector
 ```
 
-```rst title="docs/changelog/next_release/2345.bugfix.rst"
-Fixed behavior of `WebDAV` connector -- by :github:user:`someuser`
-```
-
-```rst
-Added support of `timeout` in `S3` connector
--- by :github:user:`someuser`, :github:user:`anotheruser` and :github:user:`otheruser`
+```markdown title="mddocs/docs/changelog/RELEASE_TEMPLATE/3456.feature.md"
+Added support of `timeout` in ``S3`` connector
 ```
 
 #### How to skip change notes check? { #DBR-onetl-contributing-how-to-skip-change-notes-check }
@@ -306,51 +293,26 @@ Just add `ci:skip-changelog` label to pull request.
 
 Before making a release from the `develop` branch, follow these steps:
 
-0. Checkout to `develop` branch and update it to the actual state
+1. Checkout to `develop` branch and update it to the actual state
 
     ```bash
     git checkout develop
     git pull -p
     ```
 
-1. Backup `NEXT_RELEASE.rst`
-
-    ```bash
-    cp "docs/changelog/NEXT_RELEASE.rst" "docs/changelog/temp_NEXT_RELEASE.rst"
-    ```
-
-2. Build the Release notes with Towncrier
+2. Get current release version
 
     ```bash
     VERSION=$(cat onetl/VERSION)
-    towncrier build "--version=${VERSION}" --yes
     ```
 
-3. Change file with changelog to release version number
+3. Build changelog for current release
 
     ```bash
-    mv docs/changelog/NEXT_RELEASE.rst "docs/changelog/${VERSION}.rst"
+    make docs-generate-changelog
     ```
 
-4. Remove content above the version number heading in the `${VERSION}.rst` file
-
-    ```bash
-    awk '!/^.*towncrier release notes start/' "docs/changelog/${VERSION}.rst" > temp && mv temp "docs/changelog/${VERSION}.rst"
-    ```
-
-5. Update Changelog Index
-
-    ```bash
-    awk -v version=${VERSION} '/DRAFT/{print;print "    " version;next}1' docs/changelog/index.rst > temp && mv temp docs/changelog/index.rst
-    ```
-
-6. Restore `NEXT_RELEASE.rst` file from backup
-
-    ```bash
-    mv "docs/changelog/temp_NEXT_RELEASE.rst" "docs/changelog/NEXT_RELEASE.rst"
-    ```
-
-7. Commit and push changes to `develop` branch
+4. Commit and push changes to `develop` branch
 
     ```bash
     git add .
@@ -358,7 +320,7 @@ Before making a release from the `develop` branch, follow these steps:
     git push
     ```
 
-8. Merge `develop` branch to `master`, **WITHOUT** squashing
+5. Merge `develop` branch to `master`, **WITHOUT** squashing
 
     ```bash
     git checkout master
@@ -367,14 +329,14 @@ Before making a release from the `develop` branch, follow these steps:
     git push
     ```
 
-9. Add git tag to the latest commit in `master` branch
+6. Add git tag to the latest commit in `master` branch
 
     ```bash
     git tag "$VERSION"
     git push origin "$VERSION"
     ```
 
-10. Update version in `develop` branch **after release**:
+7. Update version in `develop` branch **after release**:
 
     ```bash
     git checkout develop

--- a/mddocs/docs/nav.md
+++ b/mddocs/docs/nav.md
@@ -191,6 +191,7 @@
 * [Troubleshooting](troubleshooting/index.md)
     * [Spark](troubleshooting/spark.md)
 * [Changelog](changelog/index.md)
+    * [Next release](changelog/NEXT_RELEASE.md)
     * [0.15.1](changelog/0.15.1.md)
     * [0.15.0](changelog/0.15.0.md)
     * [0.14.1](changelog/0.14.1.md)

--- a/mddocs/mkdocs.yml
+++ b/mddocs/mkdocs.yml
@@ -71,12 +71,8 @@ plugins:
             extensions:
               - scripts/griffe_expand_refs.py:ExpandShortRefs
               - griffe_inherited_docstrings
-            # - griffe_sphinx
             # - griffe_pydantic: {schema: false}
   - macros
-  # - plantuml:
-  #     puml_url: https://www.plantuml.com/plantuml/
-  #     puml_keyword: plantuml
   # - i18n:
   #     docs_structure: folder
   #     languages:
@@ -87,6 +83,7 @@ plugins:
   #       - locale: ru
   #         name: Русский
   #         build: false
+  - towncrier
 
 markdown_extensions:
   - footnotes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ content-type = "text/x-rst"
 
 [tool.setuptools.packages.find]
 include = ["onetl*"]
-exclude = ["docs", "tests"]
+exclude = ["mddocs", "tests"]
 
 [tool.setuptools.package-data]
 "*" = ["py.typed", "VERSION"]
@@ -208,6 +208,9 @@ docs = [
     "griffe-inherited-docstrings>=1.0,<2",
     "mkdocs-macros-plugin>=1.0,<2",
     "pymdown-extensions>=10.0,<11",
+    "mkdocs-towncrier>=0.1.5,<1",
+    "towncrier~=25.8.0",
+    "setuptools<82",
 ]
 
 [tool.uv]
@@ -241,7 +244,7 @@ cx-oracle = ["setuptools<82"]
 [tool.ruff]
 target-version = "py37"
 line-length = 120
-extend-exclude = ["docs/", "Makefile"]
+extend-exclude = ["mddocs/", "Makefile"]
 
 [tool.ruff.lint]
 select = ["ALL"]
@@ -344,10 +347,12 @@ partial_also = [
 [tool.towncrier]
 name = "onETL"
 package = "onetl"
-filename = "docs/changelog/NEXT_RELEASE.rst"
-directory = "docs/changelog/next_release/"
-title_format = "{version} ({project_date})"
-issue_format = ":github:pull:`{issue}`"
+filename = "mddocs/docs/changelog/RELEASE_TEMPLATE.md"
+start_string = "<!-- towncrier release notes start -->\n"
+underlines = ["", "", ""]
+directory = "mddocs/docs/changelog/next_release/"
+title_format = "## [{version}](https://github.com/MTSWebServices/onetl/tree/{version}) - {project_date}"
+issue_format = "[#{issue}](https://github.com/MTSWebServices/onetl/issues/{issue})"
 
 [[tool.towncrier.type]]
 directory = "breaking"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MTSWebServices/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

After replacing sphinx with mkdocs some things were not updated properly:
* towncrier used `.rst` files instead of `.md`
* release & CI workflow instruction relied on `.rst` files instead of `.md`
* Makefile was not updated for sphinx->mkdocs replacement, as well as release instruction.

Fixed.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [ ] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MTSWebServices/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
