### PR TITLE
[DOP-39502] Add OAuth2 Client Credentials auth for Kafka

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -142,6 +142,77 @@ services:
       retries: 5
     profiles: [kafka, db, all]
 
+  keycloak:
+    image: ${KEYCLOAK_IMAGE:-quay.io/keycloak/keycloak:26.7.0}
+    restart: unless-stopped
+    command: start-dev --import-realm
+    ports:
+      - 8080:8080
+    environment:
+      TZ: UTC
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: 123AdminUserForTests@!
+      KC_HEALTH_ENABLED: 'true'
+      KC_HOSTNAME: http://localhost:8080
+      KC_HOSTNAME_BACKCHANNEL_DYNAMIC: 'true'
+    volumes:
+      - ./docker/kafka/keycloak/onetl-kafka-realm.json:/opt/keycloak/data/import/onetl-kafka-realm.json:ro
+    networks:
+      - onetl
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >-
+          { printf 'HEAD /health/ready HTTP/1.0\r\n\r\n' >&0;
+          grep -q 'HTTP/1.0 200'; } 0<>/dev/tcp/localhost/9000
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 20s
+    profiles: [kafka-oauth]
+
+  kafka-oauth:
+    image: ${KAFKA_OAUTH_IMAGE:-apache/kafka:3.9.1}
+    restart: unless-stopped
+    ports:
+      - 9097:9097
+    environment:
+      TZ: UTC
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka-oauth:9091
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+      KAFKA_LISTENERS: CONTROLLER://:9091,INTERNAL://:9092,OAUTH_INTERNAL://:9096,OAUTH_EXTERNAL://:9097
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka-oauth:9092,OAUTH_INTERNAL://kafka-oauth:9096,OAUTH_EXTERNAL://localhost:9097
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,INTERNAL:PLAINTEXT,OAUTH_INTERNAL:SASL_PLAINTEXT,OAUTH_EXTERNAL:SASL_PLAINTEXT
+      KAFKA_SASL_ENABLED_MECHANISMS: OAUTHBEARER
+      KAFKA_LISTENER_NAME_OAUTH__INTERNAL_OAUTHBEARER_SASL_JAAS_CONFIG: org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;
+      KAFKA_LISTENER_NAME_OAUTH__INTERNAL_OAUTHBEARER_SASL_SERVER_CALLBACK_HANDLER_CLASS: org.apache.kafka.common.security.oauthbearer.OAuthBearerValidatorCallbackHandler
+      KAFKA_LISTENER_NAME_OAUTH__INTERNAL_OAUTHBEARER_SASL_OAUTHBEARER_JWKS_ENDPOINT_URL: http://keycloak:8080/realms/onetl-kafka/protocol/openid-connect/certs
+      KAFKA_LISTENER_NAME_OAUTH__INTERNAL_OAUTHBEARER_SASL_OAUTHBEARER_EXPECTED_ISSUER: http://localhost:8080/realms/onetl-kafka
+      KAFKA_LISTENER_NAME_OAUTH__EXTERNAL_OAUTHBEARER_SASL_JAAS_CONFIG: org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;
+      KAFKA_LISTENER_NAME_OAUTH__EXTERNAL_OAUTHBEARER_SASL_SERVER_CALLBACK_HANDLER_CLASS: org.apache.kafka.common.security.oauthbearer.OAuthBearerValidatorCallbackHandler
+      KAFKA_LISTENER_NAME_OAUTH__EXTERNAL_OAUTHBEARER_SASL_OAUTHBEARER_JWKS_ENDPOINT_URL: http://keycloak:8080/realms/onetl-kafka/protocol/openid-connect/certs
+      KAFKA_LISTENER_NAME_OAUTH__EXTERNAL_OAUTHBEARER_SASL_OAUTHBEARER_EXPECTED_ISSUER: http://localhost:8080/realms/onetl-kafka
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+    volumes:
+      - ./docker/kafka/oauth-client.properties:/opt/kafka/config/oauth-client.properties:ro
+    networks:
+      - onetl
+    depends_on:
+      keycloak:
+        condition: service_healthy
+    healthcheck:
+      test: [CMD-SHELL, /opt/kafka/bin/kafka-topics.sh --bootstrap-server 127.0.0.1:9096 --command-config /opt/kafka/config/oauth-client.properties --list]
+      interval: 10s
+      timeout: 10s
+      retries: 20
+      start_period: 20s
+    profiles: [kafka-oauth]
+
   mongodb:
     image: ${MONGODB_IMAGE:-mongo:latest}
     restart: unless-stopped

--- a/docker/kafka/keycloak/onetl-kafka-realm.json
+++ b/docker/kafka/keycloak/onetl-kafka-realm.json
@@ -1,0 +1,33 @@
+{
+  "realm": "onetl-kafka",
+  "enabled": true,
+  "sslRequired": "none",
+  "accessTokenLifespan": 600,
+  "clientScopes": [
+    {
+      "name": "kafka",
+      "protocol": "openid-connect",
+      "attributes": {
+        "display.on.consent.screen": "false",
+        "include.in.token.scope": "true"
+      }
+    }
+  ],
+  "clients": [
+    {
+      "clientId": "onetl-kafka",
+      "name": "onETL Kafka integration tests",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "123UsedForTestOnly@!",
+      "serviceAccountsEnabled": true,
+      "standardFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "publicClient": false,
+      "protocol": "openid-connect",
+      "optionalClientScopes": [
+        "kafka"
+      ]
+    }
+  ]
+}

--- a/docker/kafka/oauth-client.properties
+++ b/docker/kafka/oauth-client.properties
@@ -1,0 +1,5 @@
+security.protocol=SASL_PLAINTEXT
+sasl.mechanism=OAUTHBEARER
+sasl.login.callback.handler.class=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler
+sasl.oauthbearer.token.endpoint.url=http://keycloak:8080/realms/onetl-kafka/protocol/openid-connect/token
+sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required clientId="onetl-kafka" clientSecret="123UsedForTestOnly@!" scope="kafka";

--- a/mddocs/docs/changelog/next_release/530.feature.md
+++ b/mddocs/docs/changelog/next_release/530.feature.md
@@ -1,0 +1,1 @@
+Added OAuth2 Client Credentials authentication for Kafka connections on Spark 3.4 and higher.

--- a/mddocs/docs/connection/db_connection/kafka/index.md
+++ b/mddocs/docs/connection/db_connection/kafka/index.md
@@ -15,6 +15,7 @@
 
 * [Kafka BasicAuth][DBR-onetl-connection-db-connection-kafka-basic-auth-kafka-basicauth]
 * [Kafka KerberosAuth][DBR-onetl-connection-db-connection-kafka-kerberos-auth-kafka-kerberosauth]
+* [Kafka OAuth2ClientCredentials][DBR-onetl-connection-db-connection-kafka-oauth2-client-credentials-kafka-oauth2clientcredentials]
 * [Kafka ScramAuth][DBR-onetl-connection-db-connection-kafka-scram-auth-kafka-scramauth]
 
 ## Operations { #DBR-onetl-connection-db-connection-kafka-operations }

--- a/mddocs/docs/connection/db_connection/kafka/oauth2_client_credentials.md
+++ b/mddocs/docs/connection/db_connection/kafka/oauth2_client_credentials.md
@@ -1,0 +1,7 @@
+# Kafka OAuth2ClientCredentials { #DBR-onetl-connection-db-connection-kafka-oauth2-client-credentials-kafka-oauth2clientcredentials }
+
+
+::: onetl.connection.db_connection.kafka.kafka_oauth2_client_credentials.KafkaOAuth2ClientCredentials
+    options:
+        inherited_members: true
+        show_root_heading: true

--- a/mddocs/docs/connection/db_connection/kafka/prerequisites.md
+++ b/mddocs/docs/connection/db_connection/kafka/prerequisites.md
@@ -43,6 +43,7 @@ List of currently supported mechanisms:
 
 - [PLAIN][onetl.connection.db_connection.kafka.kafka_basic_auth.KafkaBasicAuth]. To no confuse this with `PLAINTEXT` connection protocol, onETL uses name `BasicAuth`.
 - [GSSAPI][onetl.connection.db_connection.kafka.kafka_kerberos_auth.KafkaKerberosAuth]. To simplify naming, onETL uses name `KerberosAuth`.
+- [OAUTHBEARER][onetl.connection.db_connection.kafka.kafka_oauth2_client_credentials.KafkaOAuth2ClientCredentials]. OAuth2 Client Credentials authentication requires Spark 3.4 or higher.
 - [SCRAM-SHA-256 or SCRAM-SHA-512][onetl.connection.db_connection.kafka.kafka_scram_auth.KafkaScramAuth] (recommended).
 
 Different mechanisms use different types of credentials (login + password, keytab file, and so on).

--- a/mddocs/docs/nav.md
+++ b/mddocs/docs/nav.md
@@ -55,6 +55,7 @@
             * [Auth](connection/db_connection/kafka/auth.md)
             * [Basic Auth](connection/db_connection/kafka/basic_auth.md)
             * [Kerberos Auth](connection/db_connection/kafka/kerberos_auth.md)
+            * [OAuth2 Client Credentials](connection/db_connection/kafka/oauth2_client_credentials.md)
             * [Scram Auth](connection/db_connection/kafka/scram_auth.md)
             * [protocol](connection/db_connection/kafka/protocol.md)
             * [Plaintext protocol](connection/db_connection/kafka/plaintext_protocol.md)

--- a/onetl/connection/db_connection/kafka/__init__.py
+++ b/onetl/connection/db_connection/kafka/__init__.py
@@ -6,6 +6,9 @@ from onetl.connection.db_connection.kafka.extra import KafkaExtra
 from onetl.connection.db_connection.kafka.kafka_auth import KafkaAuth
 from onetl.connection.db_connection.kafka.kafka_basic_auth import KafkaBasicAuth
 from onetl.connection.db_connection.kafka.kafka_kerberos_auth import KafkaKerberosAuth
+from onetl.connection.db_connection.kafka.kafka_oauth2_client_credentials import (
+    KafkaOAuth2ClientCredentials,
+)
 from onetl.connection.db_connection.kafka.kafka_plaintext_protocol import KafkaPlaintextProtocol
 from onetl.connection.db_connection.kafka.kafka_protocol import KafkaProtocol
 from onetl.connection.db_connection.kafka.kafka_scram_auth import KafkaScramAuth
@@ -24,6 +27,7 @@ __all__ = [
     "KafkaDialect",
     "KafkaExtra",
     "KafkaKerberosAuth",
+    "KafkaOAuth2ClientCredentials",
     "KafkaPlaintextProtocol",
     "KafkaProtocol",
     "KafkaReadOptions",

--- a/onetl/connection/db_connection/kafka/connection.py
+++ b/onetl/connection/db_connection/kafka/connection.py
@@ -28,6 +28,9 @@ from onetl.connection.db_connection.kafka.extra import KafkaExtra
 from onetl.connection.db_connection.kafka.kafka_auth import KafkaAuth
 from onetl.connection.db_connection.kafka.kafka_basic_auth import KafkaBasicAuth
 from onetl.connection.db_connection.kafka.kafka_kerberos_auth import KafkaKerberosAuth
+from onetl.connection.db_connection.kafka.kafka_oauth2_client_credentials import (
+    KafkaOAuth2ClientCredentials,
+)
 from onetl.connection.db_connection.kafka.kafka_plaintext_protocol import (
     KafkaPlaintextProtocol,
 )
@@ -191,6 +194,33 @@ class Kafka(DBConnection):
         ).check()
         ```
 
+    === "Create Kafka connection with `SASL_SSL` protocol and `OAUTHBEARER` auth"
+
+        ```python
+        from pathlib import Path
+
+        # Create Spark session with Kafka connector loaded
+        ...
+
+        # Create connection
+        kafka = Kafka(
+            addresses=["mybroker:9092", "anotherbroker:9092"],
+            cluster="my-cluster",
+            protocol=Kafka.SSLProtocol(
+                # read server public certificate from file
+                truststore_type="PEM",
+                truststore_certificates=Path("/path/to/server.crt").read_text(),
+            ),
+            auth=Kafka.OAuth2ClientCredentials(
+                client_id="my-client",
+                client_secret="my-secret",
+                oauth2_token_endpoint="https://keycloak.example.com/realms/my-realm/protocol/openid-connect/token",
+                scopes=["kafka"],
+            ),
+            spark=spark,
+        ).check()
+        ```
+
     === "Create Kafka connection with extra options"
 
         ```python
@@ -211,6 +241,7 @@ class Kafka(DBConnection):
 
     BasicAuth = KafkaBasicAuth
     KerberosAuth = KafkaKerberosAuth
+    OAuth2ClientCredentials = KafkaOAuth2ClientCredentials
     ScramAuth = KafkaScramAuth
     ReadOptions = KafkaReadOptions
     WriteOptions = KafkaWriteOptions

--- a/onetl/connection/db_connection/kafka/kafka_oauth2_client_credentials.py
+++ b/onetl/connection/db_connection/kafka/kafka_oauth2_client_credentials.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: 2026-present MTS PJSC
+# SPDX-License-Identifier: Apache-2.0
+from typing import TYPE_CHECKING
+
+try:
+    from pydantic.v1 import AnyUrl, Field, SecretStr
+except (ImportError, AttributeError):
+    from pydantic import AnyUrl, Field, SecretStr  # type: ignore[no-redef, assignment]
+
+from onetl._util.spark import get_spark_version
+from onetl._util.version import Version
+from onetl.connection.db_connection.kafka.kafka_auth import KafkaAuth
+from onetl.impl import GenericOptions
+
+if TYPE_CHECKING:
+    from onetl.connection.db_connection.kafka.connection import Kafka
+
+
+class KafkaOAuth2ClientCredentials(KafkaAuth, GenericOptions):
+    """Connect to Kafka using OAuth 2.0 Client Credentials Flow and `sasl.mechanism="OAUTHBEARER"`.
+
+    The Kafka client fetches access tokens from the OAuth2 server and refreshes them automatically.
+
+    For more details see [Kafka Documentation](https://kafka.apache.org/documentation/#security_sasl_oauthbearer).
+
+    !!! success "Added in 0.17.0"
+
+    !!! warning
+
+        This authentication method requires Spark 3.4 or higher.
+
+    Parameters
+    ----------
+    client_id : str
+        OAuth2 client ID.
+
+    client_secret : str
+        OAuth2 client secret.
+
+    oauth2_token_endpoint : str
+        OAuth2 endpoint used to fetch access tokens.
+
+    scopes : list[str], default: []
+        OAuth2 scopes to request.
+
+    Examples
+    --------
+
+    ```python
+    from onetl.connection import Kafka
+
+    auth = Kafka.OAuth2ClientCredentials(
+        client_id="my-client",
+        client_secret="my-secret",
+        oauth2_token_endpoint="https://keycloak.example.com/realms/my-realm/protocol/openid-connect/token",
+        scopes=["kafka"],
+    )
+    ```
+    """
+
+    client_id: str
+    client_secret: SecretStr
+    oauth2_token_endpoint: AnyUrl
+    scopes: list[str] = Field(default_factory=list)
+
+    @staticmethod
+    def _escape_jaas_value(value: str) -> str:
+        return value.replace("\\", "\\\\").replace('"', '\\"')
+
+    def get_jaas_conf(self) -> str:
+        client_id = self._escape_jaas_value(self.client_id)
+        client_secret = self._escape_jaas_value(self.client_secret.get_secret_value())
+        options = [
+            f'clientId="{client_id}"',
+            f'clientSecret="{client_secret}"',
+        ]
+
+        if self.scopes:
+            scope = self._escape_jaas_value(" ".join(self.scopes))
+            options.append(f'scope="{scope}"')
+
+        return "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required " + " ".join(options) + ";"
+
+    def get_options(self, kafka: "Kafka") -> dict:
+        spark_version = get_spark_version(kafka.spark)
+        if spark_version < Version("3.4"):
+            msg = f"Kafka OAuth2 Client Credentials authentication requires Spark 3.4 or higher, got {spark_version}."
+            raise ValueError(msg)
+
+        if spark_version < Version("3.5"):
+            callback_handler = "org.apache.kafka.common.security.oauthbearer.secured.OAuthBearerLoginCallbackHandler"
+        else:
+            callback_handler = "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler"
+
+        return {
+            "sasl.mechanism": "OAUTHBEARER",
+            "sasl.login.callback.handler.class": callback_handler,
+            "sasl.oauthbearer.token.endpoint.url": str(self.oauth2_token_endpoint),
+            "sasl.jaas.config": self.get_jaas_conf(),
+        }
+
+    def cleanup(self, kafka: "Kafka") -> None:
+        # nothing to cleanup
+        pass

--- a/tests/tests_unit/tests_db_connection_unit/test_kafka_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_kafka_unit.py
@@ -370,6 +370,127 @@ def test_kafka_basic_auth(spark_mock):
         }
 
 
+@pytest.mark.parametrize(
+    ("spark_version", "callback_handler"),
+    [
+        (
+            "3.4.4",
+            "org.apache.kafka.common.security.oauthbearer.secured.OAuthBearerLoginCallbackHandler",
+        ),
+        (
+            "3.5.0",
+            "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler",
+        ),
+        (
+            "4.2.0",
+            "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    ("scopes", "scope_option"),
+    [
+        ([], ""),
+        (["kafka"], ' scope="kafka"'),
+        (["kafka:read", "kafka:write"], ' scope="kafka:read kafka:write"'),
+    ],
+)
+def test_kafka_oauth2_client_credentials(spark_mock, spark_version, callback_handler, scopes, scope_option):
+    spark_mock.version = spark_version
+    kafka = Kafka(
+        spark=spark_mock,
+        addresses=["some_address"],
+        cluster="cluster",
+        auth=Kafka.OAuth2ClientCredentials(
+            client_id="client-id",
+            client_secret="client-secret",
+            oauth2_token_endpoint="https://keycloak.example.com/realms/onetl/protocol/openid-connect/token",
+            scopes=scopes,
+        ),
+    )
+
+    assert kafka.auth.get_options(kafka) == {
+        "sasl.mechanism": "OAUTHBEARER",
+        "sasl.login.callback.handler.class": callback_handler,
+        "sasl.oauthbearer.token.endpoint.url": (
+            "https://keycloak.example.com/realms/onetl/protocol/openid-connect/token"
+        ),
+        "sasl.jaas.config": (
+            "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required "
+            f'clientId="client-id" clientSecret="client-secret"{scope_option};'
+        ),
+    }
+
+
+def test_kafka_oauth2_client_credentials_escapes_client_secret():
+    auth = Kafka.OAuth2ClientCredentials(
+        client_id="client-id",
+        client_secret='secret"value\\',
+        oauth2_token_endpoint="https://keycloak.example.com/token",
+        scopes=["kafka:read"],
+    )
+
+    assert auth.get_jaas_conf() == (
+        "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required "
+        'clientId="client-id" '
+        'clientSecret="secret\\"value\\\\" '
+        'scope="kafka:read";'
+    )
+
+
+def test_kafka_oauth2_client_credentials_hides_secret():
+    auth = Kafka.OAuth2ClientCredentials(
+        client_id="client-id",
+        client_secret="client-secret",
+        oauth2_token_endpoint="https://keycloak.example.com/token",
+    )
+
+    assert "client-secret" not in repr(auth)
+    assert auth.client_secret != "client-secret"
+    assert auth.client_secret.get_secret_value() == "client-secret"
+
+
+@pytest.mark.parametrize("spark_version", ["3.2.4", "3.3.4"])
+def test_kafka_oauth2_client_credentials_unsupported_spark(spark_mock, spark_version):
+    spark_mock.version = spark_version
+    kafka = Kafka(
+        spark=spark_mock,
+        addresses=["some_address"],
+        cluster="cluster",
+        auth=Kafka.OAuth2ClientCredentials(
+            client_id="client-id",
+            client_secret="client-secret",
+            oauth2_token_endpoint="https://keycloak.example.com/token",
+        ),
+    )
+
+    msg = rf"Kafka OAuth2 Client Credentials authentication requires Spark 3\.4 or higher, got {spark_version}\."
+    with pytest.raises(ValueError, match=msg):
+        kafka.auth.get_options(kafka)
+
+
+@pytest.mark.parametrize("missing_field", ["client_id", "client_secret", "oauth2_token_endpoint"])
+def test_kafka_oauth2_client_credentials_missing_field(missing_field):
+    kwargs = {
+        "client_id": "client-id",
+        "client_secret": "client-secret",
+        "oauth2_token_endpoint": "https://keycloak.example.com/token",
+    }
+    kwargs.pop(missing_field)
+
+    with pytest.raises(ValueError, match="field required"):
+        Kafka.OAuth2ClientCredentials(**kwargs)
+
+
+def test_kafka_oauth2_client_credentials_invalid_endpoint():
+    with pytest.raises(ValueError, match="invalid or missing URL scheme"):
+        Kafka.OAuth2ClientCredentials(
+            client_id="client-id",
+            client_secret="client-secret",
+            oauth2_token_endpoint="keycloak.example.com/token",
+        )
+
+
 @pytest.mark.parametrize("option", ["sasl.jaas.config", "sasl.mechanism"])
 def test_kafka_scram_auth_prohibited_options(option):
     msg = rf"Options \['{option}'\] are not allowed to use in a KafkaScramAuth"


### PR DESCRIPTION
## Change Summary

Added Kafka OAuth2 Client Credentials authentication for Spark 3.4+. 

Added a dedicated Docker Compose profile for Kafka OAuth and Keycloak, so the additional identity-provider infrastructure is started only for OAuth integration tests. OAuth tests will use a separate CI job and Spark 3.4+ matrix, leaving the existing Kafka test setup unchanged.

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [x] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MTSWebServices/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
